### PR TITLE
Add google scripts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
       fi ;
       /tmp/terraform init ;
       if [[ "$provider" == "gcp" ]]; then
-        /tmp/terraform validate -var-file=terraform.tfvars -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var ssh_pub_key_file=/dev/null ;
+        /tmp/terraform validate -var-file=terraform.tfvars -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var ssh_key_file=/dev/null -var ssh_pub_key_file=/dev/null ;
       else
         /tmp/terraform validate -var-file=terraform.tfvars -var private_key_location=/dev/null ;
       fi ;

--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -91,7 +91,9 @@ These are the relevant files and what each provides:
 
 - The `gcp_credentials_file` variable must contain the path to the JSON file with the GCP credentials created above.
 
-- The `ssh_pub_key_file` variable must contain the path to your SSH public key.
+- The `ssh_key_file` variable must contain the path to your SSH private key.  This is used by the provisioner.
+
+- The `ssh_pub_key_file` variable must contain the path to your SSH public key.  This is used to access the instances.
 
 - The `region` variable must contain the name of the desired region.
 

--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -101,6 +101,8 @@ These are the relevant files and what each provides:
 
 - The `sap_hana_deployment_bucket` variable must contain the name of the Google Storage bucket with the HANA installation files.
 
+- The `sap_hana_backup_size` variable set the size of the SAP HANA backup partition.
+
 - The `images_path_bucket` variable must contain the name of the Google Storage bucket with the SLES image.
 
 - The `sles4sap_os_image_file` variable must contain the name of the SLES4SAP image.

--- a/gcp/terraform/disks.tf
+++ b/gcp/terraform/disks.tf
@@ -10,7 +10,7 @@ resource "google_compute_disk" "node_data" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-data-${count.index}"
   type  = "pd-standard"
-  size  = "1500"
+  size  = "${var.init_type == "all" ? 1500 : 50}"
   zone  = "${element(data.google_compute_zones.available.names, count.index)}"
 }
 
@@ -18,7 +18,7 @@ resource "google_compute_disk" "backup" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-backup-${count.index}"
   type  = "pd-standard"
-  size  = "500"
+  size  = "${var.init_type == "all" ? 500 : 10}"
   zone  = "${element(data.google_compute_zones.available.names, count.index)}"
 }
 

--- a/gcp/terraform/disks.tf
+++ b/gcp/terraform/disks.tf
@@ -18,7 +18,7 @@ resource "google_compute_disk" "backup" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-backup-${count.index}"
   type  = "pd-standard"
-  size  = "${var.init_type == "all" ? 500 : 10}"
+  size  = "${var.init_type == "all" ? var.sap_hana_backup_size : 10}"
   zone  = "${element(data.google_compute_zones.available.names, count.index)}"
 }
 

--- a/gcp/terraform/disks.tf
+++ b/gcp/terraform/disks.tf
@@ -10,7 +10,7 @@ resource "google_compute_disk" "node_data" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-data-${count.index}"
   type  = "pd-standard"
-  size  = "${var.init_type == "all" ? 1500 : 50}"
+  size  = "${var.init_type == "all" ? 500 : 50}"
   zone  = "${element(data.google_compute_zones.available.names, count.index)}"
 }
 

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -124,6 +124,12 @@ resource "google_compute_instance" "clusternodes" {
 
   provisioner "file" {
     source      = "./provision/"
-    destination = "/tmp/"
+    destination = "/root/provision/"
+
+    connection {
+      type        = "ssh"
+      user        = "root"
+      private_key = "${file(var.ssh_key_file)}"
+    }
   }
 }

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -121,4 +121,9 @@ resource "google_compute_instance" "clusternodes" {
   service_account {
     scopes = ["compute-rw", "storage-rw", "logging-write", "monitoring-write", "service-control", "service-management"]
   }
+
+  provisioner "file" {
+    source      = "./provision/"
+    destination = "/tmp/"
+  }
 }

