### PR TITLE
Add libvirt to travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ script:
   - find . -name \*.sh -exec bash -n {} \;
   - find . -name \*.tpl | while read f ; do head -1 "$f" | grep -qnE '^#! ?/bin/(ba)?sh' && bash -n "$f" ; done
   - find . -name \*.json -type f | while read f ; do cat "$f" | python -m json.tool >/dev/null ; done
-  - for provider in aws azure gcp ; do
+  - for provider in aws azure gcp libvirt ; do
       set -x ;
       cd $provider/terraform ;
       /tmp/terraform fmt -check ;

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -3,47 +3,46 @@ provider "libvirt" {
 }
 
 module "base" {
-  source = "./modules/base"
-  image = "${var.base_image}"
+  source  = "./modules/base"
+  image   = "${var.base_image}"
   iprange = "${var.iprange}"
 
   // optional parameters below
   name_prefix = "${var.name_prefix}"
+
   // pool = "default"
   pool = "terraform"
+
   // network_name = "default"
   network_name = ""
-  bridge = "br0"
-  timezone = "Europe/Berlin"
+  bridge       = "br0"
+  timezone     = "Europe/Berlin"
 }
 
 module "sbd_disk" {
-  source = "./modules/sbd"
+  source             = "./modules/sbd"
   base_configuration = "${module.base.configuration}"
-  sbd_disk_size = "104857600"
+  sbd_disk_size      = "104857600"
 }
 
 module "hana_node" {
-  source = "./modules/hana_node"
+  source             = "./modules/hana_node"
   base_configuration = "${module.base.configuration}"
+
   // hana01 and hana02
 
-  name = "hana"
+  name  = "hana"
   count = 2
-
-  vcpu = 4
+  vcpu   = 4
   memory = 32678
-
   sap_inst_media = "${var.sap_inst_media}"
-  ntp_server = "pool.ntp.org"
+  ntp_server     = "pool.ntp.org"
   hana_disk_size = "68719476736"
-  host_ips = "${var.host_ips}"
-  sbd_disk_id = "${module.sbd_disk.id}"
-
+  host_ips       = "${var.host_ips}"
+  sbd_disk_id    = "${module.sbd_disk.id}"
   # Set proper ssh file. The default files are public in github
   # Copy custom files in salt/hana_node/file/sshkeys
   cluster_ssh_pub = "${var.cluster_ssh_pub}"
   cluster_ssh_key = "${var.cluster_ssh_key}"
-
   additional_repos = "${var.additional_repos}"
 }

--- a/libvirt/terraform/modules/base/main.tf
+++ b/libvirt/terraform/modules/base/main.tf
@@ -1,39 +1,44 @@
 terraform {
-    required_version = "~> 0.11.7"
+  required_version = "~> 0.11.7"
 }
 
 resource "libvirt_volume" "base_image" {
-  name = "${var.name_prefix}baseimage"
+  name   = "${var.name_prefix}baseimage"
   source = "${var.image}"
-  count = "${var.use_shared_resources ? 0 : 1}"
-  pool = "${var.pool}"
+  count  = "${var.use_shared_resources ? 0 : 1}"
+  pool   = "${var.pool}"
 }
 
 resource "libvirt_network" "isolated_network" {
-  name = "${var.name_prefix}-isolated"
-  mode = "none"
-  addresses = [ "${var.iprange}" ]
-  dhcp { enabled = "false" }
+  name      = "${var.name_prefix}-isolated"
+  mode      = "none"
+  addresses = ["${var.iprange}"]
+
+  dhcp {
+    enabled = "false"
+  }
+
   autostart = true
 }
 
 output "configuration" {
   depends_on = [
     "libvirt_volume.base_image",
-    "libvirt_network.isolated_network"
+    "libvirt_network.isolated_network",
   ]
+
   value = {
-    timezone = "${var.timezone}"
-    ssh_key_path = "${var.ssh_key_path}"
-    domain = "${var.domain}"
-    name_prefix = "${var.name_prefix}"
+    timezone             = "${var.timezone}"
+    ssh_key_path         = "${var.ssh_key_path}"
+    domain               = "${var.domain}"
+    name_prefix          = "${var.name_prefix}"
     use_shared_resources = "${var.use_shared_resources}"
-    isolated_network_id = "${join(",", libvirt_network.isolated_network.*.id)}"
-    iprange = "${var.iprange}"
+    isolated_network_id  = "${join(",", libvirt_network.isolated_network.*.id)}"
+    iprange              = "${var.iprange}"
 
     // Provider-specific variables
-    pool = "${var.pool}"
+    pool         = "${var.pool}"
     network_name = "${var.bridge == "" ? var.network_name : ""}"
-    bridge = "${var.bridge}"
+    bridge       = "${var.bridge}"
   }
 }

