### PR TITLE
Fix the repos priorities to prefer the official repo packages first

### DIFF
--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -4,7 +4,7 @@
   pkgrepo.managed:
     - humanname: {{ label }}
     - baseurl: {{ url }}
-    - priority: 94
+    - priority: 120
     - gpgcheck: 0
 {% endfor %}
 {% endif %}

--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -7,3 +7,4 @@ ha-factory-repo:
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}/SLE_15/
 {% endif %}
     - gpgautoimport: True
+    - priority: 110


### PR DESCRIPTION
The priorities work from ASC order, where 1 is the highest priority. With that, this PR adjust the priorities in order to:
1. Prefer the packages from the SUSE official repos (provided by Registration)
2. Prefer the packages from the HA/SAP salt packages repo
3. Prefer the Additional repos that can be included by the user.

This is considered by zypper in case the same package is provided by different repos.