--- a/gcp/terraform/provision/google/README.md
+++ b/gcp/terraform/provision/google/README.md
@@ -1,0 +1,8 @@
+To download the latest version upstream of each script, click on each one:
+
+- [alias](https://storage.googleapis.com/sapdeploy/pacemaker-gcp/alias)
+- [gcpstonith](https://storage.googleapis.com/sapdeploy/pacemaker-gcp/gcpstonith)
+- [route](https://storage.googleapis.com/sapdeploy/pacemaker-gcp/route)
+- [sap_lib_ha.sh](https://storage.googleapis.com/sapdeploy/dm-templates/lib/sap_lib_ha.sh)
+- [sap_lib_hdb.sh](https://storage.googleapis.com/sapdeploy/dm-templates/lib/sap_lib_hdb.sh)
+- [sap_lib_main.sh](https://storage.googleapis.com/sapdeploy/dm-templates/lib/sap_lib_main.sh)

--- a/gcp/terraform/provision/google/alias
+++ b/gcp/terraform/provision/google/alias
@@ -1,0 +1,232 @@
+#!/bin/bash
+# ---------------------------------------------------------------------
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------
+# Description:	Google Cloud Platform - Floating IP Address (Alias)
+# Version:			1.0.43
+# Date:					18/March/2018
+# ---------------------------------------------------------------------
+
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+meta_data() {
+  cat <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="gcp:alias">
+  <version>1.0</version>
+  <longdesc lang="en">Floating IP Address on Google Cloud Platform - Using Alias IP address functionality to attach a secondary IP address to a running instance</longdesc>
+  <shortdesc lang="en">Floating IP Address on Google Cloud Platform</shortdesc>
+  <parameters>
+    <parameter name="hostlist" unique="1" required="1">
+      <longdesc lang="en">List of hosts in the cluster</longdesc>
+      <shortdesc lang="en">Host list</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="logging" unique="0" required="0">
+      <longdesc lang="en">If enabled (set to true), IP failover logs will be posted to stackdriver logging</longdesc>
+      <shortdesc lang="en">Stackdriver-logging support</shortdesc>
+      <content type="boolean" default="" />
+    </parameter>
+    <parameter name="alias_ip" unique="1" required="1">
+      <longdesc lang="en">IP Address to be added including CIDR. E.g 192.168.0.1/32</longdesc>
+      <shortdesc lang="en">IP Address to be added including CIDR. E.g 192.168.0.1/32</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="alias_range_name" unique="1" required="0">
+      <longdesc lang="en">Subnet name for the Alias IP2</longdesc>
+      <shortdesc lang="en">Subnet name for the Alias IP</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="gcloud_path" unique="0" required="0">
+      <longdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud - If this is left blank, the default path of /usr/bin/gcloud will be used</longdesc>
+      <shortdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+  </parameters>
+  <actions>
+    <action name="start" timeout="300" />
+    <action name="stop" timeout="15" />
+    <action name="monitor" timeout="15" interval="60" depth="0" />
+    <action name="meta-data" timeout="15" />
+  </actions>
+</resource-agent>
+EOF
+}
+
+
+get_zone() {
+  ZONE=$(${GCLOUDCMD} --quiet compute instances list --filter="name=('${1}')" --format 'csv[no-heading](zone)')
+}
+
+
+get_ip() {
+  IP=$(${GCLOUDCMD} --quiet compute instances describe ${1} --zone ${ZONE} --format text | grep aliasIpRanges | grep ${OCF_RESKEY_alias_ip} | awk '{ print $2 }')
+}
+
+
+get_my_zone() {
+  MYZONE=$(curl -sH'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/zone" | cut -d'/' -f4)
+}
+
+
+get_my_ip() {
+  if [[ $(curl -sH'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip-aliases/") ]]; then
+    MYIP=$(curl -sH'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/network-interfaces/0/ip-aliases/0")
+  else
+    unset MYIP
+  fi
+}
+
+
+get_gcloud() {
+  ## if gcloud command isn't set, default to the default path
+  if [[ -n ${OCF_RESKEY_gcloud_path} ]]; then
+    GCLOUDCMD=${OCF_RESKEY_gcloud_path}
+  else
+    GCLOUDCMD="/usr/bin/gcloud"
+  fi
+
+  ## check gcloud command exists
+  if [[ ! -f ${GCLOUDCMD} ]]; then
+    log_error "gcloud command not found at ${GCLOUDCMD}"
+    exit 1
+  fi
+}
+
+
+check_gcloud_version() {
+  ${GCLOUDCMD} --quiet beta compute instances network-interfaces --help >/dev/null
+  if [[ $? -gt 0 ]]; then
+    log_error "gcloud version does not support beta 'network-interfaces' function. Upgrade gcloud SDK or specifiy gcloud path to a newer version"
+    exit 1
+  fi
+}
+
+
+log_info() {
+  echo "gcp:alias - INFO - ${1}"
+  LOG="`hostname` ${OCF_RESOURCE_INSTANCE} \"${1}\""
+  echo ${LOG}
+  if [[ -n ${OCF_RESKEY_logging} ]]; then
+    if [[ ${OCF_RESKEY_logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} logging write ${HOSTNAME} "${LOG}" --severity=INFO || :
+    fi
+  fi
+}
+
+
+log_error() {
+  echo "gcp:alias - ERROR - ${1}"
+  LOG="`hostname` ${OCF_RESOURCE_INSTANCE} \"${1}\""
+  if [[ -n ${OCF_RESKEY_logging} ]]; then
+    if [[ ${OCF_RESKEY_logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} logging write ${HOSTNAME} "${LOG}" --severity=ERROR || :
+    fi
+  fi
+}
+
+case ${1} in
+
+  start)
+    get_gcloud
+    check_gcloud_version
+    get_my_zone
+    get_my_ip
+
+    ## If I already have the IP, exit. If it has an alias IP that isn't the VIP, then remove it
+    if [[ -n ${MYIP} ]]; then
+      if [[ ${MYIP} == ${OCF_RESKEY_alias_ip} ]]; then
+        log_info "${HOSTNAME} already has ${MYIP} attached. No action required"
+        exit 0
+      else
+        log_info "Removing ${MYIP} from ${HOSTNAME}"
+        ${GCLOUDCMD} --quiet beta compute instances network-interfaces update ${HOSTNAME} --zone ${MYZONE} --aliases ""
+      fi
+    fi
+
+    ## Loops through all hosts & remove the alias IP from the host that has it
+    HOSTLIST=${OCF_RESKEY_hostlist/$HOSTNAME/}
+    IFS=' ' read -r -a HOSTS <<< "$HOSTLIST"
+    IP="TBD"
+    for HOST in "${HOSTS[@]}"; do
+      get_zone ${HOST}
+      get_ip ${HOST}
+      log_info "Checking to see if ${HOST} owns $OCF_RESKEY_alias_ip"
+      ## keep trying to remove until it's not there anymore - Added due to the fingerprint bug
+      while [[ -n ${IP} ]]; do
+        log_info "${IP} is attached to ${HOST} - Removing all alias IP addresses from ${HOST}"
+        ${GCLOUDCMD} --quiet beta compute instances network-interfaces update ${HOST} --zone ${ZONE} --aliases ""
+        get_ip ${HOST}
+        sleep 2
+      done
+    done
+
+    ## add alias IP to localhost
+    if [[ -z ${OCF_RESKEY_alias_range_name} ]]; then
+      log_info "Adding ${OCF_RESKEY_alias_ip} to ${HOSTNAME}"
+      ${GCLOUDCMD} --quiet beta compute instances network-interfaces update ${HOSTNAME} --zone ${MYZONE} --aliases ${OCF_RESKEY_alias_ip}
+    else
+      log_info "Adding ${OCF_RESKEY_alias_ip} in secondary range ${OCF_RESKEY_alias_range_name} to ${HOSTNAME}"
+      ${GCLOUDCMD} --quiet beta compute instances network-interfaces update ${HOSTNAME} --zone ${MYZONE} --aliases ${OCF_RESKEY_alias_range_name}:${OCF_RESKEY_alias_ip}
+    fi
+
+    ## Check the IP has been added
+    get_my_ip
+    if [[ -n ${MYIP} ]]; then
+      if [[ ${MYIP} == ${OCF_RESKEY_alias_ip} ]]; then
+        log_info "Finished adding ${OCF_RESKEY_alias_ip} to ${HOSTNAME}"
+      else
+        log_error "Failed to add IP. ${HOSTNAME} has an IP attached but it isn't ${OCF_RESKEY_alias_ip}"
+        exit 1
+      fi
+    else
+      log_error "Failed to add IP address ${OCF_RESKEY_alias_ip} to ${HOSTNAME}"
+      exit 1
+    fi
+
+    #$ exit gracefully
+    exit 0
+	;;
+
+	stop)
+    #$ exit gracefully
+    exit 0
+	;;
+
+	status|monitor)
+    get_gcloud
+    get_my_ip
+    if [[ -n ${MYIP} ]]; then
+      if [[ ${MYIP} == ${OCF_RESKEY_alias_ip} ]]; then
+        log_info "${HOSTNAME} has the correct IP address attached"
+        exit 0
+      else
+        exit 7
+      fi
+    else
+      exit 7
+    fi
+  ;;
+
+  meta-data)
+    meta_data
+  ;;
+
+  *)
+    echo "gcp:alias - no such function \"${1}\""
+    exit 1
+	;;
+esac

--- a/gcp/terraform/provision/google/gcpstonith
+++ b/gcp/terraform/provision/google/gcpstonith
@@ -1,0 +1,160 @@
+#!/bin/bash -x
+# ---------------------------------------------------------------------
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------
+# Description:	Google Cloud Platform - STONITH/Fencing agent
+# Version:			1.0.2
+# Date:					18/March/2018
+# ---------------------------------------------------------------------
+
+meta_data() {
+ cat <<EOF
+<parameters>
+ <parameter name="instance_name" unique="1" required="1">
+	 <longdesc lang="en">The instance name of the host to be managed by this STONITH device</longdesc>
+	 <shortdesc lang="en">Instance Name</shortdesc>
+	 <content type="string" default="" />
+ </parameter>
+ <parameter name="logging" unique="0" required="0">
+	 <longdesc lang="en">If enabled (set to true), IP failover logs will be posted to stackdriver logging</longdesc>
+	 <shortdesc lang="en">Stackdriver-logging support</shortdesc>
+	 <content type="boolean" default="" />
+ </parameter>
+ <parameter name="gcloud_path" unique="0" required="0">
+	 <longdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud - If this is left blank, the default path of /usr/bin/gcloud will be used</longdesc>
+	 <shortdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud</shortdesc>
+	 <content type="string" default="" />
+ </parameter>
+</parameters>
+EOF
+}
+
+
+get_zone() {
+  ZONE=$(${GCLOUDCMD} --quiet compute instances list --filter="name=('${1}')" --format 'csv[no-heading](zone)' --verbosity none || true)
+}
+
+
+log_info() {
+  echo "gcp:stonith - INFO - ${1}"
+  LOG="`hostname` gcp:stonith \"${1}\""
+  echo ${LOG}
+  if [[ -n ${logging} ]]; then
+    if [[ ${logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} --quiet logging write ${HOSTNAME} "${LOG}" --severity=INFO || true
+    fi
+  fi
+}
+
+
+log_error() {
+  echo "gcp:stonith - ERROR - ${1}"
+  LOG="`hostname` gcp:stonith \"${1}\""
+  if [[ -n ${logging} ]]; then
+    if [[ ${logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} --quiet logging write ${HOSTNAME} "${LOG}" --severity=ERROR || true
+    fi
+  fi
+}
+
+
+get_gcloud() {
+  ## if gcloud command isn't set, default to the default path
+  if [[ -n ${gcloud_path} ]]; then
+    GCLOUDCMD=${gcloud_path}
+  else
+    GCLOUDCMD="/usr/bin/gcloud"
+  fi
+
+  ## check gcloud command exists
+  if [[ ! -f ${GCLOUDCMD} ]]; then
+    log_error "gcloud command not found at ${GCLOUDCMD}"
+    exit 1
+  fi
+}
+
+
+## find the zone of the instance in question
+
+case ${1} in
+ on|poweron)
+    get_gcloud
+    get_zone ${instance_name}
+    log_info "Issuing poweron of ${instance_name} in zone ${ZONE}"
+  	${GCLOUDCMD} --quiet compute instances start ${instance_name} --zone=${ZONE} || true
+    log_info "Poweron of ${instance_name} in zone ${ZONE} complete"
+	;;
+
+	off|poweroff)
+    get_gcloud
+    get_zone ${instance_name}
+    log_info "Issuing poweroff of ${instance_name} in zone ${ZONE}"
+  	${GCLOUDCMD} --quiet compute instances stop ${instance_name} --zone=${ZONE} || true
+    log_info "Poweroff of ${instance_name} in zone ${ZONE} complete"
+	;;
+
+	reset|reboot)
+    get_gcloud
+    get_zone ${instance_name}
+    log_info "Issuing reset of ${instance_name} in zone ${ZONE}"
+  	${GCLOUDCMD} --quiet compute instances reset ${instance_name} --zone=${ZONE} || true
+    log_info "Reset of ${instance_name} in zone ${ZONE} complete"
+	;;
+
+	status)
+    get_gcloud
+    get_zone ${instance_name}
+    status=$(${GCLOUDCMD} --quiet compute instances list --filter="name=('${instance_name}')" --format 'csv[no-heading](status)' --verbosity none || true)
+
+    if [ "${status}" = "RUNNING" ]; then
+      exit 0
+    else
+      exit 1
+    fi
+	;;
+
+ gethosts)
+  	echo ${instance_name}
+	;;
+
+	getconfignames)
+ 		echo instance_name
+ 	;;
+
+ getinfo-xml|meta-data)
+ 		meta_data
+ ;;
+
+ getinfo-devid)
+ 		echo "Google Cloud Platform STONITH/Fencing device"
+ ;;
+
+ getinfo-devname)
+ 		echo "Google Cloud Platform STONITH/Fencing device"
+ ;;
+
+ getinfo-devdescr)
+ 		echo "Google Cloud Platform host reset/poweron/poweroff/move"
+ ;;
+
+ getinfo-devurl)
+ 		echo "http://cloud.google.com"
+ ;;
+
+ *)
+		echo "No such function: \"${1}\""
+  	exit 1
+ ;;
+
+esac

--- a/gcp/terraform/provision/google/route
+++ b/gcp/terraform/provision/google/route
@@ -1,0 +1,162 @@
+#!/bin/bash
+# ---------------------------------------------------------------------
+# Copyright 2016 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ---------------------------------------------------------------------
+# Description:	Google Cloud Platform - Floating IP Address (Route)
+# Version:			1.0.43
+# Date:					18/March/2018
+# ---------------------------------------------------------------------
+
+: ${OCF_FUNCTIONS_DIR=${OCF_ROOT}/lib/heartbeat}
+. ${OCF_FUNCTIONS_DIR}/ocf-shellfuncs
+
+meta_data() {
+  cat <<EOF
+<?xml version="1.0"?>
+<!DOCTYPE resource-agent SYSTEM "ra-api-1.dtd">
+<resource-agent name="gcp:vip">
+  <version>1.0</version>
+  <longdesc lang="en">Long</longdesc>
+  <shortdesc lang="en">Short</shortdesc>
+  <parameters>
+    <parameter name="route_name" unique="1" required="1">
+      <longdesc lang="en">The name of the GCP route.</longdesc>
+      <shortdesc lang="en">Route name</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="route_network" unique="1" required="1">
+      <longdesc lang="en">GCP network in which the route should be created.</longdesc>
+      <shortdesc lang="en">Network name</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="route_ip" unique="1" required="1">
+      <longdesc lang="en">IP Address to be routed through.</longdesc>
+      <shortdesc lang="en">IP Address</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+    <parameter name="logging" unique="0" required="0">
+      <longdesc lang="en">If enabled (by setting to yes or true), IP failover logs will be posted to stackdriver logging</longdesc>
+      <shortdesc lang="en">Stackdriver-logging support</shortdesc>
+      <content type="boolean" default="" />
+    </parameter>
+    <parameter name="gcloud_path" unique="0" required="0">
+      <longdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud - If this is left blank, the default path of /usr/bin/gcloud will be used</longdesc>
+      <shortdesc lang="en">Full path of the gcloud binary. E.g /usr/local/gsdk/google-cloud-sdk/bin/gcloud</shortdesc>
+      <content type="string" default="" />
+    </parameter>
+  </parameters>
+  <actions>
+    <action name="start" timeout="300" />
+    <action name="stop" timeout="15" />
+    <action name="monitor" timeout="15" interval="10" depth="0" />
+    <action name="meta-data" timeout="5" />
+  </actions>
+</resource-agent>
+EOF
+}
+
+
+get_route() {
+  ROUTE=$(${GCLOUDCMD} --quiet compute routes describe ${OCF_RESKEY_route_name} --verbosity=none -q | grep nextHop | grep -o '[^/]*$')
+}
+
+
+get_my_zone() {
+  MYZONE=$(curl -sH'Metadata-Flavor: Google' "http://metadata.google.internal/computeMetadata/v1/instance/zone" | cut -d'/' -f4)
+}
+
+
+get_gcloud() {
+  ## if gcloud command isn't set, default to the default path
+  if [[ -n ${OCF_RESKEY_gcloud_path} ]]; then
+    GCLOUDCMD=${OCF_RESKEY_gcloud_path}
+  else
+    GCLOUDCMD="/usr/bin/gcloud"
+  fi
+
+  ## check gcloud command exists
+  if [[ ! -f ${GCLOUDCMD} ]]; then
+    log_error "gcloud command not found at ${GCLOUDCMD}"
+    exit 1
+  fi
+}
+
+
+log_info() {
+  echo "gcp:route - INFO - ${1}"
+  LOG="`hostname` ${OCF_RESOURCE_INSTANCE} \"${1}\""
+  echo ${LOG}
+  if [[ -n ${OCF_RESKEY_logging} ]]; then
+    if [[ ${OCF_RESKEY_logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} logging write ${HOSTNAME} "${LOG}" --severity=INFO || :
+    fi
+  fi
+}
+
+
+log_error() {
+  echo "gcp:route - ERROR - ${1}"
+  LOG="`hostname` ${OCF_RESOURCE_INSTANCE} \"${1}\""
+  if [[ -n ${OCF_RESKEY_logging} ]]; then
+    if [[ ${OCF_RESKEY_logging,,} =~ ^(yes|true|enabled)$ ]]; then
+      ${GCLOUDCMD} logging write ${HOSTNAME} "${LOG}" --severity=ERROR || :
+    fi
+  fi
+}
+
+case ${1} in
+  start)
+    get_gcloud
+    get_my_zone
+    get_route
+
+    ## If I already have the IP, exit. If it has an alias IP that isn't the VIP, then remove it
+    if [ "${ROUTE}" = "${HOSTNAME}" ]; then
+      log_info "${OCF_RESKEY_route_name} is already routed to ${HOSTNAME}. No action required"
+      exit 0
+    fi
+    ## delete the current route
+    log_info "Deleting route '${OCF_RESKEY_route_name}'"
+    ${GCLOUDCMD} --quiet compute routes delete ${OCF_RESKEY_route_name} --verbosity=none
+
+    ## add a new route
+    log_info "Creating route '${OCF_RESKEY_route_name}' pointing to host ${HOSTNAME}"
+    ${GCLOUDCMD} --quiet compute routes create ${OCF_RESKEY_route_name} --priority=1000 --network=${OCF_RESKEY_route_network} --destination-range=${OCF_RESKEY_route_ip}/32 --next-hop-instance=${HOSTNAME} --next-hop-instance-zone=${MYZONE}
+    exit 0
+	;;
+
+	stop)
+		exit 0
+	;;
+
+	status|monitor)
+    get_gcloud
+    get_route
+    if [ "${ROUTE}" = "${HOSTNAME}" ]; then
+      log_info "Route '${OCF_RESKEY_route_name}' is correctly pointing to ${HOSTNAME}"
+      exit 0
+    else
+      exit 7
+    fi
+	;;
+
+  meta-data)
+    meta_data
+  ;;
+
+  *)
+    echo "no such function \"${1}\""
+    exit $OCF_ERR_UNIMPLEMENTED
+	;;
+esac

