### PR TITLE
Update aws cli usage adding the region option

### DIFF
--- a/aws/terraform_salt/instances.tf
+++ b/aws/terraform_salt/instances.tf
@@ -122,6 +122,7 @@ resource "aws_instance" "clusternodes" {
   provisioner "file" {
     content = <<EOF
 provider: "aws"
+region: ${var.aws_region}
 role: "hana_node"
 name_prefix: ${var.name}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/salt/hana_node/download_hana_inst.sls
+++ b/salt/hana_node/download_hana_inst.sls
@@ -1,9 +1,9 @@
 download_files:
   cmd.run:
     - name: "aws s3 sync {{ grains['hana_inst_master'] }}
-      {{ grains['hana_inst_folder'] }} --only-show-errors"
+      {{ grains['hana_inst_folder'] }} --only-show-errors --region {{ grains['region'] }}"
     - onlyif: "aws s3 sync --dryrun {{ grains['hana_inst_master'] }}
-      {{ grains['hana_inst_folder'] }} | grep download"
+      {{ grains['hana_inst_folder'] }} --region {{ grains['region'] }} | grep download"
     - output_loglevel: quiet
 
 {{ grains['hana_inst_folder'] }}:


### PR DESCRIPTION
In SLES12SP3 (and older) version the aws-cli version doesn't work if region is not provided.

To fix that we will use the region in all the deployments as it works fine.