### PR TITLE
Add the init_type variable to setup the cluster without installing HANA

### DIFF
--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -95,11 +95,13 @@ These are the relevant files and what each provides:
 
 - The `sap_hana_deployment_bucket` variable must contain the name of the Google Storage bucket with the HANA installation files.
 
-- The `images_path_bucket` must contain the name of the Google Storage bucket with the SLES image.
+- The `images_path_bucket` variable must contain the name of the Google Storage bucket with the SLES image.
 
-- The `sles4sap_os_image_file` must contain the name of the SLES image.
+- The `sles4sap_os_image_file` variable must contain the name of the SLES image.
 
-- The `post_deployment_script` specifies the URL location of a script to run after the deployment is complete. This script should be hosted on a web server or in a GCS bucket.
+- The `post_deployment_script` variable specifies the URL location of a script to run after the deployment is complete. This script should be hosted on a web server or in a GCS bucket.
+
+- The `init_type` variable controls what is deployed in the cluster nodes. Valid values are `all` (installs HANA and configures cluster), `skip-hana` (does not install HANA, but configures cluster). Defaults to `all`.
 
 2. Deploy:
 

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -67,6 +67,7 @@ resource "google_compute_instance" "clusternodes" {
     sap_vip                    = "${var.sap_vip}"
     sap_vip_secondary_range    = ""
     suse_regcode               = "${var.suse_regcode}"
+    init_type                  = "${var.init_type}"
   }
 
   service_account {

--- a/gcp/terraform/terraform.tfvars
+++ b/gcp/terraform/terraform.tfvars
@@ -4,7 +4,7 @@ project     = "my-project"
 gcp_credentials_file = "my-project.json"
 
 # SUSE registration code
-suse_regcode = "xxxxxxxxxxxx"
+suse_regcode = ""
 
 # Internal IPv4 range
 ip_cidr_range = "10.0.0.0/24"
@@ -46,3 +46,5 @@ sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"
 # The script should be hosted on a web server or in a GCS bucket.
 post_deployment_script = ""
 
+# Variable for init-nodes.tpl script. Can be all, skip-hana or skip-all
+init_type = "all"

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -46,3 +46,8 @@ variable "storage_url" {
 }
 
 variable "post_deployment_script" {}
+
+variable "init_type" {
+  type    = "string"
+  default = "all"
+}


### PR DESCRIPTION
The `init_variable` supports:
- `all` (default: setup the cluster and install HANA)
- `skip-hana` (setup the cluster and don't install HANA)
- `skip-all` (don't do nothing)