### PR TITLE
Update deprecated function

### DIFF
--- a/azure/terraform/network.tf
+++ b/azure/terraform/network.tf
@@ -210,7 +210,7 @@ resource "azurerm_public_ip" "iscsisrv" {
   name                         = "iscsisrv-ip"
   location                     = "${var.az_region}"
   resource_group_name          = "${azurerm_resource_group.myrg.name}"
-  public_ip_address_allocation = "Dynamic"
+  allocation_method            = "Dynamic"
   idle_timeout_in_minutes      = 30
 
   tags {
@@ -250,7 +250,7 @@ resource "azurerm_public_ip" "clusternodes" {
   name                         = "clusternodes-ip-${count.index}"
   location                     = "${var.az_region}"
   resource_group_name          = "${azurerm_resource_group.myrg.name}"
-  public_ip_address_allocation = "Dynamic"
+  allocation_method            = "Dynamic"
   idle_timeout_in_minutes      = 30
 
   tags {

--- a/azure/terraform/network.tf
+++ b/azure/terraform/network.tf
@@ -207,11 +207,11 @@ resource "azurerm_network_interface" "iscsisrv" {
 }
 
 resource "azurerm_public_ip" "iscsisrv" {
-  name                         = "iscsisrv-ip"
-  location                     = "${var.az_region}"
-  resource_group_name          = "${azurerm_resource_group.myrg.name}"
-  allocation_method            = "Dynamic"
-  idle_timeout_in_minutes      = 30
+  name                    = "iscsisrv-ip"
+  location                = "${var.az_region}"
+  resource_group_name     = "${azurerm_resource_group.myrg.name}"
+  allocation_method       = "Dynamic"
+  idle_timeout_in_minutes = 30
 
   tags {
     workspace = "${terraform.workspace}"
@@ -246,12 +246,12 @@ resource "azurerm_network_interface_backend_address_pool_association" "clusterno
 }
 
 resource "azurerm_public_ip" "clusternodes" {
-  count                        = "${var.ninstances}"
-  name                         = "clusternodes-ip-${count.index}"
-  location                     = "${var.az_region}"
-  resource_group_name          = "${azurerm_resource_group.myrg.name}"
-  allocation_method            = "Dynamic"
-  idle_timeout_in_minutes      = 30
+  count                   = "${var.ninstances}"
+  name                    = "clusternodes-ip-${count.index}"
+  location                = "${var.az_region}"
+  resource_group_name     = "${azurerm_resource_group.myrg.name}"
+  allocation_method       = "Dynamic"
+  idle_timeout_in_minutes = 30
 
   tags {
     workspace = "${terraform.workspace}"


### PR DESCRIPTION
* Update deprecated `public_ip_address_allocation` in favor of `allocation_method` in Azure configuration files.
[Link ](https://github.com/terraform-providers/terraform-provider-azurerm/pull/2576)for upstream PR about this change