--- a/gcp/terraform/provision/google/sap_lib_ha.sh
+++ b/gcp/terraform/provision/google/sap_lib_ha.sh
@@ -1,0 +1,446 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Description:  Google Cloud Platform - SAP Deployment Functions
+# Build Date:   Wed Feb 20 13:53:45 GMT 2019
+# ------------------------------------------------------------------------
+
+ha::check_settings() {
+
+  # Set additional global constants
+  readonly PRIMARY_NODE_IP=$(ping "${VM_METADATA[sap_primary_instance]}" -c 1 | head -1 | awk  '{ print $3 }' | sed 's/(//' | sed 's/)//')
+  readonly SECONDARY_NODE_IP=$(ping "${VM_METADATA[sap_secondary_instance]}" -c 1 | head -1 | awk  '{ print $3 }' | sed 's/(//' | sed 's/)//')
+
+  ## check required parameters are present
+  if [ -z "${VM_METADATA[sap_vip]}" ] || [ -z "${VM_METADATA[sap_primary_instance]}" ] || [ -z "${PRIMARY_NODE_IP}" ] || [ -z "${VM_METADATA[sap_primary_zone]}" ] || [ -z "${VM_METADATA[sap_secondary_instance]}" ] || [ -z "${SECONDARY_NODE_IP}" ]; then
+    main::errhandle_log_warning "High Availability variables were missing or incomplete. Both SAP HANA VM's will be installed and configured but HA will need to be manually setup "
+    main::complete
+  fi
+
+  mkdir -p /root/.deploy
+}
+
+
+ha::download_scripts() {
+  main::errhandle_log_info "Downloading pacemaker-gcp"
+  mkdir -p /usr/lib/ocf/resource.d/gcp
+  mkdir -p /usr/lib64/stonith/plugins/external
+  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/alias -o /usr/lib/ocf/resource.d/gcp/alias
+  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/route -o /usr/lib/ocf/resource.d/gcp/route
+  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/gcpstonith -o /usr/lib64/stonith/plugins/external/gcpstonith
+  chmod +x /usr/lib/ocf/resource.d/gcp/alias
+  chmod +x /usr/lib/ocf/resource.d/gcp/route
+  chmod +x /usr/lib64/stonith/plugins/external/gcpstonith
+}
+
+
+ha::create_hdb_user() {
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    hana_monitoring_user="slehasync"
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    hana_monitoring_user="rhelhasync"
+  fi
+
+  main::errhandle_log_info "Adding user ${hana_monitoring_user} to ${VM_METADATA[sap_hana_sid]}"
+
+  ## create .sql file
+  echo "CREATE USER ${hana_monitoring_user} PASSWORD \"${VM_METADATA[sap_hana_system_password]}\";" > /root/.deploy/"${HOSTNAME}"_hdbadduser.sql
+  echo "GRANT DATA ADMIN TO ${hana_monitoring_user};" >> /root/.deploy/"${HOSTNAME}"_hdbadduser.sql
+  echo "ALTER USER ${hana_monitoring_user} DISABLE PASSWORD LIFETIME;" >> /root/.deploy/"${HOSTNAME}"_hdbadduser.sql
+
+  ## run .sql file
+  PATH="$PATH:/usr/sap/${VM_METADATA[sap_hana_sid]}/HDB${VM_METADATA[sap_hana_instance_number]}/exe"
+  bash -c "source /usr/sap/*/home/.sapenv.sh && hdbsql -u system -p '${VM_METADATA[sap_hana_system_password]}' -i ${VM_METADATA[sap_hana_instance_number]} -I /root/.deploy/${HOSTNAME}_hdbadduser.sql"
+}
+
+
+ha::hdbuserstore() {
+
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    hana_user_store_key="SLEHALOC"
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    hana_user_store_key="SAPHANARH2SR"
+  fi
+
+  main::errhandle_log_info "Adding hdbuserstore entry '${hana_user_store_key}' ponting to localhost:3${VM_METADATA[sap_hana_instance_number]}15"
+
+  #add user store
+  PATH="$PATH:/usr/sap/${VM_METADATA[sap_hana_sid]}/HDB${VM_METADATA[sap_hana_instance_number]}/exe"
+  bash -c "source /usr/sap/*/home/.sapenv.sh && hdbuserstore SET ${hana_user_store_key} localhost:3${VM_METADATA[sap_hana_instance_number]}15 ${hana_monitoring_user} '${VM_METADATA[sap_hana_system_password]}'"
+
+  #check userstore
+  bash -c "source /usr/sap/*/home/.sapenv.sh && hdbsql -U ${hana_user_store_key} -o /root/.deploy/hdbsql.out -a 'select * from dummy'"
+
+  if  ! grep -q \"X\" /root/.deploy/hdbsql.out; then
+    main::errhandle_log_warning "Unable to connect to HANA after adding hdbuserstore entry. Both SAP HANA systems have been installed and configured but the remainder of the HA setup will need to be manually performed"
+    main::complete
+  fi
+
+  main::errhandle_log_info "--- hdbuserstore connection test successful"
+}
+
+
+ha::install_secondary_sshkeys() {
+  main::errhandle_log_info "Adding ${VM_METADATA[sap_primary_instance]} ssh keys to ${VM_METADATA[sap_secondary_instance]}"
+  gcloud compute instances add-metadata "${VM_METADATA[sap_secondary_instance]}" --metadata "ssh-keys=root:$(cat ~/.ssh/id_rsa.pub)" --zone "${VM_METADATA[sap_secondary_zone]}"
+  cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+}
+
+
+ha::install_primary_sshkeys() {
+  main::errhandle_log_info "Adding ${VM_METADATA[sap_secondary_instance]} ssh keys to ${VM_METADATA[sap_primary_instance]}"
+  gcloud compute instances add-metadata "${VM_METADATA[sap_primary_instance]}" --metadata "ssh-keys=root:$(cat /root/.ssh/id_rsa.pub)" --zone "${VM_METADATA[sap_primary_zone]}"
+  cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+}
+
+
+ha::wait_for_secondary() {
+  local count=0
+
+  main::errhandle_log_info "Waiting for ready signal from ${VM_METADATA[sap_secondary_instance]} before continuing"
+
+  while [[ ! -f /root/.deploy/.${VM_METADATA[sap_secondary_instance]}.ready ]]; do
+		count=$((count +1))
+    scp -o StrictHostKeyChecking=no "${VM_METADATA[sap_secondary_instance]}":/root/.deploy/."${VM_METADATA[sap_secondary_instance]}".ready /root/.deploy
+    main::errhandle_log_info "--- ${VM_METADATA[sap_secondary_instance]} is not ready - sleeping for 60 seconds then trying again"
+    sleep 60s
+    if [ ${count} -gt 15 ]; then
+      main::errhandle_log_warning "${VM_METADATA[sap_secondary_instance]} wasn't ready in time. Both SAP HANA systems have been installed and configured but the remainder of the HA setup will need to be manually performed"
+      main::complete
+    fi
+  done
+
+  main::errhandle_log_info "--- ${VM_METADATA[sap_secondary_instance]} is now ready - continuing HA setup"
+}
+
+
+ha::wait_for_primary() {
+  local count=0
+
+  main::errhandle_log_info "Waiting for ready signal from ${VM_METADATA[sap_primary_instance]} before continuing"
+  scp -o StrictHostKeyChecking=no "${VM_METADATA[sap_primary_instance]}":/root/.deploy/."${VM_METADATA[sap_primary_instance]}".ready /root/.deploy
+
+  while [[ ! -f /root/.deploy/."${VM_METADATA[sap_primary_instance]}".ready ]]; do
+		count=$((count +1))
+    scp -o StrictHostKeyChecking=no "${VM_METADATA[sap_primary_instance]}":/root/.deploy/."${VM_METADATA[sap_primary_instance]}".ready /root/.deploy
+    main::errhandle_log_info "--- ${VM_METADATA[sap_primary_instance]} is not not ready - sleeping for 60 seconds then trying again"
+    sleep 60s
+    if [ ${count} -gt 10 ]; then
+      main::errhandle_log_warning "${VM_METADATA[sap_primary_instance]} wasn't ready in time. Both SAP HANA systems have been installed and configured but the remainder of the HA setup will need to be manually performed"
+      main::complete
+    fi
+  done
+
+  main::errhandle_log_info "--- ${VM_METADATA[sap_primary_instance]} is now ready - continuing HA setup"
+}
+
+
+ha::ready(){
+  echo "ready" > /root/.deploy/."${HOSTNAME}".ready
+}
+
+
+ha::config_cluster(){
+  main::errhandle_log_info "Configuring cluster primivatives"
+}
+
+
+ha::copy_hdb_ssfs_keys(){
+  main::errhandle_log_info "Transfering SSFS keys from ${VM_METADATA[sap_primary_instance]}"
+  rm /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/data/SSFS_"${VM_METADATA[sap_hana_sid]}".DAT
+  rm /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/key/SSFS_"${VM_METADATA[sap_hana_sid]}".KEY
+  scp -o StrictHostKeyChecking=no "${VM_METADATA[sap_primary_instance]}":/usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/data/SSFS_"${VM_METADATA[sap_hana_sid]}".DAT /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/data/SSFS_"${VM_METADATA[sap_hana_sid]}".DAT
+  scp -o StrictHostKeyChecking=no "${VM_METADATA[sap_primary_instance]}":/usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/key/SSFS_"${VM_METADATA[sap_hana_sid]}".KEY /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/key/SSFS_"${VM_METADATA[sap_hana_sid]}".KEY
+  chown "${VM_METADATA[sap_hana_sid],,}"adm:sapsys /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/data/SSFS_"${VM_METADATA[sap_hana_sid]}".DAT
+  chown "${VM_METADATA[sap_hana_sid],,}"adm:sapsys /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/key/SSFS_"${VM_METADATA[sap_hana_sid]}".KEY
+  chmod g+wrx,u+wrx /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/data/SSFS_"${VM_METADATA[sap_hana_sid]}".DAT
+  chmod g+wrx,u+wrx  /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/security/rsecssfs/key/SSFS_"${VM_METADATA[sap_hana_sid]}".KEY
+}
+
+
+ha::enable_hsr() {
+  main::errhandle_log_info "Enabling HANA System Replication support "
+  runuser -l "${VM_METADATA[sap_hana_sid],,}adm" -c "hdbnsutil -sr_enable --name=${HOSTNAME}"
+}
+
+
+ha::config_hsr() {
+  main::errhandle_log_info "Configuring SAP HANA system replication primary -> secondary"
+  runuser -l "${VM_METADATA[sap_hana_sid],,}adm" -c "hdbnsutil -sr_register --remoteHost=${VM_METADATA[sap_primary_instance]} --remoteInstance=${VM_METADATA[sap_hana_instance_number]} --replicationMode=syncmem --operationMode=logreplay --name=${VM_METADATA[sap_secondary_instance]}"
+}
+
+
+ha::check_hdb_replication(){
+  main::errhandle_log_info "Checking SAP HANA replication status"
+  # check status
+  bash -c "source /usr/sap/*/home/.sapenv.sh && /usr/sap/${VM_METADATA[sap_hana_sid]}/HDB${VM_METADATA[sap_hana_instance_number]}/exe/hdbsql -o /root/.deploy/hdbsql.out -a -U ${hana_user_store_key} 'select distinct REPLICATION_STATUS from SYS.M_SERVICE_REPLICATION'"
+  
+  local count=0
+    
+  while ! grep -q \"ACTIVE\" /root/.deploy/hdbsql.out; do
+    main::errhandle_log_info "--- Replication is still in progressing. Waiting 60 seconds then trying again"
+    bash -c "source /usr/sap/*/home/.sapenv.sh && /usr/sap/${VM_METADATA[sap_hana_sid]}/HDB${VM_METADATA[sap_hana_instance_number]}/exe/hdbsql -o /root/.deploy/hdbsql.out -a -U ${hana_user_store_key} 'select distinct REPLICATION_STATUS from SYS.M_SERVICE_REPLICATION'"
+    sleep 60s
+    if [ ${count} -gt 20 ]; then
+      main::errhandle_log_error "SAP HANA System Replication didn't complete. Please check network connectivity and firewall rules"
+    fi
+  done
+  main::errhandle_log_info "--- Replication in sync. Continuing with HA configuration"
+}
+
+
+ha::check_cluster(){
+  main::errhandle_log_info "Checking cluster status"
+  
+  local count=0
+
+  while ! crm_mon -s | grep -q "2 nodes online"; do
+    main::errhandle_log_info "--- Cluster is not yet online. Waiting 60 seconds then trying again"
+    sleep 60s
+    if [ ${count} -gt 20 ]; then
+      main::errhandle_log_error "Pacemaker cluster failed to come online. Please check network connectivity and firewall rules"
+    fi
+  done
+  main::errhandle_log_info "--- Two cluster nodes are online and ready. Continuing with HA configuration"
+}
+
+
+ha::config_corosync(){
+  main::errhandle_log_info "--- Creating /etc/corosync/corosync.conf"
+  cat <<EOF > /etc/corosync/corosync.conf
+    totem {
+      version: 2
+      secauth: off
+      crypto_hash: sha1
+      crypto_cipher: aes256
+      cluster_name:	hacluster
+      clear_node_high_bit: yes
+      token: 5000
+      token_retransmits_before_loss_const: 6
+      join: 60
+      consensus: 7500
+      max_messages:	20
+      transport: udpu
+      interface {
+        ringnumber:	0
+        bindnetaddr: ${1}
+        mcastport: 5405
+        ttl: 1
+      }
+    }
+    logging {
+      fileline:	off
+      to_stderr: no
+      to_logfile: no
+      logfile: /var/log/cluster/corosync.log
+      to_syslog: yes
+      debug: off
+      timestamp: on
+      logger_subsys {
+        subsys: QUORUM
+        debug: off
+      }
+    }
+    nodelist {
+      node {
+        ring0_addr: ${VM_METADATA[sap_primary_instance]}
+        nodeid: 1
+      }
+      node {
+        ring0_addr: ${VM_METADATA[sap_secondary_instance]}
+        nodeid: 2
+      }
+    }
+    quorum {
+      provider: corosync_votequorum
+      expected_votes: 2
+      two_node: 1
+    }
+EOF
+}
+
+
+ha::config_pacemaker_primary() {
+  main::errhandle_log_info "Creating cluster on primary node"
+  main::errhandle_log_info "--- Creating corosync-keygen"
+  corosync-keygen
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    main::errhandle_log_info "--- Starting csync2"
+    script -q -c 'ha-cluster-init -y csync2' > /dev/null 2>&1 &
+    ha::config_corosync "${PRIMARY_NODE_IP}"
+    main::errhandle_log_info "--- Starting cluster"
+    sleep 5s
+    systemctl enable pacemaker
+    systemctl start pacemaker
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    main::errhandle_log_info "--- Creating /etc/corosync/corosync.conf"
+    pcs cluster setup --name hana --local "${VM_METADATA[sap_primary_instance]} ${VM_METADATA[sap_secondary_instance]}" --force
+    main::errhandle_log_info "--- Starting cluster services & enabling on startup"
+    service pacemaker start
+    service pscd start
+    systemctl enable pcsd.service
+    systemctl enable pacemaker
+    main::errhandle_log_info "--- Setting hacluster password"
+    echo linux | passwd --stdin hacluster
+  fi
+}
+
+
+ha::pacemaker_maintenance() {
+  local mode="${1}"
+
+  main::errhandle_log_info "Setting cluster maintenance mode to ${mode}"
+  crm configure property maintenance-mode="${mode}"
+}
+
+
+ha::config_pacemaker_secondary() {
+  main::errhandle_log_info "Joining ${VM_METADATA[sap_secondary_instance]} to cluster"
+
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    ha::config_corosync "${SECONDARY_NODE_IP}"
+    bash -c "ha-cluster-join -y -c ${VM_METADATA[sap_primary_instance]} csync2"
+    systemctl enable pacemaker
+    systemctl start pacemaker
+    systemctl enable hawk
+    systemctl start hawk    
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    corosync-keygen
+    pcs cluster setup --name hana --local "${VM_METADATA[sap_primary_instance]} ${VM_METADATA[sap_secondary_instance]}" --force
+    service pacemaker start
+    service pscd start
+    systemctl enable pcsd.service
+    systemctl enable pacemaker
+  fi
+
+  main::complete
+}
+
+
+ha::pacemaker_add_stonith() {
+  main::errhandle_log_info "Cluster: Adding STONITH devices"
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    crm configure primitive STONITH-"${VM_METADATA[sap_primary_instance]}" stonith:external/gcpstonith op monitor interval="300s" timeout="60s" on-fail="restart" op start interval="0" timeout="60s" onfail="restart" params instance_name="${VM_METADATA[sap_primary_instance]}" gcloud_path="${GCLOUD}" logging="yes"
+    crm configure primitive STONITH-"${VM_METADATA[sap_secondary_instance]}" stonith:external/gcpstonith op monitor interval="300s" timeout="60s" on-fail="restart" op start interval="0" timeout="60s" onfail="restart" params instance_name="${VM_METADATA[sap_secondary_instance]}" gcloud_path="${GCLOUD}" logging="yes"
+    crm configure location LOC_STONITH_"${VM_METADATA[sap_primary_instance]}" STONITH-"${VM_METADATA[sap_primary_instance]}" -inf: "${VM_METADATA[sap_primary_instance]}"
+    crm configure location LOC_STONITH_"${VM_METADATA[sap_secondary_instance]}" STONITH-"${VM_METADATA[sap_secondary_instance]}" -inf: "${VM_METADATA[sap_secondary_instance]}"
+  fi
+}
+
+
+ha::pacemaker_add_vip() {
+  main::errhandle_log_info "Cluster: Adding virtual IP"
+  if ! ping -c 1 -W 1 "${VM_METADATA[sap_vip]}"; then 
+    if [ "${LINUX_DISTRO}" = "SLES" ]; then
+      crm configure primitive rsc_vip_int-primary IPaddr2 params ip="${VM_METADATA[sap_vip]}" cidr_netmask=32 nic="eth0" op monitor interval=10s
+      if [[ -n "${VM_METADATA[sap_vip_secondary_range]}" ]]; then
+        crm configure primitive rsc_vip_gcp-primary ocf:gcp:alias op monitor interval="60s" timeout="60s" op start interval="0" timeout="180s" op stop interval="0" timeout="180s" params alias_ip="${VM_METADATA[sap_vip]}/32" hostlist="${VM_METADATA[sap_primary_instance]} ${VM_METADATA[sap_secondary_instance]}" gcloud_path="${GCLOUD}" alias_range_name="${VM_METADATA[sap_vip_secondary_range}" logging="yes" meta priority=10
+      else
+        crm configure primitive rsc_vip_gcp-primary ocf:gcp:alias op monitor interval="60s" timeout="60s" op start interval="0" timeout="180s" op stop interval="0" timeout="180s" params alias_ip="${VM_METADATA[sap_vip]}/32" hostlist="${VM_METADATA[sap_primary_instance]} ${VM_METADATA[sap_secondary_instance]}" gcloud_path="${GCLOUD}" logging="yes" meta priority=10
+      fi
+      crm configure group g-primary rsc_vip_int-primary rsc_vip_gcp-primary
+    fi
+  else
+    main::errhandle_log_warning "- VIP is already associated with another VM. The cluster setup will continue but the floating/virtual IP address will not be added"
+  fi
+}
+
+
+ha::pacemaker_config_bootstrap_hdb() {
+  main::errhandle_log_info "Cluster: Configuring bootstrap for SAP HANA"
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    crm configure property no-quorum-policy="ignore"
+    crm configure property startup-fencing="true"
+    crm configure property stonith-timeout="300s"
+    crm configure property stonith-enabled="true"
+    crm configure rsc_defaults resource-stickiness="1000"
+    crm configure rsc_defaults migration-threshold="5000"
+    crm configure op_defaults timeout="600"
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    pcs property set no-quorum-policy="ignore"
+    pcs property set startup-fencing="true"
+    pcs property set stonith-timeout="300s"
+    pcs property set stonith-enabled="true"
+    pcs resource defaults default-resource-stickness=1000
+    pcs resource defaults default-migration-threshold=5000
+    pcs resource op defaults timeout=600s
+  fi
+}
+
+
+ha::pacemaker_config_bootstrap_nfs() {
+  main::errhandle_log_info "Cluster: Configuring bootstrap for NFS"
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    crm configure property no-quorum-policy="ignore"
+    crm configure property startup-fencing="true"
+    crm configure property stonith-timeout="300s"
+    crm configure property stonith-enabled="true"
+    crm configure rsc_defaults resource-stickiness="100"
+    crm configure rsc_defaults migration-threshold="5000"
+    crm configure op_defaults timeout="600"
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    pcs property set no-quorum-policy="ignore"
+    pcs property set startup-fencing="true"
+    pcs property set stonith-timeout="300s"
+    pcs property set stonith-enabled="true"
+    pcs resource defaults default-resource-stickness=1000
+    pcs resource defaults default-migration-threshold=5000
+    pcs resource op defaults timeout=600s
+  fi
+}
+
+
+ha::pacemaker_add_hana() {
+  main::errhandle_log_info "Cluster: Adding HANA nodes"
+
+  if [ "${LINUX_DISTRO}" = "SLES" ]; then
+    cat <<EOF > /root/.deploy/cluster.tmp
+    primitive rsc_SAPHanaTopology_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} ocf:suse:SAPHanaTopology \
+        operations \$id="rsc_sap2_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]}-operations" \
+        op monitor interval="10" timeout="600" \
+        op start interval="0" timeout="600" \
+        op stop interval="0" timeout="300" \
+        params SID="${VM_METADATA[sap_hana_sid]}" InstanceNumber="${VM_METADATA[sap_hana_instance_number]}"
+
+    clone cln_SAPHanaTopology_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} rsc_SAPHanaTopology_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} \
+        meta is-managed="true" clone-node-max="1" target-role="Started" interleave="true"
+EOF
+
+    crm configure load update /root/.deploy/cluster.tmp
+
+    cat <<EOF > /root/.deploy/cluster.tmp
+    primitive rsc_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} ocf:suse:SAPHana \
+        operations \$id="rsc_sap_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]}-operations" \
+        op start interval="0" timeout="3600" \
+        op stop interval="0" timeout="3600" \
+        op promote interval="0" timeout="3600" \
+        op monitor interval="10" role="Master" timeout="700" \
+        op monitor interval="11" role="Slave" timeout="700" \
+        params SID="${VM_METADATA[sap_hana_sid]}" InstanceNumber="${VM_METADATA[sap_hana_instance_number]}" PREFER_SITE_TAKEOVER="true" \
+        DUPLICATE_PRIMARY_TIMEOUT="7200" AUTOMATED_REGISTER="true"
+
+    ms msl_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} rsc_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} \
+        meta is-managed="true" notify="true" clone-max="2" clone-node-max="1" \
+        target-role="Started" interleave="true"
+
+    colocation col_saphana_ip_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} 4000: g-primary:Started \
+        msl_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]}:Master
+    order ord_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} Optional: cln_SAPHanaTopology_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} \
+        msl_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]}
+EOF
+
+    crm configure load update /root/.deploy/cluster.tmp
+  fi
+}

