### PR TITLE
Fix and init type

### DIFF
--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -95,11 +95,14 @@ These are the relevant files and what each provides:
 
 - The `sap_hana_deployment_bucket` variable must contain the name of the Google Storage bucket with the HANA installation files.
 
-- The `images_path_bucket` must contain the name of the Google Storage bucket with the SLES image.
+- The `images_path_bucket` variable must contain the name of the Google Storage bucket with the SLES image.
 
-- The `sles4sap_os_image_file` must contain the name of the SLES image.
+- The `sles4sap_os_image_file` variable must contain the name of the SLES image.
 
-- The `post_deployment_script` specifies the URL location of a script to run after the deployment is complete. This script should be hosted on a web server or in a GCS bucket.
+- The `post_deployment_script` variable specifies the URL location of a script to run after the deployment is complete. This script should be hosted on a web server or in a GCS bucket.
+
+- The `init_type` variable controls what is deployed in the cluster nodes. Valid values are `all` (installs HANA and configures cluster), `skip-hana` (does not install HANA, but configures cluster) and `skip-cluster` (installs HANA, but does not configure cluster). Defaults to `all`.
+
 
 2. Deploy:
 

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -67,6 +67,7 @@ resource "google_compute_instance" "clusternodes" {
     sap_vip                    = "${var.sap_vip}"
     sap_vip_secondary_range    = ""
     suse_regcode               = "${var.suse_regcode}"
+    init_type                  = "${var.init_type}"
   }
 
   service_account {

--- a/gcp/terraform/startup.sh
+++ b/gcp/terraform/startup.sh
@@ -36,6 +36,7 @@ source /dev/stdin <<< "$(curl -s ${DEPLOY_URL}/lib/sap_lib_ha.sh | sed -r 's/(AU
 
 ### Base GCP and OS Configuration
 main::get_os_version
+main::get_settings
 
 if [[ -n ${VM_METADATA[suse_regcode]} ]] ; then
 	SUSEConnect -r "${VM_METADATA[suse_regcode]}"
@@ -46,7 +47,6 @@ main::install_gsdk /usr/local
 main::set_boot_parameters
 main::install_packages
 main::config_ssh
-main::get_settings
 main::create_static_ip
 
 ##prepare for SAP HANA
@@ -81,11 +81,13 @@ if [[ $HOSTNAME =~ node-0$ ]] ; then
 	ha::ready
 	ha::config_pacemaker_primary
 	ha::check_cluster
+	ha::pacemaker_maintenance true
 	ha::pacemaker_add_stonith
 	ha::pacemaker_add_vip
 	ha::pacemaker_config_bootstrap_hdb
 	ha::pacemaker_add_hana
 	ha::check_hdb_replication
+	ha::pacemaker_maintenance false
 else
 	ha::wait_for_primary
 	ha::copy_hdb_ssfs_keys

--- a/gcp/terraform/startup.sh
+++ b/gcp/terraform/startup.sh
@@ -43,12 +43,19 @@ if [[ -n ${VM_METADATA[suse_regcode]} ]] ; then
 	( . /etc/os-release ; SUSEConnect -p sle-module-public-cloud/${VERSION_ID%-*}/x86_64 )
 fi
 
+if [[ ${VM_METADATA[init_type]} == "skip-cluster" ]] ; then
+	exit 0
+fi
+
 main::install_gsdk /usr/local
+if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 main::set_boot_parameters
+fi
 main::install_packages
 main::config_ssh
 main::create_static_ip
 
+if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 ##prepare for SAP HANA
 hdb::check_settings
 hdb::set_kernel_parameters
@@ -64,6 +71,7 @@ hdb::extract_media
 hdb::install
 hdb::upgrade
 hdb::config_backup
+fi
 
 ## Setup HA
 ha::check_settings
@@ -73,27 +81,35 @@ else
 	ha::install_primary_sshkeys
 fi
 ha::download_scripts
+if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 ha::create_hdb_user
 ha::hdbuserstore
 hdb::backup /hanabackup/data/pre_ha_config
+fi
 if [[ $HOSTNAME =~ node-0$ ]] ; then
+	if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 	ha::enable_hsr
+	fi
 	ha::ready
 	ha::config_pacemaker_primary
 	ha::check_cluster
 	ha::pacemaker_maintenance true
 	ha::pacemaker_add_stonith
 	ha::pacemaker_add_vip
+	if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 	ha::pacemaker_config_bootstrap_hdb
 	ha::pacemaker_add_hana
 	ha::check_hdb_replication
+	fi
 	ha::pacemaker_maintenance false
 else
 	ha::wait_for_primary
 	ha::copy_hdb_ssfs_keys
+	if [[ ${VM_METADATA[init_type]} == skip-* ]] ; then
 	hdb::stop
 	ha::config_hsr
 	hdb::start_nowait
+	fi
 	ha::config_pacemaker_secondary
 fi
 

--- a/gcp/terraform/terraform.tfvars
+++ b/gcp/terraform/terraform.tfvars
@@ -4,7 +4,7 @@ project     = "my-project"
 gcp_credentials_file = "my-project.json"
 
 # SUSE registration code
-suse_regcode = "xxxxxxxxxxxx"
+suse_regcode = ""
 
 # Internal IPv4 range
 ip_cidr_range = "10.0.0.0/24"
@@ -45,4 +45,7 @@ sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"
 # Specifies the URL location of a script to run after the deployment is complete.
 # The script should be hosted on a web server or in a GCS bucket.
 post_deployment_script = ""
+
+# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-cluster
+init_type = "all"
 

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -46,3 +46,8 @@ variable "storage_url" {
 }
 
 variable "post_deployment_script" {}
+
+variable "init_type" {
+  type    = "string"
+  default = "all"
+}


### PR DESCRIPTION
- The first commit fixes a bug that currently prevents the deployment due to changes in upstream scripts from Google.
- The second commit adds the `init_type` variable, used by other PC deployments. Valid values are `all` (installs HANA and configures cluster), `skip-hana` (does not install HANA, but configures cluster) and `skip-cluster` (installs HANA, but does not configure cluster). Defaults to `all`. 