### PR TITLE
Cast osmajorrelease version to int

### DIFF
--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -1,9 +1,9 @@
 ha-factory-repo:
   pkgrepo.managed:
     - name: ha-factory
-{% if grains['osmajorrelease'] == 12 %}
+{% if grains['osmajorrelease']|int == 12 %}
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_12_SP4/
-{% elif grains['osmajorrelease'] == 15 %}
+{% elif grains['osmajorrelease']|int == 15 %}
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_15/
 {% endif %}
     - gpgautoimport: True


### PR DESCRIPTION
In some older releases (sles12sp3 in libvirt) the osmajorrelase
parameter is a string.

This might solve the issue with old salt versions (salt-call 2016.11.4 (Carbon) for example)

    osfullname:
        SLES
    osmajorrelease:
        12
    osrelease:
        12.3
    osrelease_info:
        - 12
        - 3

**INFO: I was wondering why we didn't find this issue with cloud providers. The reason is, we install salt using other systems (install-saltminion.sh). In libvirt, we use the default salt version. This might create different problems as some feature are not available.
Maybe, we should consider to update salt to the last version before starting the provisioning**