### PR TITLE
Add ami iscsi server

### DIFF
--- a/aws/terraform/README.md
+++ b/aws/terraform/README.md
@@ -68,7 +68,8 @@ terraform apply
 
 **Important**: when not using remote terraform states, the `terraform init` command will fail unless the file [remote-states.tf](remote-states.tf) is removed before initialization. When using remote terraform states, first follow the [procedure to create a remote terraform state](create_remote_state).
 
-This configuration uses the public **SUSE Linux Enterprise Server 12-SP3 BYOS x86_64** image available in AWS (as defined in the file [variables.tf](variables.tf)) and can be used as is.
+This configuration uses the public **SUSE Linux Enterprise Server 15 for SAP Applications BYOS x86_64** and **SUSE Linux Enterprise Server 12 SP4 for SAP Applications BYOS x86_64** images available in AWS (as defined in the file [variables.tf](variables.tf)) and can be used as is.
+The first one is used for the cluster nodes and the second for the iSCSI server. AMI used for iSCSI server doesn't matter as long as it works, it's just a support services server.
 
 If the use of a private/custom image is required (for example, to perform the Build Validation of a new AWS Public Cloud image), first upload the image to the cloud using the [procedure described below](#upload-image-to-aws), and then [register it as an AMI](#import-ami-via-snapshot). Once the new AMI is available, edit its AMI id value in the [variables.tf](variables.tf) file for your region of choice.
 

--- a/aws/terraform/instances.tf
+++ b/aws/terraform/instances.tf
@@ -3,7 +3,7 @@
 # EC2 Instances
 
 resource "aws_instance" "iscsisrv" {
-  ami                         = "${lookup(var.sles4sap, var.aws_region)}"
+  ami                         = "${lookup(var.iscsi_srv, var.aws_region)}"
   instance_type               = "t2.micro"
   key_name                    = "${aws_key_pair.mykey.key_name}"
   associate_public_ip_address = true

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -1,21 +1,41 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
-# Map for suse-sles-sap-12-sp3-byos-v20180706-hvm-ssd-x86_64
-# SLES 12SP3 in eu-central-1: ami-2cffc5c7
+# Map used for suse-sles-sap-15-byos-v20180816-hvm-ssd-x86_64
+# SLES4SAP 15 in eu-central-1: ami-024f50fdc1f2f5603
+# Used for cluster nodes
 
 variable "sles4sap" {
   type = "map"
 
   default = {
-    "us-east-1"    = "ami-b1daf5ce"
-    "us-east-2"    = "ami-bf8db5da"
-    "us-west-1"    = "ami-9f08e8fc"
-    "us-west-2"    = "ami-2c693f54"
-    "ca-central-1" = "ami-890f8ded"
-    "eu-central-1" = "ami-6da59f86"
-    "eu-west-1"    = "ami-a07b6d4a"
-    "eu-west-2"    = "ami-f40ae293"
-    "eu-west-3"    = "ami-b8cb7bc5"
+    "us-east-1"    = "ami-027447d2b7312df2d"
+    "us-east-2"    = "ami-099a51d3b131f3ce2"
+    "us-west-1"    = "ami-0f213357578720889"
+    "us-west-2"    = "ami-0fc86417df3e0f6d4"
+    "ca-central-1" = "ami-0811b93a30ab570f7"
+    "eu-central-1" = "ami-024f50fdc1f2f5603"
+    "eu-west-1"    = "ami-0ca96dfbaf35b0c31"
+    "eu-west-2"    = "ami-00189dbab3fd43af2"
+    "eu-west-3"    = "ami-00e70e3421f053648"
+  }
+}
+# Map used for suse-sles-sap-12-sp4-byos-v20181212-hvm-ssd-x86_64
+# SLES4SAP 12SP4 in eu-central-1: ami-027ab92ac76584bfd
+# Used for iscsi server
+
+variable "iscsi_srv" {
+  type = "map"
+
+  default = {
+    "us-east-1"    = "ami-00ec2c9db6d48cd44"
+    "us-east-2"    = "ami-00ec2c9db6d48cd44"
+    "us-west-1"    = "ami-0df4bc22c34ae1b79"
+    "us-west-2"    = "ami-0941337aabe54ea2c"
+    "ca-central-1" = "ami-0d4b452ab1f2f86d3"
+    "eu-central-1" = "ami-027ab92ac76584bfd"
+    "eu-west-1"    = "ami-0b0d07bd990ccf8c8"
+    "eu-west-2"    = "ami-07e9d18e2d5b1e5ce"
+    "eu-west-3"    = "ami-0f916db5a97a370f0"
   }
 }
 

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -19,6 +19,7 @@ variable "sles4sap" {
     "eu-west-3"    = "ami-00e70e3421f053648"
   }
 }
+
 # Map used for suse-sles-sap-12-sp4-byos-v20181212-hvm-ssd-x86_64
 # SLES4SAP 12SP4 in eu-central-1: ami-027ab92ac76584bfd
 # Used for iscsi server


### PR DESCRIPTION
- Improvement for using a different AMI for iSCSI server.
- README update according to this change
- Change of default AMI to use SLES 15 instead of SLES 12SP3, it's just an update for default options.