### PR TITLE
Fix/documentation

### DIFF
--- a/aws/terraform_salt/README.md
+++ b/aws/terraform_salt/README.md
@@ -46,16 +46,16 @@ These are the relevant files and what each provides:
 
 ## How to use
 
-To use, copy the `*.tf`, `*.tpl` and `terraform.tfvars` files and the `provision` directory into your working directory.
+To use, copy the `*.tf`, `*.tpl`  and `terraform.tfvars.example` files into your working directory and rename `terraform.tfvars.example` to `terraform.tfvars`.
 
 Then, from your working directory, generate private and public keys for the cluster nodes with the following commands:
 
 ```
 mkdir provision/hana_node/files/sshkeys; ssh-keygen -t rsa -f provision/hana_node/files/sshkeys/cluster.id_rsa
 ```
-The key files need to be named as you defined it in [terraform.tfvars](terraform.tfvars) file.
+The key files need to be named as you defined it in [terraform.tfvars](terraform.tfvars.example) file.
 
-To deploy the cluster only the parameters of three files should be changed:  [terraform.tfvars](https://github.com/SUSE/ha-sap-terraform-deployments/blob/master/aws/terraform_salt/terraform.tfvars),  hana.sls and cluster.sls. Configure these files according to the wanted cluster type.
+To deploy the cluster only the parameters of three files should be changed:  `terraform.tfvars`,  `hana.sls` and `cluster.sls`. Configure these files according to the wanted cluster type.
 
 ### The terraform.tfvars file
 The easiest way to customize the variables is using a  _terraform.tfvars_  file. Here is an example:
@@ -86,7 +86,7 @@ reg_additional_modules = {
 }
  ```
 
-Following that edit in the [terraform.tfvars](terraform.tfvars) file:
+Following that edit in the [terraform.tfvars](terraform.tfvars.example) file:
 
 * The public SSH key to use to connect to the instances. It is recommended to use a different key than the one generated in the previous steps.
 * The location of the private key associated with that public key.
@@ -124,9 +124,11 @@ terraform apply
 
 This configuration uses the public **SUSE Linux Enterprise Server 15 for SAP Applications BYOS x86_64** image available in AWS (as defined in the file [variables.tf](variables.tf)) and can be used as is.
 
-If the use of a private/custom image is required (for example, to perform the Build Validation of a new AWS Public Cloud image), first upload the image to the cloud using the [procedure described below](#upload-image-to-aws), and then [register it as an AMI](#import-ami-via-snapshot). Once the new AMI is available, edit its AMI id value in the [terraform.tfvars](terraform.tfvars) file for your region of choice.
+If the use of a private/custom image is required (for example, to perform the Build Validation of a new AWS Public Cloud image), first upload the image to the cloud using the [procedure described below](#upload-image-to-aws), and then [register it as an AMI](#import-ami-via-snapshot). Once the new AMI is available, edit its AMI id value in the [terraform.tfvars](terraform.tfvars.example) file for your region of choice.
 
-To define the custom AMI in terraform, you should use the [terraform.tfvars](terraform.tfvars) file:
+**Important:** The image used for the iSCSI server **must be at least SLES 15 version** since the iSCSI salt formula is not compatible with lower versions.
+
+To define the custom AMI in terraform, you should use the [terraform.tfvars](terraform.tfvars.example) file:
 ```
  # Custom AMI for nodes
 sles4sap = {
@@ -160,7 +162,7 @@ Check outputs with:
 terraform output
 ```
 
-By default this configuration will deploy the infrastructure to the `eu-central-1` region of AWS. Internally, the provided terraform files are only configured for the European (eu-central-1, eu-west-1, eu-west-2 and eu-west-3) and North American zones (us-east-1, us-east-2, us-west-1, us-west-2 and ca-central-1), but this as well as the default zone can be changed by editing the [variables.tf](variables.tf) or the [terraform.tfvars](terraform.tfvars) files.
+By default this configuration will deploy the infrastructure to the `eu-central-1` region of AWS. Internally, the provided terraform files are only configured for the European (eu-central-1, eu-west-1, eu-west-2 and eu-west-3) and North American zones (us-east-1, us-east-2, us-west-1, us-west-2 and ca-central-1), but this as well as the default zone can be changed by editing the [variables.tf](variables.tf) or the [terraform.tfvars](terraform.tfvars.example) files.
 
 It is also possible to change the AWS region from the command line with the `-var aws_region` parameter, for example:
 
@@ -190,7 +192,7 @@ All this means that basically the default command `terraform apply` and be also 
 
 ### Variables
 
- In the file [terraform.tfvars](terraform.tfvars) there are a number of variables that control what is deployed. Some of these variables are:
+ In the file [terraform.tfvars](terraform.tfvars.example) there are a number of variables that control what is deployed. Some of these variables are:
 
  * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
  * **ninstances**: number of cluster nodes to deploy. Defaults to 2.

--- a/aws/terraform_salt/init-server.tpl
+++ b/aws/terraform_salt/init-server.tpl
@@ -8,6 +8,10 @@ while [[ ! -d "/root/salt/" ]];do
   sleep 5
 done
 
+# Registration for install salt-minion only
+# Node servers are deregistered just after
+# If you don't use qa_mode, a complete registration is done by salt later
+
 if grep -q 'role: "iscsi_srv"' /tmp/grains; then
   sh /root/salt/install-salt-minion.sh -r ${regcode}
 elif [[ ! -e /usr/bin/salt-minion ]]; then

--- a/azure/terraform_salt/README.md
+++ b/azure/terraform_salt/README.md
@@ -1,3 +1,4 @@
+
 # Azure Public Cloud deployment with terraform and Salt
 
 The terraform configuration files in this directory can be used to create the infrastructure required to install a SAP HanaSR cluster on Suse Linux Enterprise Server for SAP Applications in **Azure**.
@@ -57,6 +58,8 @@ The key files need to be named as you defined it in `terraform.tfvars` file.
 After that we need to update the `terraform.tfvars` file and copy the pillar files to `salt/hana_node/files/pillar` folder.
 
 ### Variables
+
+**Important:** The image used for the iSCSI server **must be at least SLES 15 version** since the      iSCSI salt formula is not compatible with lower versions.
 
 In the file [terraform.tfvars.example](terraform.tfvars.example) there are a number of variables that control what is deployed. Some of these variables are:
 

--- a/azure/terraform_salt/init-server.tpl
+++ b/azure/terraform_salt/init-server.tpl
@@ -1,12 +1,16 @@
 #!/bin/bash -xe
 
-# exec > /tmp/init_server.log 2>&1
+exec > /tmp/init_server.log 2>&1
 
 # Wait for the provisioner file step in Terraform
 while [[ ! -d "/root/salt/" ]];do
   echo "Waiting for Salt directory..."
   sleep 5
 done
+
+# Registration for install salt-minion only
+# Node servers are deregistered just after
+# If you don't use qa_mode, a complete registration is done by salt later
 
 if grep -q 'role: "iscsi_srv"' /tmp/grains; then
   sh /root/salt/install-salt-minion.sh -r ${regcode}

--- a/azure/terraform_salt/terraform.tfvars.example
+++ b/azure/terraform_salt/terraform.tfvars.example
@@ -17,16 +17,16 @@ az_region = "westeurope"
 
 # Public sles4sap image
 sles4sap_public = {
-  #"publisher" = "SUSE"
-  #"offer"     = "SLES-SAP-BYOS"
+  "publisher" = "SUSE"
+  "offer"     = "SLES-SAP-BYOS"
   "sku"       = "12-sp4"
   "version"   = "2019.03.06"
 }
 
 # Public iscsi server image
 iscsi_srv_public = {
-  #"publisher" = "SUSE"
-  #"offer"     = "SLES-SAP-BYOS"
+  "publisher" = "SUSE"
+  "offer"     = "SLES-SAP-BYOS"
   "sku"       = "15"
   "version"   = "2018.08.20"
 }

--- a/libvirt/terraform/README.md
+++ b/libvirt/terraform/README.md
@@ -1,3 +1,4 @@
+
 # Terraform cluster deployment with Libvirt
 
 This terraform module deploys a cluster running the SUSE Linux Enterprise Server
@@ -26,7 +27,7 @@ host module with some particular updates.
 - [default](../../salt/default): Default configuration for each node. Install the most
 basic packages and apply basic configuration.
 - [hana_node](../../salt/hana_node): Apply SAP HANA nodes specific updates to install
-SAP HANA and enable system replication according [pillar](../../salt/hana_node/files/pillar/hana.sls)
+SAP HANA and enable system replication according [pillar](../../pillar_examples/libvirt/hana.sls)
 data.
 
 ## How to use
@@ -42,12 +43,12 @@ data.
 
 ### Deployment
 
-To deploy the cluster only the parameters of three files should be changed: [main.tf](main.tf), [hana.sls](../../salt/hana_node/files/pillar/hana.sls) and [cluster.sls](../../salt/hana_node/files/pillar/cluster.sls).
+To deploy the cluster only the parameters of three files should be changed: [main.tf](main.tf), [hana.sls](../../pillar_examples/libvirt/hana.sls) and [cluster.sls](../../pillar_examples/libvirt/cluster.sls).
 Configure these files according the wanted cluster type.
 
 Find more information about the hana and cluster formulas in (check the pillar.example files):
 - https://github.com/SUSE/saphanabootstrap-formula
-- https://github.com/krig/habootstrap-formula
+- https://github.com/SUSE/habootstrap-formula
 
 The easiest way to customize the variables is using a *terraform.tfvars* file.
 Here an example:
@@ -120,11 +121,11 @@ If the current *main.tf* is used, only *uri* (usually SAP HANA cluster deploymen
 
 #### hana.sls
 
-**hana.sls** is used to configure the SAP HANA cluster. Check the options in: [saphanabootstrap-formula](https://github.com/arbulu89/saphanabootstrap-formula)
+**hana.sls** is used to configure the SAP HANA cluster. Check the options in: [saphanabootstrap-formula](https://github.com/SUSE/saphanabootstrap-formula)
 
 #### cluster.sls
 
-**cluster.sls** is used to configure the HA cluster. Check the options in: [habootstrap-formula](https://github.com/krig/habootstrap-formula)
+**cluster.sls** is used to configure the HA cluster. Check the options in: [habootstrap-formula](https://github.com/SUSE/habootstrap-formula)
 
 
 ### Destroying the cluster


### PR DESCRIPTION
This PR includes minor updates mainly on the documentation:
- Fix broken links in README files
- Add important information about the iSCSI image
- Add comments about the necessary registration for salt-minion package
- Allow `init_server.log` for Azure by removing an unwanted `#` 
- Remove unwanted comments in Azure `terraform.tfvars.example`