--- a/gcp/terraform/provision/google/sap_lib_ha.sh
+++ b/gcp/terraform/provision/google/sap_lib_ha.sh
@@ -37,9 +37,9 @@ ha::download_scripts() {
   main::errhandle_log_info "Downloading pacemaker-gcp"
   mkdir -p /usr/lib/ocf/resource.d/gcp
   mkdir -p /usr/lib64/stonith/plugins/external
-  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/alias -o /usr/lib/ocf/resource.d/gcp/alias
-  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/route -o /usr/lib/ocf/resource.d/gcp/route
-  curl https://storage.googleapis.com/sapdeploy/pacemaker-gcp/gcpstonith -o /usr/lib64/stonith/plugins/external/gcpstonith
+  cp /root/provision/alias /usr/lib/ocf/resource.d/gcp/alias
+  cp /root/provision/route /usr/lib/ocf/resource.d/gcp/route
+  cp /root/provision/gcpstonith /usr/lib64/stonith/plugins/external/gcpstonith
   chmod +x /usr/lib/ocf/resource.d/gcp/alias
   chmod +x /usr/lib/ocf/resource.d/gcp/route
   chmod +x /usr/lib64/stonith/plugins/external/gcpstonith

--- a/gcp/terraform/provision/google/sap_lib_ha.sh
+++ b/gcp/terraform/provision/google/sap_lib_ha.sh
@@ -429,7 +429,7 @@ EOF
         op monitor interval="10" role="Master" timeout="700" \
         op monitor interval="11" role="Slave" timeout="700" \
         params SID="${VM_METADATA[sap_hana_sid]}" InstanceNumber="${VM_METADATA[sap_hana_instance_number]}" PREFER_SITE_TAKEOVER="true" \
-        DUPLICATE_PRIMARY_TIMEOUT="7200" AUTOMATED_REGISTER="true"
+        DUPLICATE_PRIMARY_TIMEOUT="7200" AUTOMATED_REGISTER="false"
 
     ms msl_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} rsc_SAPHana_${VM_METADATA[sap_hana_sid]}_HDB${VM_METADATA[sap_hana_instance_number]} \
         meta is-managed="true" notify="true" clone-max="2" clone-node-max="1" \

