### PR TITLE
Do not set a root password. SSH keys work

### DIFF
--- a/azure/terraform/provision/prepare_env.sh
+++ b/azure/terraform/provision/prepare_env.sh
@@ -56,15 +56,4 @@ cat <<-END >> /root/.bashrc
     alias hins='cd /root/sap_inst; ./install_hana.sh'
 END
 
-# We move the ssh keys to the proper location.
-mkdir -p $HOME/.ssh
-mv /tmp/"$(hostname -s)"_id_rsa $HOME/.ssh/id_rsa
-mv /tmp/"$(hostname -s)"_id_rsa.pub $HOME/.ssh/id_rsa.pub
-chmod 600 $HOME/.ssh/id_rsa
-
-for i in $(ls /tmp/*.pub)
-do 
-  (cat "${i}"; echo) >>  $HOME/.ssh/authorized_keys
-done
-
 format_and_mount "$1" "$2" "$3"

--- a/azure/terraform/provision/sshkeys.sh
+++ b/azure/terraform/provision/sshkeys.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+mv /tmp/node0_id_rsa /tmp/$(hostname -s | sed -r 's/[0-9]+$//')0_id_rsa
+mv /tmp/node0_id_rsa.pub /tmp/$(hostname -s | sed -r 's/[0-9]+$//')0_id_rsa.pub
+mv /tmp/node1_id_rsa /tmp/$(hostname -s | sed -r 's/[0-9]+$//')1_id_rsa
+mv /tmp/node1_id_rsa.pub /tmp/$(hostname -s | sed -r 's/[0-9]+$//')1_id_rsa.pub
+
+# We move the ssh keys to the proper location.
+mkdir -p $HOME/.ssh
+mv /tmp/"$(hostname -s)"_id_rsa $HOME/.ssh/id_rsa
+mv /tmp/"$(hostname -s)"_id_rsa.pub $HOME/.ssh/id_rsa.pub
+chmod 600 $HOME/.ssh/id_rsa
+
+for i in $(ls /tmp/*.pub)
+do 
+  (cat "${i}"; echo) >>  $HOME/.ssh/authorized_keys
+done


### PR DESCRIPTION
Created a new script provision/sshkeys.sh with content from provision/prepare_env.sh and 4 lines from the install_hana() function to manage the nodes' ssh keys before the cluster setup.

A root password is no longer needed for setting up the cluster.