### PR TITLE
update readme about cluster ssh keys creation process

### DIFF
--- a/libvirt/terraform/README.md
+++ b/libvirt/terraform/README.md
@@ -49,9 +49,6 @@ Find more information about the hana and cluster formulas in (check the pillar.e
 - https://github.com/SUSE/saphanabootstrap-formula
 - https://github.com/krig/habootstrap-formula
 
-
-In order to enable the cluster creation, ssh keys must be shared between the nodes. For that create new ssh keys (or use already created ones) and copy them in salt/hana_node/files/sshkeys/ .
-
 The easiest way to customize the variables is using a *terraform.tfvars* file.
 Here an example:
 


### PR DESCRIPTION
remove description about creating new ssh keys from readme, as now it is automated