### PR TITLE
Fix the comparison when the reg email is not informed

### DIFF
--- a/salt/default/registration.sls
+++ b/salt/default/registration.sls
@@ -2,14 +2,20 @@
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }}  {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] is not None else "" }}
+    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }} {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }}
+    - retry:
+        attempts: 3
+        interval: 15
 {% endif %}
 
 {% if grains['reg_additional_modules'] %}
 {% for module, mod_reg_code in grains['reg_additional_modules'].items() %}
 {{ module }}_registration:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -p {{ module }}  {{ ("-r " ~ mod_reg_code) if mod_reg_code is not None else "" }}
+    - name: /usr/bin/SUSEConnect -p {{ module }} {{ ("-r " ~ mod_reg_code) if mod_reg_code else "" }}
+    - retry:
+        attempts: 3
+        interval: 15
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/salt/default/registration.sls
+++ b/salt/default/registration.sls
@@ -2,14 +2,14 @@
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }}  {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] != "" else "" }}
+    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }}  {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] != None else "" }}
 {% endif %}
 
 {% if grains['reg_additional_modules'] %}
 {% for module, mod_reg_code in grains['reg_additional_modules'].items() %}
 {{ module }}_registration:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -p {{ module }}  {{ ("-r " ~ mod_reg_code) if mod_reg_code != "" else "" }}
+    - name: /usr/bin/SUSEConnect -p {{ module }}  {{ ("-r " ~ mod_reg_code) if mod_reg_code != None else "" }}
 {% endfor %}
 {% endif %}
 {% endif %}

--- a/salt/default/registration.sls
+++ b/salt/default/registration.sls
@@ -2,14 +2,14 @@
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }}  {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] != None else "" }}
+    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }}  {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] is not None else "" }}
 {% endif %}
 
 {% if grains['reg_additional_modules'] %}
 {% for module, mod_reg_code in grains['reg_additional_modules'].items() %}
 {{ module }}_registration:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -p {{ module }}  {{ ("-r " ~ mod_reg_code) if mod_reg_code != None else "" }}
+    - name: /usr/bin/SUSEConnect -p {{ module }}  {{ ("-r " ~ mod_reg_code) if mod_reg_code is not None else "" }}
 {% endfor %}
 {% endif %}
 {% endif %}


### PR DESCRIPTION
The grains function returns None and the comparison fails generating a
string "-e None" when the email is not informed.