### PR TITLE
Change the format of the HA/SAP Salt packages Repo URL

### DIFF
--- a/aws/terraform_salt/README.md
+++ b/aws/terraform_salt/README.md
@@ -209,7 +209,7 @@ All this means that basically the default command `terraform apply` and be also 
  * **iscsidev**: device used by the iscsi server.
 * **cluster_ssh_pub**: SSH public key name (must match with the key copied in sshkeys folder)
 * **cluster_ssh_key**: SSH private key name (must match with the key copied in sshkeys folder)
-* **ha_sap_deployment_repo**: Repository with HA packages
+* **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 * **reg_code**: registration code for the installed base product (Ex.: SLES for SAP). This parameter is optional. If informed, the system will be registered against the SUSE Customer Center.
 * **reg_email**: email to be associated with the system registration. This parameter is optional.
 * **reg_additional_modules**: additional optional modules and extensions to be registered (Ex.: Containers Module, HA module, Live Patching, etc). The variable is a key-value map, where the key is   the _module name_ and the value is the _registration code_. If the _registration code_ is not needed,  set an empty string as value. The module format must follow SUSEConnect convention:

--- a/aws/terraform_salt/terraform.tfvars.example
+++ b/aws/terraform_salt/terraform.tfvars.example
@@ -53,9 +53,11 @@ cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
 # example : host_ips = ["10.0.1.0", "10.0.1.1"]
 host_ips = ["10.0.1.0", "10.0.1.1"]
 
-# Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
-# Contains the salt formulas
-#ha_sap_deployment_repo = ""
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+ha_sap_deployment_repo = ""
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"

--- a/aws/terraform_salt/variables.tf
+++ b/aws/terraform_salt/variables.tf
@@ -155,8 +155,12 @@ variable "host_ips" {
   type        = "list"
 }
 
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
+  description = "Repository url used to install install HA/SAP deployment packages"
   type        = "string"
 }
 

--- a/azure/terraform_salt/README.md
+++ b/azure/terraform_salt/README.md
@@ -80,7 +80,7 @@ In the file [terraform.tfvars.example](terraform.tfvars.example) there are a num
 * **init-type**: initilization script parameter that controls what is deployed in the cluster nodes. Valid values are `all` (installs Hana and configures cluster), `skip-hana` (does not install Hana, but configures cluster) and `skip-cluster` (installs hana, but does not configure cluster). Defaults to `all`.
 * **cluster_ssh_pub**: SSH public key name (must match with the key copied in sshkeys folder)
 * **cluster_ssh_key**: SSH private key name (must match with the key copied in sshkeys folder)
-* **ha_sap_deployment_repo**: Repository with HA packages
+* **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 * **reg_code**: registration code for the installed base product (Ex.: SLES for SAP). This parameter is optional. If informed, the system will be registered against the SUSE Customer Center.
 * **reg_email**: email to be associated with the system registration. This parameter is optional.
 * **reg_additional_modules**: additional optional modules and extensions to be registered (Ex.: Containers Module, HA module, Live Patching, etc). The variable is a key-value map, where the key is   the _module name_ and the value is the _registration code_. If the _registration code_ is not needed,  set an empty string as value. The module format must follow SUSEConnect convention:

--- a/azure/terraform_salt/terraform.tfvars.example
+++ b/azure/terraform_salt/terraform.tfvars.example
@@ -73,7 +73,10 @@ cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
 # example : host_ips = ["10.0.1.0", "10.0.1.1"]
 host_ips = ["10.74.1.11", "10.74.1.12"]
 
-# HA packages Repository
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 ha_sap_deployment_repo = ""
 
 # Optional SUSE Customer Center Registration parameters

--- a/azure/terraform_salt/variables.tf
+++ b/azure/terraform_salt/variables.tf
@@ -113,8 +113,12 @@ variable "host_ips" {
   type        = "list"
 }
 
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
+  description = "Repository url used to install install HA/SAP deployment packages"
   type        = "string"
 }
 

