### PR TITLE
Update repository selection conditions

### DIFF
--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -1,9 +1,9 @@
 ha-factory-repo:
   pkgrepo.managed:
     - name: ha-factory
-{% if grains['osfinger'] == 'SLES-12' %}
+{% if grains['osmajorrelease'] == 12 %}
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_12_SP4/
-{% elif grains['osfinger'] == 'SLES-15' %}
+{% elif grains['osmajorrelease'] == 15 %}
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_15/
 {% endif %}
     - gpgautoimport: True


### PR DESCRIPTION
Grains information is different in old SLES12 version (sp1, sp2, sp3).

To solve that we need to use osmajorrelease instead of osfinger.

Anyway, this approach must be improved in the future to use the exact repository version.
By now, as the packages are not ready for old versions we can workaround with the current solution.

