### PR TITLE
Add sle-module-public-cloud module for GCP instances

### DIFF
--- a/gcp/terraform/startup.sh
+++ b/gcp/terraform/startup.sh
@@ -39,6 +39,7 @@ main::get_os_version
 
 if [[ -n ${VM_METADATA[suse_regcode]} ]]
 	SUSEConnect -r "${VM_METADATA[suse_regcode]}"
+	( . /etc/os-release ; SUSEConnect -p sle-module-public-cloud/${VERSION%-*}/x86_64 )
 fi
 
 main::install_gsdk /usr/local


### PR DESCRIPTION
This fix adds a module needed for BYOS images to install missing packages.