--- a/gcp/terraform/provision/google/sap_lib_hdb.sh
+++ b/gcp/terraform/provision/google/sap_lib_hdb.sh
@@ -1,0 +1,564 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Description:  Google Cloud Platform - SAP Deployment Functions
+# Build Date:   Wed Feb 20 13:53:45 GMT 2019
+# ------------------------------------------------------------------------
+
+hdb::calculate_volume_sizes() {
+  local hana_node_type=${1}
+
+  main::errhandle_log_info "Calculating disk volume sizes"
+
+  hana_log_size=$((VM_MEMSIZE/2))
+  hana_log_size=$((128*(1+(hana_log_size/128))))
+  if [[ ${hana_log_size} -ge 512 ]]; then
+    hana_log_size=512
+  fi
+
+  hana_data_size=$(((VM_MEMSIZE*15)/10))
+
+  if [[ ${VM_METADATA[sap_hana_scaleout_nodes]} -eq 0 ]]; then
+    hana_shared_size=${VM_MEMSIZE}
+  else
+    hana_shared_size=$((VM_MEMSIZE*((VM_METADATA[sap_hana_scaleout_nodes]+3)/4)))
+  fi
+
+  ## if worker node, set the hana_shared_size to 0
+  if [[ "${hana_node_type}" = "secondary" ]]; then
+    hana_shared_size=0
+  fi
+
+  ## if there is enough space (i.e, multi_sid enabled or if 208GB instances) then double the volume sizes
+  hana_pdssd_size=$(($(lsblk --nodeps --bytes --noheadings --output SIZE /dev/sdb)/1024/1024/1024))
+  hana_pdssd_size_x2=$(((hana_data_size+hana_log_size)*2 +hana_shared_size))
+
+  if [[ ${hana_pdssd_size} -gt ${hana_pdssd_size_x2} ]]; then
+    main::errhandle_log_info "--- Determined double volume sizes are required"
+    main::errhandle_log_info "--- Determined minimum data volume requirement to be $((hana_data_size*2))"
+    hana_log_size=$((hana_log_size*2))
+  else
+    main::errhandle_log_info "--- Determined minimum data volume requirement to be ${hana_data_size}"
+    main::errhandle_log_info "--- Determined log volume requirement to be ${hana_log_size}"
+    main::errhandle_log_info "--- Determined shared volume requirement to be ${hana_shared_size}"
+  fi
+}
+
+
+hdb::create_sap_data_log_volumes() {
+
+  main::errhandle_log_info "Building /usr/sap, /hana/data & /hana/log"
+
+  ## create volume group
+  main::create_vg /dev/sdb vg_hana
+
+	## create logical volumes
+	main::errhandle_log_info '--- Creating logical volumes'
+	lvcreate -L 32G -n sap vg_hana
+	lvcreate -L ${hana_log_size}G -n log vg_hana
+	lvcreate -l 100%FREE -n data vg_hana
+
+	## format file systems
+  main::format_mount /usr/sap /dev/vg_hana/sap xfs
+  main::format_mount /hana/data /dev/vg_hana/data xfs
+  main::format_mount /hana/log /dev/vg_hana/log xfs
+
+  ## create base folders
+  mkdir -p /hana/data/"${VM_METADATA[sap_hana_sid]}" /hana/log/"${VM_METADATA[sap_hana_sid]}"
+  chmod 777 /hana/data/"${VM_METADATA[sap_hana_sid]}" /hana/log/"${VM_METADATA[sap_hana_sid]}"
+}
+
+
+hdb::create_shared_volume() {
+
+  main::create_vg /dev/sdb vg_hana
+	lvcreate -L ${hana_shared_size}G -n shared vg_hana
+
+  ## format and mount
+  main::format_mount /hana/shared /dev/vg_hana/shared xfs
+}
+
+
+hdb::create_backup_volume() {
+
+  main::errhandle_log_info "Building /hanabackup"
+
+  ## create volume group
+  main::create_vg /dev/sdc vg_hanabackup
+
+  main::errhandle_log_info "--- Creating logical volume"
+  lvcreate -l 100%FREE -n backup vg_hanabackup
+
+  ## create filesystems
+  main::format_mount /hanabackup /dev/vg_hanabackup/backup xfs
+}
+
+
+hdb::set_kernel_parameters(){
+  main::errhandle_log_info "Setting kernel paramaters"
+  {
+    echo "vm.pagecache_limit_mb = 0"
+    echo "vm.pagecache_limit_ignore_dirty=0"
+    echo "net.ipv4.tcp_slow_start_after_idle=0"
+    echo "kernel.numa_balancing = 0"
+    echo "net.ipv4.tcp_slow_start_after_idle=0"
+    echo "net.core.somaxconn = 4096"
+    echo "net.ipv4.tcp_tw_reuse = 1"
+    echo "net.ipv4.tcp_tw_recycle = 1"
+    echo "net.ipv4.tcp_timestamps = 1"
+    echo "net.ipv4.tcp_syn_retries = 8"
+    echo "net.ipv4.tcp_wmem = 4096 16384 4194304"
+  } >> /etc/sysctl.conf
+
+  sysctl -p
+
+  main::errhandle_log_info "Preparing tuned/sapconf"
+
+  if [[ "${LINUX_DISTRO}" = "SLES" ]] && [[ "${LINUX_VERSION}" = "15" ]]; then 
+    systemctl start tuned
+    systemctl enable tuned
+    saptune daemon start
+    saptune solution apply HANA
+  else
+    mkdir -p /etc/tuned/sap-hana/
+    cp /usr/lib/tuned/sap-hana/tuned.conf /etc/tuned/sap-hana/
+    systemctl start tuned
+    systemctl enable tuned
+    tuned-adm profile sap-hana
+  fi
+}
+
+
+hdb::download_media() {
+	main::errhandle_log_info "Downloading HANA media from ${VM_METADATA[sap_hana_deployment_bucket]}"
+	mkdir -p /hana/shared/media
+
+  ## download unrar from GCS. Fix for RHEL missing unrar and SAP packaging change which stoppped unar working.
+  curl "${DEPLOY_URL}"/third_party/unrar/unrar -o /root/.deploy/unrar
+  chmod a=wrx /root/.deploy/unrar
+
+  ## download SAP HANA media
+  if ! ${GSUTIL} rsync -x ".part*$|IMDB_SERVER*.SAR$" gs://"${VM_METADATA[sap_hana_deployment_bucket]}" /hana/shared/media/ ; then
+    main::errhandle_log_warning "HANA Media Download Failed. The deployment has finished and ready for SAP HANA, but SAP HANA will need to be downloaded and installed manually"
+    main::complete
+	fi
+}
+
+
+hdb::create_install_cfg() {
+
+  ## output settings to log
+  main::errhandle_log_info "Creating HANA installation configuration file /root/.deploy/${HOSTNAME}_hana_install.cfg"
+
+  ## check parameters
+  if [ -z "${VM_METADATA[sap_hana_deployment_bucket]}" ] || [ -z "${VM_METADATA[sap_hana_system_password]}" ] || [ -z "${VM_METADATA[sap_hana_sidadm_password]}" ] || [ -z "${VM_METADATA[sap_hana_sid]}" ] || [ -z "${VM_METADATA[sap_hana_sidadm_uid]}" ]; then
+    main::errhandle_log_warning "SAP HANA variables were missing or incomplete in the deployment manager template. The deployment has finished and ready for SAP HANA, but SAP HANA will need to be installed manually"
+    main::complete
+  fi
+
+  mkdir -p /root/.deploy
+
+  ## create hana_install.cfg file
+  {
+    echo "[Server]" >/root/.deploy/"${HOSTNAME}"_hana_install.cfg
+    echo "sid=${VM_METADATA[sap_hana_sid]}"
+    echo "number=${VM_METADATA[sap_hana_instance_number]}"
+    echo "sapadm_password=${VM_METADATA[sap_hana_sidadm_password]}"
+    echo "password=${VM_METADATA[sap_hana_sidadm_password]}"
+    echo "system_user_password=${VM_METADATA[sap_hana_system_password]}"
+    echo "userid=${VM_METADATA[sap_hana_sidadm_uid]}"
+    echo "groupid=${VM_METADATA[sap_hana_sapsys_gid]}"
+  } >>/root/.deploy/"${HOSTNAME}"_hana_install.cfg
+
+  ## If HA configured, disable autostart
+  if [ -n "${VM_METADATA[sap_vip]}" ]; then
+    echo "autostart=n" >>/root/.deploy/"${HOSTNAME}"_hana_install.cfg
+  else
+    echo "autostart=y" >>/root/.deploy/"${HOSTNAME}"_hana_install.cfg
+  fi
+
+  ## If scale-out then add gceStorageClient
+  if [ -n "${VM_METADATA[sap_hana_standby_nodes]}" ]; then
+    echo "storage_cfg=/hana/shared/gceStorageClient" >>/root/.deploy/"${HOSTNAME}"_hana_install.cfg
+  fi
+
+}
+
+
+hdb::extract_media() {
+
+  main::errhandle_log_info "Extracting SAP HANA media"
+  cd /hana/shared/media/ || main::errhandle_log_error "Unable to access /hana/shared/media. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+
+  ## Workaround requried due to unar not working with SAP HANA 2.0 SP3. TODO - Remove once no longer required
+  if [[ -f /root/.deploy/unrar ]]; then
+    if ! /root/.deploy/unrar -o+ x "*part1.exe" >/dev/null; then
+      main::errhandle_log_error "HANA media extraction failed. Please ensure the correct media is uploaded to your GCS bucket"
+    fi
+  elif [ "${LINUX_DISTRO}" = "SLES" ]; then
+    if ! unrar -o+ x "*part1.exe" >/dev/null; then
+      main::errhandle_log_error "HANA media extraction failed. Please ensure the correct media is uploaded to your GCS bucket"
+    fi
+  elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+    local file
+    for file in *.exe; do
+      if ! unar -f "${file}" >/dev/null; then
+        main::errhandle_log_error "HANA media extraction failed. Please ensure the correct media is uploaded to your GCS bucket"
+      fi
+    done
+  fi
+}
+
+
+hdb::install() {
+	main::errhandle_log_info 'Installing SAP HANA'
+	if ! /hana/shared/media/51*/DATA_UNITS/HDB_LCM_LINUX_X86_64/hdblcm --configfile=/root/.deploy/"${HOSTNAME}"_hana_install.cfg -b; then
+		main::errhandle_log_error "HANA Installation Failed. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required"
+	fi
+}
+
+
+hdb::upgrade(){
+	if [ "$(ls /hana/shared/media/IMDB_SERVER*.SAR)" ]; then
+	  main::errhandle_log_info "An SAP HANA update was found in GCS. Performing the upgrade:"
+	  main::errhandle_log_info "--- Extracting HANA upgrade media"
+		cd /hana/shared/media || main::errhandle_log_error "Unable to access /hana/shared/media. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+		/usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/exe/hdb/SAPCAR -xvf "IMDB_SERVER*.SAR"
+		cd SAP_HANA_DATABASE || main::errhandle_log_error "Unable to access /hana/shared/media. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+	  main::errhandle_log_info "--- Upgrading Database"
+		if ! ./hdblcm --configfile=/root/.deploy/"${HOSTNAME}"_hana_install.cfg --action=update --ignore=check_signature_file --update_execution_mode=optimized --batch; then
+		    main::errhandle_log_warning "SAP HANA Database revision upgrade failed to install."
+		fi
+	fi
+}
+
+
+hdb::install_afl() {
+  if [[ "$(${GSUTIL} ls gs://"${VM_METADATA[sap_hana_deployment_bucket]}"/IMDB_AFL*)" ]]; then
+    main::errhandle_log_info "SAP AFL was found in GCS. Installing SAP AFL addon"
+    main::errhandle_log_info "--- Downloading AFL media"
+    ${GSUTIL} cp gs://"${VM_METADATA[sap_hana_deployment_bucket]}"/IMDB_AFL*.SAR /hana/shared/media/
+    main::errhandle_log_info "--- Extracting AFL media"
+    cd /hana/shared/media || main::errhandle_log_warning "AFL failed to install"
+    /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/exe/hdb/SAPCAR -xvf "IMDB_AFL*.SAR"
+    cd SAP_HANA_AFL || main::errhandle_log_warning "AFL failed to install"
+    main::errhandle_log_info "--- Installing AFL"
+    ./hdbinst --sid="${VM_METADATA[sap_hana_sid]}"
+  fi
+}
+
+
+hdb::set_parameters() {
+  local inifile=${1}
+  local section=${2}
+  local setting=${3}
+  local value=${4}
+  local tenant=${5}
+
+  # if tenant specified, run it on that tenant. Else do it in SYSTEMDB. If that fails (HANA 2.0 SP0 <) then run it without specifying a tenant
+  if [[ -n ${tenant} ]]; then
+    bash -c "source /usr/sap/${VM_METADATA[sap_hana_sid]}/home/.sapenv.sh && hdbsql -d ${tenant} -u SYSTEM -p ${VM_METADATA[sap_hana_system_password]} -i ${VM_METADATA[sap_hana_instance_number]} \"ALTER SYSTEM ALTER CONFIGURATION ('$inifile', 'SYSTEM') SET ('$section','$setting') = '$value' with reconfigure\""
+  else
+    if ! bash -c "source /usr/sap/${VM_METADATA[sap_hana_sid]}/home/.sapenv.sh && hdbsql -d SYSTEMDB -u SYSTEM -p ${VM_METADATA[sap_hana_system_password]} -i ${VM_METADATA[sap_hana_instance_number]} \"ALTER SYSTEM ALTER CONFIGURATION ('$inifile', 'SYSTEM') SET ('$section','$setting') = '$value' with reconfigure\""; then
+      bash -c "source /usr/sap/${VM_METADATA[sap_hana_sid]}/home/.sapenv.sh && hdbsql -u SYSTEM -p ${VM_METADATA[sap_hana_system_password]} -i ${VM_METADATA[sap_hana_instance_number]} \"ALTER SYSTEM ALTER CONFIGURATION ('$inifile', 'SYSTEM') SET ('$section','$setting') = '$value' with reconfigure\""
+    fi
+  fi
+}
+
+
+hdb::config_backup() {
+  main::errhandle_log_info 'Configuring backup locations to /hanabackup'
+  mkdir -p /hanabackup/data/"${VM_METADATA[sap_hana_sid]}" /hanabackup/log/"${VM_METADATA[sap_hana_sid]}"
+  chown -R root:sapsys /hanabackup
+  chmod -R g=wrx /hanabackup
+  hdb::set_parameters global.ini persistence basepath_databackup /hanabackup/data/"${VM_METADATA[sap_hana_sid]}"
+  hdb::set_parameters global.ini persistence basepath_logbackup /hanabackup/log/"${VM_METADATA[sap_hana_sid]}"
+}
+
+
+hdb::check_settings() {
+
+  ## Set defaults if required
+  VM_METADATA[sap_hana_sidadm_uid]=$(main::check_default 900 "${VM_METADATA[sap_hana_sidadm_uid]}")
+  VM_METADATA[sap_hana_sapsys_gid]=$(main::check_default 79 "${VM_METADATA[sap_hana_sapsys_gid]}")
+
+  ## fix instance number to be two digits
+  local tmp_instance_number
+  if [[ -n "${VM_METADATA[sap_hana_instance_number]}" ]]; then
+    if [[ ${VM_METADATA[sap_hana_instance_number]} -lt 10 ]]; then
+     tmp_instance_number="0${VM_METADATA[sap_hana_instance_number]}"
+     VM_METADATA[sap_hana_instance_number]=${tmp_instance_number}
+    fi
+  fi
+
+  ## figure out the master node hostname
+  if [[ ${VM_METADATA[startup-script]} = *"secondary"* ]]; then
+     hana_master_node="$(hostname | rev | cut -d"w" -f2-999 | rev)"
+  else
+     hana_master_node=${HOSTNAME}
+  fi
+
+  ## check you have access to the bucket
+  if ! ${GSUTIL} ls gs://"${VM_METADATA[sap_hana_deployment_bucket]}"/*.exe; then
+    unset "VM_METADATA[sap_hana_deployment_bucket]"
+    main::errhandle_log_info "SAP HANA media not found in bucket. Ensure that you have uploaded the full SAP HANA package which consists of 1 .exe file and multiple .rar files. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+  fi
+
+  ## Remove passwords from metadata
+  main::remove_metadata sap_hana_system_password
+  main::remove_metadata sap_hana_sidadm_password
+}
+
+
+hdb::config_nfs() {
+  if [ ! "${VM_METADATA[sap_hana_scaleout_nodes]}" = "0" ]; then
+
+    main::errhandle_log_info "Configuring NFS for scale-out"
+
+		## turn off NFS4 support
+		sed -ie 's/NFS4_SUPPORT="yes"/NFS4_SUPPORT="no"/g' /etc/sysconfig/nfs
+
+		main::errhandle_log_info "--- Starting NFS server"
+		if [ "${LINUX_DISTRO}" = "SLES" ]; then
+			systemctl start nfsserver
+		elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+			systemctl start nfs
+		fi
+
+		## Check NFS has started - Fix for bug which occasionally causes a delay in the NFS start-up
+		while [ "$(pgrep -c nfs)" -le 3 ]; do
+			main::errhandle_log_info "--- NFS server not running. Waiting 10 seconds then trying again"
+			sleep 10s
+			if [ "${LINUX_DISTRO}" = "SLES" ]; then
+				systemctl start nfsserver
+			elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+				systemctl start nfs
+			fi
+		done
+
+		## Enable & start NFS service
+		main::errhandle_log_info "--- Enabling NFS server at boot up"
+		if [ "${LINUX_DISTRO}" = "SLES" ]; then
+			systemctl enable nfsserver
+		elif [ "${LINUX_DISTRO}" = "RHEL" ]; then
+			systemctl enable nfs
+		fi
+
+		## Adding file system to NFS exports file systems
+    local worker
+		for worker in $(seq 1 "${VM_METADATA[sap_hana_scaleout_nodes]}"); do
+		  echo "/hana/shared ${HOSTNAME}w${worker}(rw,no_root_squash,sync,no_subtree_check)" >>/etc/exports
+		  echo "/hanabackup ${HOSTNAME}w${worker}(rw,no_root_squash,sync,no_subtree_check)" >>/etc/exports
+		done
+
+		## manually exporting file systems
+		exportfs -rav
+	fi
+}
+
+
+hdb::install_scaleout_nodes() {
+  if [ ! "${VM_METADATA[sap_hana_scaleout_nodes]}" = "0" ]; then
+    main::errhandle_log_info "Installing ${VM_METADATA[sap_hana_scaleout_nodes]} additional worker nodes"
+
+    ## Set basepath
+    hdb::set_parameters global.ini persistence basepath_shared no
+
+    ## Check each host is online and ssh'able before contining
+    local worker
+		local count=0
+
+		for worker in $(seq 1 "${VM_METADATA[sap_hana_scaleout_nodes]}"); do
+			while ! ssh -o StrictHostKeyChecking=no "${HOSTNAME}"w"${worker}" "echo 1"; do
+				count=$((count +1))
+				main::errhandle_log_info "--- ${HOSTNAME}w${worker} is not accessible via SSH - sleeping for 10 seconds and trying again"
+				sleep 10
+				if [ $count -gt 60 ]; then
+					main::errhandle_log_error "Unable to add additional HANA hosts. Couldn't connect to additional ${HOSTNAME}w${worker} via SSH"
+				fi
+			done
+		done
+
+		## get passwords from install file
+		local hana_xml="<?xml version=\"1.0\" encoding=\"UTF-8\"?><Passwords>"
+		hana_xml+="<password><![CDATA[$(grep password /root/.deploy/"${HOSTNAME}"_hana_install.cfg | grep -v sapadm | grep -v system | cut -d"=" -f2 | head -1)]]></password>"
+		hana_xml+="<sapadm_password><![CDATA[$(grep sapadm_password /root/.deploy/"${HOSTNAME}"_hana_install.cfg | cut -d"=" -f2)]]></sapadm_password>"
+		hana_xml+="<system_user_password><![CDATA[$(grep system_user_password /root/.deploy/"${HOSTNAME}"_hana_install.cfg | cut -d"=" -f2 | head -1)]]></system_user_password></Passwords>"
+
+    cd /hana/shared/"${VM_METADATA[sap_hana_sid]}"/hdblcm || main::errhandle_log_info "Unable to access hdblcm. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+
+		for worker in $(seq 1 "${VM_METADATA[sap_hana_scaleout_nodes]}"); do
+      main::errhandle_log_info "--- Adding node ${HOSTNAME}w${worker}"
+      if ! echo "$hana_xml" | ./hdblcm --action=add_hosts --addhosts="${HOSTNAME}"w"${worker}" --root_user=root --listen_interface=global --read_password_from_stdin=xml -b; then
+        main::errhandle_log_error "Unable to access hdblcm. The server deployment is complete but SAP HANA is not deployed. Manual SAP HANA installation will be required."
+      fi
+    done
+
+    ## Post deployment & installation cleanup
+    main::complete
+  fi
+}
+
+
+hdb::mount_nfs() {
+  main::errhandle_log_info 'Mounting NFS volumes /hana/shared & /hanabackup'
+  echo "$(hostname | rev | cut -d"w" -f2-999 | rev):/hana/shared /hana/shared nfs	nfsvers=3,rsize=32768,wsize=32768,hard,intr,timeo=18,retrans=200 0 0" >>/etc/fstab
+  echo "$(hostname | rev | cut -d"w" -f2-999 | rev):/hanabackup /hanabackup nfs	nfsvers=3,rsize=32768,wsize=32768,hard,intr,timeo=18,retrans=200 0 0" >>/etc/fstab
+
+  mkdir -p /hana/shared /hanabackup
+  
+  ## mount file systems
+  mount -a
+
+  ## check /hana/shared is mounted before continuing
+  local count=0
+  while ! grep -q '/hana/shared' /etc/mtab ; do
+    count=$((count +1))
+    main::errhandle_log_info "--- /hana/shared is not mounted. Waiting 10 seconds and trying again"
+    sleep 10s
+    mount -a
+    if [ ${count} -gt 120 ]; then
+      main::errhandle_log_error "/hana/shared is not mounted - Unable to continue"
+    fi
+  done
+}
+
+
+hdb::backup() {
+  local backup_name=${1}
+
+  main::errhandle_log_info "Creating HANA backup ${backup_name}"
+  PATH="$PATH:/usr/sap/${VM_METADATA[sap_hana_sid]}/HDB${VM_METADATA[sap_hana_instance_number]}/exe"
+
+  ## Call bash with source script to avoid RHEL library errors
+  bash -c "source /usr/sap/${VM_METADATA[sap_hana_sid]}/home/.sapenv.sh && hdbsql -u system -p ${VM_METADATA[sap_hana_system_password]} -i ${VM_METADATA[sap_hana_instance_number]} \"BACKUP DATA USING FILE ('${backup_name}')\""
+  bash -c "source /usr/sap/${VM_METADATA[sap_hana_sid]}/home/.sapenv.sh && hdbsql -u system -p ${VM_METADATA[sap_hana_system_password]} -d SYSTEMDB -i ${VM_METADATA[sap_hana_instance_number]} \"BACKUP DATA for SYSTEMDB USING FILE ('${backup_name}_SYSTEMDB')\""
+}
+
+
+hdb::execute_sql() {
+    local host="${0}"
+    local instance_number="${0}"
+    local sid="${0}"
+    local user="${1}"
+    local password="${2}"
+    local tenant="${3}"
+    local statement="${4}"
+
+    /usr/sap/"${sid}"/HDB"${instance_number}"/exe/hdbsql -d "${tenant}" -n "${host}" -i "${instance_number}" -u "${user}" -p "${password}" "${statement}"
+}
+
+
+hdb::stop() {
+  main::errhandle_log_info "Stopping SAP HANA"
+  su - "${VM_METADATA[sap_hana_sid],,}"adm -c "HDB stop"
+}
+
+
+hdb::stop_nowait(){
+    /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/exe/hdb/sapcontrol -prot NI_HTTP -nr "${VM_METADATA[sap_hana_instance_number]}" -function Stop
+}
+
+
+hdb::restart_nowait(){
+    /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/exe/hdb/sapcontrol -prot NI_HTTP -nr "${VM_METADATA[sap_hana_instance_number]}" -function RestartInstance
+}
+
+
+hdb::start() {
+  main::errhandle_log_info "Starting SAP HANA"
+  su - "${VM_METADATA[sap_hana_sid],,}"adm -c "HDB start"
+}
+
+
+hdb::start_nowait(){
+    /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/exe/hdb/sapcontrol -prot NI_HTTP -nr "${VM_METADATA[sap_hana_instance_number]}" -function Start
+}
+
+
+hdb::install_backint() {
+    main::errhandle_log_info "Installing SAP HANA Backint for Google Cloud Storage"
+    su - "${VM_METADATA[sap_hana_sid],,}"adm -c "curl https://storage.googleapis.com/sapdeploy/backint-gcs/install.sh | bash"
+}
+
+
+hdb::config_backint() {
+  local backup_bucket="${1}"
+
+  ## if bucket isn't specified as an argument, use the bucket defined in the VM metadata
+  if [[ ${backup_bucket} ]]; then
+    main::errhandle_log_info "--- Setting HANA backup bucket to ${backup_bucket}"
+  elif [[ -n ${VM_METADATA[sap_hana_backup_bucket]} ]]; then
+      backup_bucket=${VM_METADATA[sap_hana_backup_bucket]}
+  else
+      main::errhandle_log_warning "--- Unknown backup bucket specified. Backup using BackInt is unlikely to work without reviewing and correcting parameters"
+  fi
+
+  ## check if bucket is accessible
+  if ! ${GSUTIL} -q ls gs://"${VM_METADATA[sap_hana_backup_bucket]}"; then
+    main::errhandle_log_warning "--- Bbackup bucket doesn't exist or permission is denied."
+  fi
+
+  ## update configuration file with settings
+  sed -i --follow-symlinks "s/<GCS Bucket Name>/${backup_bucket}/" /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+
+  if ! grep -q DISABLE_COMPRESSION /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt; then
+    echo "\\#DISABLE_COMPRESSION" >> /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+  fi
+
+  if ! grep -q CHUNK_SIZE_MB /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt; then
+    echo "\\#CHUNK_SIZE_MB 1024" >> /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+  fi
+
+  ## Set SAP HANA parameters
+  main::errhandle_log_info "--- Configuring SAP HANA to use BackInt"
+  hdb::set_parameters global.ini backup data_backup_parameter_file /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+  hdb::set_parameters global.ini backup log_backup_parameter_file /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+  hdb::set_parameters global.ini backup catalog_backup_parameter_file /usr/sap/"${VM_METADATA[sap_hana_sid]}"/SYS/global/hdb/opt/hdbconfig/parameters.txt
+  hdb::set_parameters global.ini backup log_backup_using_backint true
+  hdb::set_parameters global.ini backup catalog_backup_using_backint true
+
+  ## Calculate number of channels based on instanec size + Configure in SAP HANA
+  local backup_channels
+  backup_channels=$(((VM_MEMSIZE / 128) + (VM_MEMSIZE % 128 > 0)))
+  if [[ ${backup_channels} -ge 16 ]]; then
+    backup_channels=16
+  fi
+
+  hdb::set_parameters global.ini backup parallel_data_backup_backint_channels "${backup_channels}"
+
+  ## Set catalog location
+  hdb::set_parameters global.ini persistence 'basepath_catalogbackup' /hanabackup/log/"${VM_METADATA[sap_hana_sid]}"
+}
+
+
+hdb::install_worker_sshkeys() {
+  if [ ! "${VM_METADATA[sap_hana_scaleout_nodes]}" = "0" ]; then
+    main::errhandle_log_info "Installing SSH keys"
+    local worker
+    local count=0
+  	for worker in $(seq 1 "${VM_METADATA[sap_hana_scaleout_nodes]}"); do
+      while ! ${GCLOUD} --quiet compute instances add-metadata "${hana_master_node}"w"${worker}" --metadata "ssh-keys=root:$(cat ~/.ssh/id_rsa.pub)"; do
+          ## if gcloud returns an error, keep trying.
+          main::errhandle_log_info "--- Unable to add keys to ${hana_master_node}w${worker}. Waiting 10 seconds then trying again"
+    			sleep 10s
+          ## if more than 60 failures, give up
+          if [ $count -gt 60 ]; then
+            main::errhandle_log_error "Unable to add SSH keys to all scale-out worker hosts"
+          fi
+      done
+    done
+  fi
+}

