### PR TITLE
Feature/public ssh key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ script:
       fi ;
       /tmp/terraform init ;
       if [[ "$provider" == "gcp" ]]; then
-        /tmp/terraform validate -var-file=terraform.tfvars.example -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var ssh_key_file=/dev/null -var ssh_pub_key_file=/dev/null ;
+        /tmp/terraform validate -var-file=terraform.tfvars.example -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var private_key_location=/dev/null -var public_key_location=/dev/null ;
       else
         /tmp/terraform validate -var-file=terraform.tfvars.example -var private_key_location=/dev/null -var public_key_location=/dev/null ;
       fi ;

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ script:
       if [[ "$provider" == "gcp" ]]; then
         /tmp/terraform validate -var-file=terraform.tfvars.example -var sap_hana_sidadm_password="NOT_SECRET" -var sap_hana_system_password="NOT_SECRET" -var gcp_credentials_file=/dev/null -var ssh_key_file=/dev/null -var ssh_pub_key_file=/dev/null ;
       else
-        /tmp/terraform validate -var-file=terraform.tfvars.example -var private_key_location=/dev/null ;
+        /tmp/terraform validate -var-file=terraform.tfvars.example -var private_key_location=/dev/null -var public_key_location=/dev/null ;
       fi ;
       if [[ "$provider" == "aws" ]]; then
         cd ../terraform_salt ;

--- a/aws/terraform/README.md
+++ b/aws/terraform/README.md
@@ -134,7 +134,7 @@ In the file [terraform.tfvars](terraform.tfvars) there are a number of variables
 * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
 * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
 * **aws_region**: AWS region where to deploy the configuration.
- * **public_key_loaction**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
+ * **public_key_location**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
 * **private_key_location**: local path to the private SSH key associated to the public key from the previous line.
 * **aws_credentials**: path to the `aws-cli` credentials file. This is required to configure `aws-cli` in the instances so that they can access the S3 bucket containing the Hana installation master.
 * **hana_inst_master**: path to the `S3 Bucket` containing the Hana installation master.

--- a/aws/terraform/README.md
+++ b/aws/terraform/README.md
@@ -134,7 +134,7 @@ In the file [terraform.tfvars](terraform.tfvars) there are a number of variables
 * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
 * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
 * **aws_region**: AWS region where to deploy the configuration.
-* **public_key**: SSH public key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
+ * **public_key_loaction**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
 * **private_key_location**: local path to the private SSH key associated to the public key from the previous line.
 * **aws_credentials**: path to the `aws-cli` credentials file. This is required to configure `aws-cli` in the instances so that they can access the S3 bucket containing the Hana installation master.
 * **hana_inst_master**: path to the `S3 Bucket` containing the Hana installation master.

--- a/aws/terraform/keys.tf
+++ b/aws/terraform/keys.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "mykey" {
   key_name   = "${terraform.workspace} - mykey"
-  public_key = "${var.public_key}"
+  public_key = "${file("${var.public_key_location}")}"
 }

--- a/aws/terraform/terraform.tfvars.example
+++ b/aws/terraform/terraform.tfvars.example
@@ -9,8 +9,8 @@ ninstances = "2"
 # Region where to deploy the configuration
 aws_region = "eu-central-1"
 
-# SSH Public key to configure access to the remote instances
-public_key = "ADD_YOUR_SSH_PUBLIC_KEY_HERE"
+# SSH Public key location to configure access to the remote instances
+public_key_location = "/path/to/your/public/ssh/key"
 
 # Private SSH Key location
 private_key_location = "/path/to/your/private/ssh/key"
@@ -23,4 +23,3 @@ hana_inst_master = "s3://path/to/your/hana/installation/master"
 
 # Variable for init-nodes.tpl script. Can be all, skip-hana or skip-cluster
 init-type = "all"
-

--- a/aws/terraform/variables.tf
+++ b/aws/terraform/variables.tf
@@ -57,7 +57,7 @@ variable "aws_region" {
   type = "string"
 }
 
