### PR TITLE
Change 'order' constraint to not use deprecated one

### DIFF
--- a/azure/terraform/provision/hanasr.template
+++ b/azure/terraform/provision/hanasr.template
@@ -25,5 +25,5 @@ ms msl_SAPHana_PRD_HDB00 rsc_SAPHana_PRD_HDB00 \
 	meta master-node-max=1 master-max=1 clone-node-max=1 interleave=true is-managed=true
 clone cln_SAPHanaTopology_PRD_HDB00 rsc_SAPHanaTopology_PRD_HDB00 \
 	meta clone-node-max=1 interleave=true
-order TopFirst 1000: cln_SAPHanaTopology_PRD_HDB00 msl_SAPHana_PRD_HDB00
+order TopFirst Mandatory: cln_SAPHanaTopology_PRD_HDB00 msl_SAPHana_PRD_HDB00
 colocation col_ip_on_sr-primary 2000: rsc_ip_PRD:Started msl_SAPHana_PRD_HDB00:Master


### PR DESCRIPTION
The HA order constraint for HANA should use the 'Mandatory' keyword instead of the current value of '1000'.

This is mandatory for newer version of Pacemaker, but also usable on previous version available on SLE-12-SP3+.