--- a/gcp/terraform/provision/google/sap_lib_hdb.sh
+++ b/gcp/terraform/provision/google/sap_lib_hdb.sh
@@ -126,7 +126,7 @@ hdb::set_kernel_parameters(){
 
   main::errhandle_log_info "Preparing tuned/sapconf"
 
-  if [[ "${LINUX_DISTRO}" = "SLES" ]] && [[ "${LINUX_VERSION}" = "15" ]]; then 
+  if [[ "${LINUX_DISTRO}" = "SLES" ]] && [[ "${LINUX_VERSION}" =~ ^15 ]]; then
     systemctl start tuned
     systemctl enable tuned
     saptune daemon start

--- a/gcp/terraform/provision/google/sap_lib_main.sh
+++ b/gcp/terraform/provision/google/sap_lib_main.sh
@@ -1,0 +1,463 @@
+#!/bin/bash
+# ------------------------------------------------------------------------
+# Copyright 2018 Google Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Description:  Google Cloud Platform - SAP Deployment Functions
+# Build Date:   Wed Feb 20 13:53:45 GMT 2019
+# ------------------------------------------------------------------------
+
+set +e
+
+main::set_boot_parameters() {
+	main::errhandle_log_info 'Checking boot paramaters'
+
+	## disable selinux
+	if [[ -e /etc/sysconfig/selinux ]]; then
+	  main::errhandle_log_info "--- Disabling SELinux"
+		sed -ie 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/sysconfig/selinux
+	fi
+
+	if [[ -e /etc/selinux/config ]]; then
+		main::errhandle_log_info "--- Disabling SELinux"
+		sed -ie 's/SELINUX=enforcing/SELINUX=disabled/g' /etc/selinux/config
+	fi
+	## work around for LVM boot where LVM volues are not started on certain SLES/RHEL versions
+  if [[ -e /etc/sysconfig/lvm ]]; then
+    sed -ie 's/LVM_ACTIVATED_ON_DISCOVERED="disable"/LVM_ACTIVATED_ON_DISCOVERED="enable"/g' /etc/sysconfig/lvm
+  fi
+
+	## Configure cstates and huge pages
+	if ! grep -q cstate /etc/default/grub ; then
+		main::errhandle_log_info "--- Update grub"
+		cmdline=$(grep GRUB_CMDLINE_LINUX_DEFAULT /etc/default/grub | head -1 | sed 's/GRUB_CMDLINE_LINUX_DEFAULT=//g' | sed 's/\"//g')
+		cp /etc/default/grub /etc/default/grub.bak
+		grep -v GRUBLINE_LINUX_DEFAULT /etc/default/grub.bak >/etc/default/grub			
+		echo "GRUB_CMDLINE_LINUX_DEFAULT=\"${cmdline} transparent_hugepage=never intel_idle.max_cstate=1 processor.max_cstate=1 intel_iommu=off\"" >>/etc/default/grub
+		grub2-mkconfig -o /boot/grub2/grub.cfg
+		echo "${HOSTNAME}" >/etc/hostname
+		main::errhandle_log_info '--- Parameters updated. Rebooting'
+		reboot
+		exit 0
+	fi
+}
+
+
+main::errhandle_log_info() {
+  local log_entry=${1}
+
+	echo "INFO - ${log_entry}"
+  if [[ -n "${GCLOUD}" ]]; then
+	   ${GCLOUD} --quiet logging write "${HOSTNAME}" "${HOSTNAME} Deployment \"${log_entry}\"" --severity=INFO
+  fi
+}
+
+
+main::errhandle_log_warning() {
+  local log_entry=${1}
+
+	if [[ -z "${deployment_warnings}" ]]; then
+		deployment_warnings=1
+	else
+		deployment_warnings=$((deployment_warnings +1))
+	fi
+
+	echo "WARNING - ${log_entry}"
+  if [[ -n "${GCLOUD}" ]]; then
+    ${GCLOUD} --quiet logging write "${HOSTNAME}" "${HOSTNAME} Deployment \"${log_entry}\"" --severity=WARNING
+  fi
+}
+
+
+main::errhandle_log_error() {
+  local log_entry=${1}
+
+	echo "ERROR - Deployment Exited - ${log_entry}"
+  if [[ -n "${GCLOUD}" ]]; then
+    ${GCLOUD}	--quiet logging write "${HOSTNAME}" "${HOSTNAME} Deployment \"${log_entry}\"" --severity=ERROR
+  fi
+	main::complete error
+}
+
+
+main::get_os_version() {
+	if grep SLES /etc/os-release; then
+		readonly LINUX_DISTRO="SLES"
+		readonly LINUX_VERSION=$(grep VERSION_ID /etc/os-release | awk -F '\"' '{ print $2 }')
+	elif grep -q "Red Hat" /etc/os-release; then
+		readonly LINUX_DISTRO="RHEL"
+		readonly LINUX_VERSION=$(grep VERSION_ID /etc/os-release | awk -F '\"' '{ print $2 }')
+	else
+		main::errhandle_log_warning "Unsupported Linux distribution. Only SLES and RHEL are supported."
+	fi
+}
+
+
+main::config_ssh() {
+	ssh-keygen -q -N "" < /dev/zero
+	sed -ie 's/PermitRootLogin no/PermitRootLogin yes/g' /etc/ssh/sshd_config
+	service sshd restart
+	cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+	/usr/sbin/rcgoogle-accounts-daemon restart
+}
+
+
+main::install_ssh_key(){
+  local host=${1}
+	local host_zone
+
+	host_zone=$(${GCLOUD} compute instances list --filter="name=('${host}')" --format "value(zone)")
+	main::errhandle_log_info "Installing ${HOSTNAME} SSH key on ${host}"
+  ${GCLOUD} --quiet compute instances add-metadata "${host}" --metadata "ssh-keys=root:$(cat ~/.ssh/id_rsa.pub)"  --zone "${host_zone}"
+}
+
+
+main::install_packages() {
+	main::errhandle_log_info 'Installing required operating system packages'
+
+  ## SuSE work around to avoid a startup race condition
+  if [[ ${LINUX_DISTRO} = "SLES" ]]; then
+    local count=0
+
+    ## check if SuSE repos are registered
+		while [[ $(find /etc/zypp/repos.d/ -maxdepth 1 | wc -l) -lt 2 ]]; do
+			main::errhandle_log_info "--- SuSE repositories are not registered. Waiting 10 seconds before trying again"
+			sleep 10s
+			count=$((count +1))
+			if [ ${count} -gt 60 ]; then
+				main::errhandle_log_error "SuSE repositories didn't register within an acceptable time."
+			fi
+		done
+		sleep 10s
+
+    ## check if zypper is still running
+  	while pgrep zypper; do
+  		errhandle_log_info "--- zypper is still running. Waiting 10 seconds before continuing"
+  		sleep 10s
+  	done
+
+		## Temporary fix fro SLES15 incompatible boto version
+		if [[ "${LINUX_VERSION}" = "15" ]]; then 
+    	cat <<EOF > /etc/default/instance_configs.cfg.template
+InstanceSetup]
+set_boto_config = false
+EOF
+			rm -f /etc/boto.cfg
+		fi
+	fi
+
+  ## packages to install
+	## TODO - Add above API packages to RHEL
+	local sles_packages="libopenssl0_9_8 libopenssl1_0_0 joe tuned krb5-32bit unrar SAPHanaSR SAPHanaSR-doc pacemaker numactl csh python-pip python-pyasn1-modules ndctl" #python-oauth2client python-oauth2client-gce python-httplib2 python-requests python-google-api-python-client"
+	local rhel_packages="unar.x86_64 tuned-profiles-sap-hana tuned-profiles-sap-hana-2.7.1-3.el7_3.3 joe resource-agents-sap-hana.x86_64 compat-sap-c++-6 numactl-libs.x86_64 libtool-ltdl.x86_64 nfs-utils.x86_64 pacemaker pcs lvm2.x86_64 compat-sap-c++-5.x86_64 csh autofs ndctl"
+
+	## install packages
+	if [[ ${LINUX_DISTRO} = "SLES" ]]; then
+		for package in ${sles_packages}; do
+		    zypper in -y "${package}"
+		done
+		zypper in -y sapconf saptune
+	elif [[ ${LINUX_DISTRO} = "RHEL" ]]; then
+		for package in $rhel_packages; do
+		    yum -y install "${package}"
+		done
+	fi
+	
+	main::errhandle_log_info "Installing python Google Cloud API client"
+	pip install --upgrade google-api-python-client
+	pip install oauth2client --upgrade
+}
+
+
+main::create_vg() {
+	local device=${1}
+	local volume_group=${2}
+
+	if [[ -b "$device" ]]; then
+		main::errhandle_log_info "--- Creating physical volume group ${device}"
+		pvcreate "${device}"
+		main::errhandle_log_info "--- Creating volume group ${volume_group} on ${device}"
+		vgcreate "${volume_group}" "${device}"
+		/sbin/vgchange -ay
+	else
+			main::errhandle_log_error "Unable to access ${device}"
+	fi 
+}
+
+
+
+main::create_vg() {
+	local device=${1}
+	local volume_group=${2}
+
+	if [[ -b "$device" ]]; then
+		main::errhandle_log_info "--- Creating physical volume group ${device}"
+		pvcreate "${device}"
+		main::errhandle_log_info "--- Creating volume group ${volume_group} on ${device}"
+		vgcreate "${volume_group}" "${device}"
+		/sbin/vgchange -ay
+	else
+			main::errhandle_log_error "Unable to access ${device}"
+	fi 
+}
+
+
+main::create_filesystem() {
+  local mount_point=${1}
+  local device=${2}
+  local filesystem=$3
+
+	if [[ -h /dev/disk/by-id/google-"${HOSTNAME}"-"${device}" ]]; then
+		main::errhandle_log_info "--- ${mount_point}"
+	  pvcreate /dev/disk/by-id/google-"${HOSTNAME}"-"${device}"
+		vgcreate vg_"${device}" /dev/disk/by-id/google-"${HOSTNAME}"-"${device}"
+		lvcreate -l 100%FREE -n vol vg_"${device}"
+    main::format_mount "${mount_point}" /dev/vg_"${device}"/vol "${filesystem}"
+		main::check_mount "${mount_point}"
+	else
+		main::errhandle_log_error "Unable to access ${device}"
+	fi
+
+}
+
+
+main::check_mount() {
+  local mount_point=${1}
+  local on_error=${2}
+
+  ## check /etc/mtab to see if the filesystem is mounted
+	if ! grep -q "${mount_point}" /etc/mtab; then
+		case "${on_error}" in
+	    error)
+				main::errhandle_log_error "Unable to mount ${mount_point}"
+	      ;;
+
+	    info)
+				main::errhandle_log_info "Unable to mount ${mount_point}"
+				;;
+
+	    warning)
+				main::errhandle_log_warn "Unable to mount ${mount_point}"
+				;;
+
+	    *)
+				main::errhandle_log_error "Unable to mount ${mount_point}"
+		esac
+	fi
+
+}
+
+
+main::format_mount() {
+  local mount_point=${1}
+  local device=${2}
+  local filesystem=${3}
+	local options=${4}
+
+	if [[ -b "$device" ]]; then
+		if [[ "${filesystem}" = "swap" ]]; then
+			echo "${device} none ${filesystem} defaults,nofail 0 0" >>/etc/fstab
+			mkswap "${device}"
+			swapon "${device}"
+		else
+			main::errhandle_log_info "--- Creating ${mount_point}"
+			mkfs -t "${filesystem}" "${device}"
+			mkdir -p "${mount_point}"
+			if [[ ! "${options}" = "tmp" ]]; then 
+				echo "${device} ${mount_point} ${filesystem} defaults,nofail 0 2" >>/etc/fstab
+				mount -a
+			else
+				mount -t "${filesystem}" "${device}" "${mount_point}"
+			fi
+			main::check_mount "${mount_point}"
+		fi
+	else
+		main::errhandle_log_error "Unable to access ${device}"	
+	fi 
+}
+
+
+main::get_settings() {
+	main::errhandle_log_info "Fetching GCE Instance Settings"
+
+	## set current zone as the default zone
+	readonly CLOUDSDK_COMPUTE_ZONE=$(main::get_metadata "http://169.254.169.254/computeMetadata/v1/instance/zone" | cut -d'/' -f4)
+	export CLOUDSDK_COMPUTE_ZONE
+	main::errhandle_log_info "--- Instance determined to be running in ${CLOUDSDK_COMPUTE_ZONE}. Setting this as the default zone"
+
+	readonly VM_REGION=${CLOUDSDK_COMPUTE_ZONE::-2}
+
+	## get instance type & details
+	readonly VM_INSTTYPE=$(main::get_metadata http://169.254.169.254/computeMetadata/v1/instance/machine-type | cut -d'/' -f4)
+	main::errhandle_log_info "--- Instance type determined to be ${VM_INSTTYPE}"
+
+	readonly VM_CPUPLAT=$(main::get_metadata "http://169.254.169.254/computeMetadata/v1/instance/cpu-platform")
+	main::errhandle_log_info "--- Instance is determined to be part on CPU Platform ${VM_CPUPLAT}"
+
+	readonly VM_CPUCOUNT=$(grep -c processor /proc/cpuinfo)
+	main::errhandle_log_info "--- Instance determined to have ${VM_CPUCOUNT} cores"
+
+  readonly VM_MEMSIZE=$(free -g | grep Mem | awk '{ print $2 }')
+	main::errhandle_log_info "--- Instance determined to have ${VM_MEMSIZE}GB of memory"
+
+	## get network settings
+	readonly VM_NETWORK=$(main::get_metadata http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/network | cut -d'/' -f4)
+	main::errhandle_log_info "--- Instance is determined to be part of network ${VM_NETWORK}"
+
+	readonly VM_NETWORK_FULL=$(gcloud compute instances describe "${HOSTNAME}" | grep "subnetwork:" | head -1 | grep -o 'projects.*')
+
+	readonly VM_SUBNET=$(grep -o 'subnetworks.*' <<< "${VM_NETWORK_FULL}" | cut -f2- -d"/")
+	main::errhandle_log_info "--- Instance is determined to be part of subnetwork ${VM_SUBNET}"
+
+	readonly VM_NETWORK_PROJECT=$(cut -d'/' -f2 <<< "${VM_NETWORK_FULL}")
+	main::errhandle_log_info "--- Networking is hosted in project ${VM_NETWORK_PROJECT}"
+
+	readonly VM_IP=$(main::get_metadata http://169.254.169.254/computeMetadata/v1/instance/network-interfaces/0/ip)
+	main::errhandle_log_info "--- Instance IP is determined to be ${VM_IP}"
+
+	# fetch all custom metadata associated with the instance
+	main::errhandle_log_info "Fetching GCE Instance Metadata"
+	local value
+	local key
+	declare -g -A VM_METADATA
+
+	for key in $(curl --fail -sH'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/attributes/ | grep -v ssh-keys); do
+		value=$(main::get_metadata "${key}")
+		VM_METADATA[$key]="${value}"
+
+		if [[ "${key}" = *"password"* ]]; then
+			main::errhandle_log_info "${key} determined to be *********"
+		else
+			main::errhandle_log_info "${key} determined to be '${value}'"
+		fi
+	done
+
+	# remove startup script
+	if [[ -n "${VM_METADATA[startup-script]}" ]]; then
+		main::remove_metadata startup-script
+	fi
+}
+
+
+main::create_static_ip() {
+	main::errhandle_log_info "Creating static IP address ${VM_IP} in subnetwork ${VM_SUBNET}"
+	${GCLOUD} --quiet compute --project "${VM_NETWORK_PROJECT}" addresses create "${HOSTNAME}" --addresses "${VM_IP}" --region "${VM_REGION}" --subnet "${VM_SUBNET}"
+}
+
+
+main::remove_metadata() {
+	local key=${1}
+
+	${GCLOUD} --quiet compute instances remove-metadata "${HOSTNAME}" --keys "${key}"
+}
+
+
+main::install_gsdk() {
+	local install_location=${1}
+
+	if [[ ! -d "${install_location}/google-cloud-sdk" ]]; then
+		bash <(curl -s https://dl.google.com/dl/cloudsdk/channels/rapid/install_google_cloud_sdk.bash) --disable-prompts --install-dir="${install_location}" >/dev/null
+		## run an instances list just to ensure the software is up to date
+		"${install_location}"/google-cloud-sdk/bin/gcloud --quiet beta compute instances list >/dev/null
+		if [[ "$LINUX_DISTRO" = "SLES" ]]; then
+			update-alternatives --install /usr/bin/gsutil gsutil /usr/local/google-cloud-sdk/bin/gsutil 1 --force
+			update-alternatives --install /usr/bin/gcloud gcloud /usr/local/google-cloud-sdk/bin/gcloud 1 --force
+		fi
+	fi
+
+	if [[ -f /usr/local/google-cloud-sdk/bin/gcloud ]]; then
+		readonly GCLOUD="/usr/local/google-cloud-sdk/bin/gcloud"
+		readonly GSUTIL="/usr/local/google-cloud-sdk/bin/gsutil"
+		readonly BQ="/usr/local/google-cloud-sdk/bin/bq"
+	elif [[ -f /usr/bin/gcloud ]]; then
+		readonly GCLOUD="/usr/bin/gloud"
+		readonly GSUTIL="/usr/bin/gsutil"
+	fi
+  main::errhandle_log_info "Installed Google SDK in ${install_location}"
+}
+
+
+main::check_default() {
+	local default=${1}
+	local current=${2}
+
+	if [[ -z ${current} ]]; then
+		echo "${default}"
+	else
+		echo "${current}"
+	fi
+}
+
+
+main::get_metadata() {
+	local key=${1}
+
+	local value
+
+	if [[ ${key} = *"169.254.169.254/computeMetadata"* ]]; then
+  	value=$(curl --fail -sH'Metadata-Flavor: Google' "${key}")
+	else
+		value=$(curl --fail -sH'Metadata-Flavor: Google' http://169.254.169.254/computeMetadata/v1/instance/attributes/"${key}")
+	fi
+	echo "${value}"
+}
+
+
+main::complete() {
+  local on_error=${1}
+
+  if [[ -z "${on_error}" ]]; then
+  	main::errhandle_log_info "INSTANCE DEPLOYMENT COMPLETE"
+  fi
+
+  ## prepare advanced logs
+  if [[ "${VM_METADATA[sap_deployment_debug]}" = "True" ]]; then
+    mkdir -p /root/.deploy
+    main::errhandle_log_info "--- Debug mode is turned on. Preparing additional logs"
+    env > /root/.deploy/"${HOSTNAME}"_debug_env.log
+    grep startup /var/log/messages > /root/.deploy/"${HOSTNAME}"_debug_startup_script_output.log
+    tar -czvf /root/.deploy/"${HOSTNAME}"_deployment_debug.tar.gz -C /root/.deploy/ .
+    main::errhandle_log_info "--- Debug logs stored in /root/.deploy/"
+		## Upload logs to GCS bucket & display complete message
+    if [ -n "${VM_METADATA[sap_hana_deployment_bucket]}" ]; then
+      main::errhandle_log_info "--- Uploading logs to Google Cloud Storage bucket"
+      ${GSUTIL} cp /root/.deploy/"${HOSTNAME}"_deployment_debug.tar.gz  gs://"${VM_METADATA[sap_hana_deployment_bucket]}"/logs/
+    fi
+  fi
+
+	## Run custom post deployment script
+	if [[ -n "${VM_METADATA[post_deployment_script]}" ]]; then
+    main::errhandle_log_info "--- Running custom post deployment script - ${VM_METADATA[post_deployment_script]}"
+		if [[ "${VM_METADATA[post_deployment_script]:0:8}" = "https://" ]] || [[ "${VM_METADATA[post_deployment_script]:0:7}" = "http://" ]]; then
+			source /dev/stdin <<< "$(curl -s "${VM_METADATA[post_deployment_script]}")"
+		elif [[ "${VM_METADATA[post_deployment_script]:0:5}" = "gs://" ]]; then
+			source /dev/stdin <<< "$("${GSUTIL}" cat "${VM_METADATA[post_deployment_script]}")"
+		else
+			main::errhandle_log_warning "--- Unknown post deployment script. URL must begin with https:// http:// or gs://"
+		fi
+	fi
+
+	if [[ -z "${deployment_warnings}" ]]; then
+		main::errhandle_log_info "--- Finished"
+	else
+		main::errhandle_log_warning "--- Finished (${deployment_warnings} warnings)"
+	fi
+
+	## exit sending right error code
+	if [[ -z "${on_error}" ]]; then
+  	exit 0
+  else
+		exit 1
+	fi
+
+}

--- a/gcp/terraform/provision/google/sap_lib_main.sh
+++ b/gcp/terraform/provision/google/sap_lib_main.sh
@@ -149,7 +149,7 @@ main::install_packages() {
 		## Temporary fix fro SLES15 incompatible boto version
 		if [[ "${LINUX_VERSION}" = "15" ]]; then 
     	cat <<EOF > /etc/default/instance_configs.cfg.template
-InstanceSetup]
+[InstanceSetup]
 set_boto_config = false
 EOF
 			rm -f /etc/boto.cfg

--- a/gcp/terraform/startup.sh
+++ b/gcp/terraform/startup.sh
@@ -29,10 +29,13 @@ else
   readonly DEPLOY_URL="https://storage.googleapis.com/sapdeploy/dm-templates"
 fi
 
+# Wait for provisioner
+while [ ! -d /root/provision ] ; do sleep 5 ; done
+
 ## Import includes
-source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_main.sh)"
-source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_hdb.sh)"
-source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_ha.sh | sed -r 's/(AUTOMATED_REGISTER)=\"true\"/\1=\"false\"/')"
+source /root/provision/sap_lib_main.sh
+source /root/provision/sap_lib_hdb.sh
+source /root/provision/sap_lib_ha.sh
 
 ### Base GCP and OS Configuration
 main::get_os_version

--- a/gcp/terraform/startup.sh
+++ b/gcp/terraform/startup.sh
@@ -30,9 +30,9 @@ else
 fi
 
 ## Import includes
-source /dev/stdin <<< "$(curl -s ${DEPLOY_URL}/lib/sap_lib_main.sh)"
-source /dev/stdin <<< "$(curl -s ${DEPLOY_URL}/lib/sap_lib_hdb.sh)"
-source /dev/stdin <<< "$(curl -s ${DEPLOY_URL}/lib/sap_lib_ha.sh | sed -r 's/(AUTOMATED_REGISTER)=\"true\"/\1=\"false\"/')"
+source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_main.sh)"
+source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_hdb.sh)"
+source /dev/stdin <<< "$(curl -s /tmp/google/lib/sap_lib_ha.sh | sed -r 's/(AUTOMATED_REGISTER)=\"true\"/\1=\"false\"/')"
 
 ### Base GCP and OS Configuration
 main::get_os_version