-variable "public_key" {
+variable "public_key_location" {
   type = "string"
 }
 

--- a/aws/terraform_salt/README.md
+++ b/aws/terraform_salt/README.md
@@ -195,7 +195,7 @@ All this means that basically the default command `terraform apply` and be also 
  * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
  * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
  * **aws_region**: AWS region where to deploy the configuration.
- * **public_key_loaction**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
+ * **public_key_location**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
  * **private_key_location**: local path to the private SSH key associated to the public key from the previous line.
  * **aws_credentials**: path to the `aws-cli` credentials file. This is required to configure `aws-cli` in the instances so that they can access the S3 bucket containing the HANA installation master.
  * **name**: hostname for the hana node without the domain part.

--- a/aws/terraform_salt/README.md
+++ b/aws/terraform_salt/README.md
@@ -64,7 +64,7 @@ The easiest way to customize the variables is using a  _terraform.tfvars_  file.
 instancetype = "m4.2xlarge"
 ninstances = "2"
 aws_region = "eu-central-1"
-public_key = "ADD_YOUR_SSH_PUBLIC_KEY_HERE"
+public_key_location = "/path/to/your/public/ssh/key"
 private_key_location = "/path/to/your/private/ssh/key"
 aws_credentials = "~/.aws/credentials"
 name = "hana"
@@ -195,7 +195,7 @@ All this means that basically the default command `terraform apply` and be also 
  * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
  * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
  * **aws_region**: AWS region where to deploy the configuration.
- * **public_key**: SSH public key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
+ * **public_key_loaction**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
  * **private_key_location**: local path to the private SSH key associated to the public key from the previous line.
  * **aws_credentials**: path to the `aws-cli` credentials file. This is required to configure `aws-cli` in the instances so that they can access the S3 bucket containing the HANA installation master.
  * **name**: hostname for the hana node without the domain part.

--- a/aws/terraform_salt/keys.tf
+++ b/aws/terraform_salt/keys.tf
@@ -1,4 +1,4 @@
 resource "aws_key_pair" "mykey" {
   key_name   = "${terraform.workspace} - mykey"
-  public_key = "${var.public_key}"
+  public_key = "${file("${var.public_key_location}")}"
 }

--- a/aws/terraform_salt/terraform.tfvars.example
+++ b/aws/terraform_salt/terraform.tfvars.example
@@ -9,8 +9,8 @@ ninstances = "2"
 # Region where to deploy the configuration
 aws_region = "eu-central-1"
 
-# SSH Public key to configure access to the remote instances
-public_key = "ADD_YOUR_SSH_PUBLIC_KEY_HERE"
+# SSH Public key location to configure access to the remote instances
+public_key_location = "/path/to/your/public/ssh/key"
 
 # Private SSH Key location
 private_key_location = "/path/to/your/private/ssh/key"

--- a/aws/terraform_salt/variables.tf
+++ b/aws/terraform_salt/variables.tf
@@ -62,7 +62,7 @@ variable "name" {
   type        = "string"
 }
 
-variable "public_key" {
+variable "public_key_location" {
   type = "string"
 }
 

--- a/azure/terraform/README.md
+++ b/azure/terraform/README.md
@@ -280,7 +280,7 @@ In the file [terraform.tfvars](terraform.tfvars) there are a number of variables
 
 * **admin_user**: name of the administration user to deploy in all virtual machines.
 * **private_key_location**: path to the local file containing the private SSH key to configure in the virtual machines to allow access.
-* **public_key**: SSH public key associated with the private key file. This public key is configured in the file `$HOME/.ssh/authorized_keys` of the administration user in the remote virtual machines.
+* **public_key_location**: SSH public key location associated with the private key file. This public key is configured in the file `$HOME/.ssh/authorized_keys` of the administration user in the remote virtual machines.
 * **instmaster**: path to a SMB/CIFS share containing the installation master of Hana.
 * **instmaster_user**: user to use to connect to the previous share.
 * **instmaster_pass**: password to use to connect to the previous share.

--- a/azure/terraform/keys.tf
+++ b/azure/terraform/keys.tf
@@ -6,7 +6,7 @@ variable "private_key_location" {
   type = "string"
 }
 
-variable "public_key" {
+variable "public_key_location" {
   type = "string"
 }
 

--- a/azure/terraform/terraform.tfvars.example
+++ b/azure/terraform/terraform.tfvars.example
@@ -5,7 +5,7 @@ admin_user = "YOUR_USERNAME_HERE"
 private_key_location = "PATH_TO_PRIVATE_SSH_KEY"
 
 # Admin user's public key
-public_key = "STRING_OF_PUBLIC_SSH_KEY"
+public_key_location = "PATH_TO_PUBLIC_SSH_KEY"
 
 # Installation master share
 instmaster = "SHARE_TO_INSTALLATION_MASTER"
@@ -30,4 +30,3 @@ az_region = "westeurope"
 
 # Variable for init-nodes.sh script
 init-type = "all"
-

--- a/azure/terraform/virtualmachines.tf
+++ b/azure/terraform/virtualmachines.tf
@@ -54,7 +54,7 @@ resource "azurerm_virtual_machine" "iscsisrv" {
 
     ssh_keys {
       path     = "/home/${var.admin_user}/.ssh/authorized_keys"
-      key_data = "${var.public_key}"
+      key_data = "${file(var.public_key_location)}"
     }
   }
 
@@ -126,7 +126,7 @@ resource "azurerm_virtual_machine" "clusternodes" {
 
     ssh_keys {
       path     = "/home/${var.admin_user}/.ssh/authorized_keys"
-      key_data = "${var.public_key}"
+      key_data = "${file(var.public_key_location)}"
     }
   }
 

--- a/azure/terraform/virtualmachines.tf-publicimg
+++ b/azure/terraform/virtualmachines.tf-publicimg
@@ -57,7 +57,7 @@ resource "azurerm_virtual_machine" "iscsisrv" {
 
     ssh_keys {
       path     = "/home/${var.admin_user}/.ssh/authorized_keys"
-      key_data = "${var.public_key}"
+      key_data = "${file(var.public_key_location)}"
     }
   }
 
@@ -132,7 +132,7 @@ resource "azurerm_virtual_machine" "clusternodes" {
 
     ssh_keys {
       path     = "/home/${var.admin_user}/.ssh/authorized_keys"
-      key_data = "${var.public_key}"
+      key_data = "${file(var.public_key_location)}"
     }
   }
 

--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -91,9 +91,9 @@ These are the relevant files and what each provides:
 
 - The `gcp_credentials_file` variable must contain the path to the JSON file with the GCP credentials created above.
 
-- The `ssh_key_file` variable must contain the path to your SSH private key.  This is used by the provisioner.
+- The `private_key_location` variable must contain the path to your SSH private key.  This is used by the provisioner.
 
-- The `ssh_pub_key_file` variable must contain the path to your SSH public key.  This is used to access the instances.
+- The `public_key_location` variable must contain the path to your SSH public key.  This is used to access the instances.
 
 - The `region` variable must contain the name of the desired region.
 

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -40,7 +40,7 @@ resource "google_compute_instance" "iscsisrv" {
   }
 
   metadata {
-    sshKeys = "root:${file(var.ssh_pub_key_file)}"
+    sshKeys = "root:${file(var.public_key_location)}"
   }
 }
 
@@ -89,7 +89,7 @@ resource "google_compute_instance" "clusternodes" {
   }
 
   metadata {
-    sshKeys = "root:${file(var.ssh_pub_key_file)}"
+    sshKeys = "root:${file(var.public_key_location)}"
 
     # For a description of these:
     # https://storage.googleapis.com/sapdeploy/dm-templates/sap_hana_ha/template.yaml
@@ -129,7 +129,7 @@ resource "google_compute_instance" "clusternodes" {
     connection {
       type        = "ssh"
       user        = "root"
-      private_key = "${file(var.ssh_key_file)}"
+      private_key = "${file(var.private_key_location)}"
     }
   }
 }

--- a/gcp/terraform/terraform.tfvars.example
+++ b/gcp/terraform/terraform.tfvars.example
@@ -19,11 +19,11 @@ iscsi_ip = "10.0.0.253"
 machine_type = "n1-highmem-8"
 machine_type_iscsi_server = "custom-1-2048"
 
-# SSH private key file
-ssh_key_file = "my-private.key"
+# SSH Public key location to configure access to the remote instances
+public_key_location = "/path/to/your/public/ssh/key"
 
-# SSH public key file
-ssh_pub_key_file = "my-public.key"
+# Private SSH Key location
+private_key_location = "/path/to/your/private/ssh/key"
 
 region = "europe-west1"
 

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -9,8 +9,13 @@ variable "gcp_credentials_file" {
 
 variable "suse_regcode" {}
 
-variable "ssh_key_file" {}
-variable "ssh_pub_key_file" {}
+variable "private_key_location" {
+  type = "string"
+}
+
+variable "public_key_location" {
+  type = "string"
+}
 
 variable "ip_cidr_range" {}
 

--- a/libvirt/terraform/modules/base/main.tf
+++ b/libvirt/terraform/modules/base/main.tf
@@ -29,7 +29,7 @@ output "configuration" {
 
   value = {
     timezone             = "${var.timezone}"
-    ssh_key_path         = "${var.ssh_key_path}"
+    public_key_location  = "${var.public_key_location}"
     domain               = "${var.domain}"
     name_prefix          = "${var.name_prefix}"
     use_shared_resources = "${var.use_shared_resources}"

--- a/libvirt/terraform/modules/base/variables.tf
+++ b/libvirt/terraform/modules/base/variables.tf
@@ -3,7 +3,7 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
-variable "ssh_key_path" {
+variable "public_key_location" {
   description = "path of pub ssh key you want to use to access VMs"
   default     = "~/.ssh/id_rsa.pub"
 }

--- a/libvirt/terraform/modules/hana_node/main.tf
+++ b/libvirt/terraform/modules/hana_node/main.tf
@@ -9,7 +9,7 @@ module "hana_node" {
   reg_additional_modules = "${var.reg_additional_modules}"
   additional_repos       = "${var.additional_repos}"
   additional_packages    = "${var.additional_packages}"
-  ssh_key_path           = "${var.ssh_key_path}"
+  public_key_location    = "${var.public_key_location}"
   host_ips               = "${var.host_ips}"
 
   grains = <<EOF

--- a/libvirt/terraform/modules/hana_node/variables.tf
+++ b/libvirt/terraform/modules/hana_node/variables.tf
@@ -44,8 +44,8 @@ variable "count" {
   default     = 1
 }
 
-variable "ssh_key_path" {
-  description = "path of additional pub ssh key you want to use to access VMs, see README_ADVANCED.md"
+variable "public_key_location" {
+  description = "path of additional pub ssh key you want to use to access VMs"
   default     = "/dev/null"
 
   # HACK: "" cannot be used as a default because of https://github.com/hashicorp/hil/issues/50

--- a/libvirt/terraform/modules/host/main.tf
+++ b/libvirt/terraform/modules/host/main.tf
@@ -103,7 +103,7 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
-authorized_keys: [${trimspace(file(var.base_configuration["ssh_key_path"]))},${trimspace(file(var.ssh_key_path))}]
+authorized_keys: [${trimspace(file(var.base_configuration["public_key_location"]))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 

--- a/libvirt/terraform/modules/host/variables.tf
+++ b/libvirt/terraform/modules/host/variables.tf
@@ -44,7 +44,7 @@ variable "grains" {
   default     = ""
 }
 
-variable "ssh_key_path" {
+variable "public_key_location" {
   description = "path of additional pub ssh key you want to use to access VMs"
   default     = "/dev/null"
 


### PR DESCRIPTION
Currently we need to copy the public key string. This is quite annoying.

I have updated how this parameter is used to use the path instead the content (this is already done this way in GCP)