### PR TITLE
Change netmask form to avoid a warning

### DIFF
--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -41,9 +41,9 @@ cluster:
         virtual_ip: {{ grains['azure_lb_ip'] }}
         {% endif %}
         {% if grains['provider'] == 'aws' %}
-        virtual_ip_mask: 255.255.0.0
+        virtual_ip_mask: 16
         {% else %}
-        virtual_ip_mask: 255.255.255.0
+        virtual_ip_mask: 24
         {% endif %}
         platform: {{ grains['provider'] }}
         prefer_takeover: true

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -18,7 +18,7 @@ cluster:
         sid: prd
         instance: 00
         virtual_ip: 10.0.1.50
-        virtual_ip_mask: 255.255.0.0
+        virtual_ip_mask: 16
         platform: aws
         prefer_takeover: true
         auto_register: false

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -18,7 +18,7 @@ cluster:
         sid: prd
         instance: 00
         virtual_ip: 10.74.1.5 # This value must match with the load balancer address: frontend_ip_configuration
-        virtual_ip_mask: 255.255.255.0
+        virtual_ip_mask: 24
         platform: azure
         prefer_takeover: true
         auto_register: false

--- a/pillar_examples/libvirt/cluster.sls
+++ b/pillar_examples/libvirt/cluster.sls
@@ -21,7 +21,7 @@ cluster:
         sid: prd
         instance: 00
         virtual_ip: 192.168.107.50
-        virtual_ip_mask: 255.255.255.0
+        virtual_ip_mask: 24
         platform: libvirt
         prefer_takeover: true
         auto_register: false


### PR DESCRIPTION
The IPaddr2 RA warns you if dotted quad netmask is used instead of the CIDR notation:

`IPaddr2(rsc_ip_PRD_HDB00)[10788]: WARNING: Please convert dotted quad netmask 255.255.0.0 to CIDR notation 16!`