### PR TITLE
Expand travis check to any new provider

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,15 @@ script:
   - find . -name \*.sh -exec bash -n {} \;
   - find . -name \*.tpl | while read f ; do head -1 "$f" | grep -qnE '^#! ?/bin/(ba)?sh' && bash -n "$f" ; done
   - find . -name \*.json -type f | while read f ; do cat "$f" | python -m json.tool >/dev/null ; done
-  - for provider in aws azure gcp libvirt ; do
+  - for provider in $(find * -maxdepth 0 -type d | grep -v salt); do
       set -x ;
       cd $provider/terraform ;
       /tmp/terraform fmt -check ;
       /tmp/terraform validate -check-variables=false ;
-      rm remote-state.tf ;
+      rm -f remote-state.tf ;
+      if [[ "$provider" == "libvirt" ]]; then
+        continue ;
+      fi ;
       /tmp/terraform init ;
       if [[ "$provider" == "gcp" ]]; then
         /tmp/terraform validate -var-file=terraform.tfvars -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var ssh_pub_key_file=/dev/null ;

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -31,10 +31,10 @@ module "hana_node" {
 
   // hana01 and hana02
 
-  name  = "hana"
-  count = 2
-  vcpu   = 4
-  memory = 32678
+  name           = "hana"
+  count          = 2
+  vcpu           = 4
+  memory         = 32678
   sap_inst_media = "${var.sap_inst_media}"
   ntp_server     = "pool.ntp.org"
   hana_disk_size = "68719476736"
@@ -43,6 +43,6 @@ module "hana_node" {
   # Set proper ssh file. The default files are public in github
   # Copy custom files in salt/hana_node/file/sshkeys
   cluster_ssh_pub = "${var.cluster_ssh_pub}"
-  cluster_ssh_key = "${var.cluster_ssh_key}"
+  cluster_ssh_key  = "${var.cluster_ssh_key}"
   additional_repos = "${var.additional_repos}"
 }


### PR DESCRIPTION
This commit makes travis check any new provider added to the repo, to guarantee that it is validated and given appropiate tests on the initial push. The travis script was also updated to take into account that
`terraform init` for libvirt will not work in travis as the terraform binary from hashicorp cannot automatically download the libvirt plugin, and that there is no remote-state.tf file in libvirt.

Libvirt's main.tf was also formatted per terraform v0.11.11.