### PR TITLE
Add install-salt-minion.sh

### DIFF
--- a/salt/install-salt-minion.sh
+++ b/salt/install-salt-minion.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+DEREGISTER="false"
+
+function print_help(){
+    cat <<-EOF
+
+Install the salt-minion provided via the official SUSE Repositories.
+
+For this, a Registration Code is required and your system will be 
+connected to the SUSE Customer Center.
+
+Supported Options:
+
+  -r [REG CODE]    Registration Code that will be used to register the system.
+  -d               Deregister the System aften the salt-minion installation
+  -h               Show this help. 
+
+EOF
+}
+
+
+
+function install_salt_minion(){
+    local regcode=$1
+
+    # Check SLE version
+    source /etc/os-release
+
+    SUSEConnect -r "$regcode"
+
+    # Register the modules accordingly with the SLE version.
+    if [[ $VERSION == *"12"* ]]; then    
+      SUSEConnect -p sle-module-adv-systems-management/12/x86_64
+    elif [[ $VERSION == *"15"* ]]; then  
+      SUSEConnect -p sle-module-basesystem/$VERSION_ID/x86_64
+    else 
+      echo "SLE Product version not supported by this script. Please, use version 12 or higher." 
+      exit 1
+    fi
+    
+    zypper --non-interactive install salt-minion
+
+    # If required, DEREGISTER 
+    if [[ $DEREGISTER == "true" ]]; then
+       SUSEConnect -d
+    fi
+}      
+
+
+while getopts ":hdr:" opt; do
+  case $opt in
+    h)
+        print_help
+        exit 0
+        ;; 
+    d) 
+        DEREGISTER="true"
+        ;;
+    r)
+        install_salt_minion "$OPTARG"
+        exit 0 
+        ;;
+    \?) echo "Invalid option -$OPTARG" >&2
+    ;;
+  esac
+done
+

--- a/salt/install-salt-minion.sh
+++ b/salt/install-salt-minion.sh
@@ -29,9 +29,9 @@ function install_salt_minion(){
     SUSEConnect -r "$regcode"
 
     # Register the modules accordingly with the SLE version.
-    if [[ $VERSION == *"12"* ]]; then    
+    if [[ $VERSION_ID =~ ^12\.? ]]; then    
       SUSEConnect -p sle-module-adv-systems-management/12/x86_64
-    elif [[ $VERSION == *"15"* ]]; then  
+    elif [[ $VERSION_ID =~ ^15\.? ]]; then  
       SUSEConnect -p sle-module-basesystem/$VERSION_ID/x86_64
     else 
       echo "SLE Product version not supported by this script. Please, use version 12 or higher." 

--- a/salt/install-salt-minion.sh
+++ b/salt/install-salt-minion.sh
@@ -60,7 +60,7 @@ while getopts ":hdr:" opt; do
         install_salt_minion "$OPTARG"
         exit 0 
         ;;
-    \?) echo "Invalid option -$OPTARG" >&2
+   *) echo "Invalid option -$OPTARG" >&2
     ;;
   esac
 done


### PR DESCRIPTION
Install the salt-minion from the SUSE official Repository using
registration. 
This script can be used for provisioning machines or images that do not have a pre-installed salt-minion.