--- a/libvirt/terraform/modules/base/variables.tf
+++ b/libvirt/terraform/modules/base/variables.tf
@@ -1,48 +1,48 @@
 variable "timezone" {
   description = "Timezone setting for all VMs"
-  default = "Europe/Berlin"
+  default     = "Europe/Berlin"
 }
 
 variable "ssh_key_path" {
   description = "path of pub ssh key you want to use to access VMs"
-  default = "~/.ssh/id_rsa.pub"
+  default     = "~/.ssh/id_rsa.pub"
 }
 
 variable "domain" {
   description = "hostname's domain"
-  default = "tf.local"
+  default     = "tf.local"
 }
 
 variable "name_prefix" {
   description = "a prefix for all names of objects to avoid collisions."
-  default = ""
+  default     = ""
 }
 
 variable "use_shared_resources" {
   description = "use true to avoid deploying images, mirrors and other shared infrastructure resources"
-  default = false
+  default     = false
 }
 
 variable "iprange" {
   description = "Used host ip addresses range"
-  type = "string"
+  type        = "string"
 }
 
 // Provider-specific variables
 
 variable "pool" {
   description = "libvirt storage pool name for VM disks"
-  default = "default"
+  default     = "default"
 }
 
 variable "network_name" {
   description = "libvirt NAT network name for VMs, use empty string for bridged networking"
-  default = "default"
+  default     = "default"
 }
 
 variable "bridge" {
   description = "a bridge device name available on the libvirt host, leave default for NAT"
-  default = ""
+  default     = ""
 }
 
 variable "image" {

--- a/libvirt/terraform/modules/hana_node/main.tf
+++ b/libvirt/terraform/modules/hana_node/main.tf
@@ -1,13 +1,14 @@
 module "hana_node" {
   source = "../host"
 
-  base_configuration = "${var.base_configuration}"
-  name = "${var.name}"
-  count = "${var.count}"
-  additional_repos = "${var.additional_repos}"
+  base_configuration  = "${var.base_configuration}"
+  name                = "${var.name}"
+  count               = "${var.count}"
+  additional_repos    = "${var.additional_repos}"
   additional_packages = "${var.additional_packages}"
-  ssh_key_path = "${var.ssh_key_path}"
-  host_ips = "${var.host_ips}"
+  ssh_key_path        = "${var.ssh_key_path}"
+  host_ips            = "${var.host_ips}"
+
   grains = <<EOF
 
 role: hana_node
@@ -21,10 +22,10 @@ cluster_ssh_key: ${var.cluster_ssh_key}
 EOF
 
   // Provider-specific variables
-  memory = "${var.memory}"
-  vcpu = "${var.vcpu}"
-  running = "${var.running}"
-  mac = "${var.mac}"
+  memory         = "${var.memory}"
+  vcpu           = "${var.vcpu}"
+  running        = "${var.running}"
+  mac            = "${var.mac}"
   hana_disk_size = "${var.hana_disk_size}"
 
   additional_disk = ["${map(
@@ -34,7 +35,7 @@ EOF
 
 output "configuration" {
   value {
-    id = "${module.hana_node.configuration["id"]}"
+    id       = "${module.hana_node.configuration["id"]}"
     hostname = "${module.hana_node.configuration["hostname"]}"
   }
 }

--- a/libvirt/terraform/modules/hana_node/variables.tf
+++ b/libvirt/terraform/modules/hana_node/variables.tf
@@ -1,87 +1,88 @@
 variable "base_configuration" {
   description = "use ${module.base.configuration}, see the main.tf example file"
-  type = "map"
+  type        = "map"
 }
 
 variable "name" {
   description = "hostname, without the domain part"
-  type = "string"
+  type        = "string"
 }
 
 variable "additional_repos" {
   description = "extra repositories used for installation {label = url}"
-  default = {}
+  default     = {}
 }
 
 variable "additional_packages" {
   description = "extra packages which should be installed"
-  default = []
+  default     = []
 }
 
-variable "count"  {
+variable "count" {
   description = "number of hosts like this one"
-  default = 1
+  default     = 1
 }
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
-  default = "/dev/null"
+  default     = "/dev/null"
+
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
 variable "hana_disk_size" {
   description = "hana partition disk size"
-  default = "68719476736" # 64GB
+  default     = "68719476736"              # 64GB
 }
 
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
-  type = "list"
+  type        = "list"
 }
 
 variable "sbd_disk_id" {
   description = "SBD disk volume id"
-  type = "string"
+  type        = "string"
 }
 
 variable "sap_inst_media" {
   description = "URL of the NFS share where the SAP software installer is stored. This media shall be mounted in /root/sap_inst"
-  type = "string"
+  type        = "string"
 }
 
 variable "ntp_server" {
   description = "ntp server address"
-  default = ""
+  default     = ""
 }
 
 variable "cluster_ssh_pub" {
   description = "path to a custom ssh public key to upload to the hana nodes"
-  default = ""
+  default     = ""
 }
 
 variable "cluster_ssh_key" {
   description = "path to a custom ssh private key to upload to the hana nodes"
-  default = ""
+  default     = ""
 }
 
 // Provider-specific variables
 
 variable "memory" {
   description = "RAM memory in MiB"
-  default = 512
+  default     = 512
 }
 
 variable "vcpu" {
   description = "Number of virtual CPUs"
-  default = 1
+  default     = 1
 }
 
 variable "running" {
   description = "Whether this host should be turned on or off"
-  default = true
+  default     = true
 }
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default = ""
+  default     = ""
 }

--- a/libvirt/terraform/modules/host/variables.tf
+++ b/libvirt/terraform/modules/host/variables.tf
@@ -1,72 +1,73 @@
 variable "base_configuration" {
   description = "use ${module.base.configuration}, see the main.tf example file"
-  type = "map"
+  type        = "map"
 }
 
 variable "name" {
   description = "hostname, without the domain part"
-  type = "string"
+  type        = "string"
 }
 
 variable "additional_repos" {
   description = "extra repositories in the form {label = url}"
-  default = {}
+  default     = {}
 }
 
 variable "additional_packages" {
   description = "extra packages to install"
-  default = []
+  default     = []
 }
 
-variable "count"  {
+variable "count" {
   description = "number of hosts like this one"
-  default = 1
+  default     = 1
 }
 
 variable "grains" {
   description = "custom grain string to be added to this host's configuration"
-  default = ""
+  default     = ""
 }
 
 variable "ssh_key_path" {
   description = "path of additional pub ssh key you want to use to access VMs"
-  default = "/dev/null"
+  default     = "/dev/null"
+
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50
 }
 
 variable "hana_disk_size" {
   description = "hana partition disk size"
-  default = "68719476736" # 64GB
+  default     = "68719476736"              # 64GB
 }
 
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
-  type = "list"
+  type        = "list"
 }
 
 // Provider-specific variables
 
 variable "memory" {
   description = "RAM memory in MiB"
-  default = 512
+  default     = 512
 }
 
 variable "vcpu" {
   description = "number of virtual CPUs"
-  default = 1
+  default     = 1
 }
 
 variable "running" {
   description = "whether this host should be turned on or off"
-  default = true
+  default     = true
 }
 
 variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
-  default = ""
+  default     = ""
 }
 
 variable "additional_disk" {
   description = "disk block definition(s) to be added to this host"
-  default = []
+  default     = []
 }

--- a/libvirt/terraform/modules/sbd/variables.tf
+++ b/libvirt/terraform/modules/sbd/variables.tf
@@ -1,9 +1,9 @@
 variable "base_configuration" {
   description = "use ${module.base.configuration}, see the main.tf example file"
-  type = "map"
+  type        = "map"
 }
 
 variable "sbd_disk_size" {
   description = "sbd partition disk size"
-  default = "104857600" # 100MB
+  default     = "104857600"               # 100MB
 }

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -1,49 +1,49 @@
 variable "qemu_uri" {
-	description = "URI to connect with the qemu-service."
-	default = "qemu:///system"
+  description = "URI to connect with the qemu-service."
+  default     = "qemu:///system"
 }
 
 variable "base_image" {
   description = "Image of the sap hana nodes"
-	type = "string"
+  type        = "string"
 }
 
 variable "iprange" {
   description = "IP range of the isolated network"
-  default = "192.168.106.0/24"
+  default     = "192.168.106.0/24"
 }
 
 variable "name_prefix" {
   description = "Prefix of the deployment VM, network and disks"
-  default = "hanatest"
+  default     = "hanatest"
 }
 
 variable "sap_inst_media" {
   description = "URL of the NFS share where the SAP software installer is stored. This media shall be mounted in /root/sap_inst"
-  type = "string"
+  type        = "string"
 }
 
 variable "host_ips" {
   description = "IP addresses of the nodes"
-  default = ["192.168.106.15", "192.168.106.16"]
+  default     = ["192.168.106.15", "192.168.106.16"]
 }
 
 variable "ntp_server" {
   description = "ntp server address. Let empty to not setup any ntp server"
-  default = ""
+  default     = ""
 }
 
 variable "cluster_ssh_pub" {
   description = "path to a custom ssh public key to upload to the hana nodes"
-  default = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
+  default     = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
 }
 
 variable "cluster_ssh_key" {
   description = "path to a custom ssh private key to upload to the hana nodes"
-  default = "salt://hana_node/files/sshkeys/cluster.id_rsa"
+  default     = "salt://hana_node/files/sshkeys/cluster.id_rsa"
 }
 
 variable "additional_repos" {
   description = "Map of the repositories to add to the images. Repo name = url"
-	type = "map"
+  type        = "map"
 }


### PR DESCRIPTION
The libvirt Terraform configuration check was not added to Travis when the PR from @arbulu89 was made.

This PR adds the check and code reformatted by `terraform fmt`.