### PR TITLE
Make the root & SAP admin & user passwords optional

### DIFF
--- a/salt/hana_node/files/pillar/hana.sls
+++ b/salt/hana_node/files/pillar/hana.sls
@@ -7,9 +7,6 @@ hana:
       install:
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
-        root_password: 'linux'
-        system_user_password: 'Qwerty1234'
-        sapadm_password: 'Qwerty1234'
       primary:
         name: NUREMBERG
         backup:
@@ -31,9 +28,6 @@ hana:
       install:
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
-        root_password: 'linux'
-        system_user_password: 'Qwerty1234'
-        sapadm_password: 'Qwerty1234'
         extra_parameters:
           hostname: 'hana02'
       secondary:
@@ -50,8 +44,5 @@ hana:
       install:
         software_path: '/root/sap_inst/51052481'
         root_user: 'root'
-        root_password: 'linux'
-        system_user_password: 'Qwerty1234'
-        sapadm_password: 'Qwerty1234'
         extra_parameters:
           hostname: 'hana02'


### PR DESCRIPTION
Make the root & SAP admin/user passwords optional.

This is needed for secure cloud configurations where SSH public keys should be used.

Should be merged when https://github.com/SUSE/saphanabootstrap-formula/pull/6 is merged and new packages are generated.