@@ -133,7 +133,6 @@ if [[ $HOSTNAME =~ node-0$ ]] ; then
 	ha::ready
 	if [[ ${VM_METADATA[use_gcp_stonith]} != true ]] ; then
 		ha-cluster-init -y -w /dev/watchdog -s ${SBDDEV} sbd
-		#echo SBD_WATCHDOG=true >> /etc/sysconfig/sbd
 		systemctl enable sbd
 	fi
 	ha::config_pacemaker_primary

--- a/gcp/terraform/terraform.tfvars
+++ b/gcp/terraform/terraform.tfvars
@@ -45,6 +45,9 @@ sap_hana_sid = "HA0"
 # The default value for the <sid>adm user ID is 900 to avoid user created groups conflicting with SAP HANA.
 sap_hana_sidadm_uid = "900"
 
+# Overrides the backup volume size (2x machine memory size) and sets the size to the number of GB specified.
+sap_hana_backup_size = 500
+
 # GCP bucket with SLES images
 images_path_bucket = "sles-images"
 sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"

--- a/gcp/terraform/terraform.tfvars
+++ b/gcp/terraform/terraform.tfvars
@@ -19,6 +19,9 @@ iscsi_ip = "10.0.0.253"
 machine_type = "n1-highmem-8"
 machine_type_iscsi_server = "custom-1-2048"
 