--- a/gcp/terraform_salt/README.md
+++ b/gcp/terraform_salt/README.md
@@ -128,7 +128,7 @@ In the file [terraform.tfvars](terraform.tfvars.example) there are a number of v
 * **hana_inst_folder**: path where HANA installation master will be downloaded from `GCP Bucket`.
 * **hana_inst_disk_device**: device used by node where HANA will be downloaded.
 * **hana_disk_device**: device used by node where HANA will be installed.
-* **ha_sap_deployment_repo**: repository with HA packages
+* **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 *  **reg_code**: registration code for the installed base product (Ex.: SLES for SAP). This parameter is optional. If informed, the system will be registered against the SUSE Customer Center.
 * **reg_email**: email to be associated with the system registration. This parameter is optional.
 * **reg_additional_modules**: additional optional modules and extensions to be registered (Ex.: Containers Module, HA module, Live Patching, etc). The variable is a key-value map, where the key is   the _module name_ and the value is the _registration code_. If the _registration code_ is not needed,  set an empty string as value. The module format must follow SUSEConnect convention:

--- a/gcp/terraform_salt/terraform.tfvars.example
+++ b/gcp/terraform_salt/terraform.tfvars.example
@@ -61,7 +61,10 @@ hana_disk_device = "/dev/sdb"
 # Device used by node where HANA will be downloaded
 hana_inst_disk_device = "/dev/sdc"
 
-# HA packages Repository
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 ha_sap_deployment_repo = ""
 
 # Optional SUSE Customer Center Registration parameters

--- a/gcp/terraform_salt/variables.tf
+++ b/gcp/terraform_salt/variables.tf
@@ -152,7 +152,6 @@ variable "ha_sap_deployment_repo" {
   type        = "string"
 }
 
-
 # Network variables
 # Pay attention to set ip address according to the cidr range
 

--- a/gcp/terraform_salt/variables.tf
+++ b/gcp/terraform_salt/variables.tf
@@ -143,10 +143,15 @@ variable "additional_packages" {
   default     = []
 }
 
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
+  description = "Repository url used to install install HA/SAP deployment packages"
   type        = "string"
 }
+
 
 # Network variables
 # Pay attention to set ip address according to the cidr range

--- a/libvirt/terraform/README.md
+++ b/libvirt/terraform/README.md
@@ -99,7 +99,7 @@ with the needed package and try again.
 - **sap_inst_media**: Public media where SAPA installation files are stored.
 - **iprange**: IP range addresses for the isolated network.
 - **host_ips**: Each host IP address (sequential order).
-- **ha_sap_deployment_repo**: Repository url used to install install HA/SAP deployment packages
+- **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 - **additional_repos**: Additional repos to add to the guest machines.
 - **reg_code**: Registration code for the installed base product (Ex.: SLES for SAP). This parameter is optional. If informed, the system will be registered against the SUSE Customer Center.
 - **reg_email**: Email to be associated with the system registration. This parameter is optional.

--- a/libvirt/terraform/terraform.tfvars.example
+++ b/libvirt/terraform/terraform.tfvars.example
@@ -5,7 +5,12 @@ name_prefix = "your-name"
 iprange = "192.168.XXX.Y/24"
 host_ips = ["192.168.XXX.Y", "192.168.XXX.Y+1"]
 additional_repos = {}
-ha_sap_deployment_repo = "url-to-your-repository"
+
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+ha_sap_deployment_repo = ""
 
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -70,7 +70,11 @@ variable "additional_repos" {
   default     = {}
 }
 
+# Repository url used to install install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
 variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install install HA/SAP deployment packages (OS version must be ommited)"
+  description = "Repository url used to install install HA/SAP deployment packages"
   type        = "string"
 }

--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -1,9 +1,5 @@
 ha-factory-repo:
   pkgrepo.managed:
     - name: ha-factory
-{% if grains['osmajorrelease']|int == 12 %}
-    - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_12_SP4/
-{% elif grains['osmajorrelease']|int == 15 %}
-    - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_15/
-{% endif %}
+    - baseurl: {{ grains['ha_sap_deployment_repo'] }}
     - gpgautoimport: True


### PR DESCRIPTION
Improve the documentation and does not calculate the version anymore, as it can be misleading for the user to format the URL this way.

The natural instinct is to Copy and Paste the URL of the repository he wants to use.