+# SSH private key file
+ssh_key_file = "my-private.key"
+
 # SSH public key file
 ssh_pub_key_file = "my-public.key"
 

--- a/gcp/terraform/terraform.tfvars
+++ b/gcp/terraform/terraform.tfvars
@@ -46,7 +46,7 @@ sap_hana_sid = "HA0"
 sap_hana_sidadm_uid = "900"
 
 # Overrides the backup volume size (2x machine memory size) and sets the size to the number of GB specified.
-sap_hana_backup_size = 500
+sap_hana_backup_size = 200
 
 # GCP bucket with SLES images
 images_path_bucket = "sles-images"

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -9,6 +9,7 @@ variable "gcp_credentials_file" {
 
 variable "suse_regcode" {}
 
+variable "ssh_key_file" {}
 variable "ssh_pub_key_file" {}
 
 variable "ip_cidr_range" {}

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -40,6 +40,7 @@ variable "sap_hana_deployment_bucket" {}
 variable "sap_hana_sidadm_uid" {}
 variable "sap_hana_sapsys_gid" {}
 variable "sap_hana_sid" {}
+variable "sap_hana_backup_size" {}
 
 variable "images_path_bucket" {}
 variable "sles4sap_os_image_file" {}


### PR DESCRIPTION
Currently, the deployment depends on Google scripts and resource agents that are downloaded.  This PR adds these scripts to avoid that any upstream changes break our deployment.  We should instead merge those upstream changes when needed.

This PR also:
   - Fixes a bug in the Google scripts for SLES 15.
   - Adds support for 15SP1
   - Uses smaller disks when not installing HANA
   - Parameterizes SAP HANA backup size