### PR TITLE
GCP: Support public images

### DIFF
--- a/gcp/terraform/README.md
+++ b/gcp/terraform/README.md
@@ -105,19 +105,26 @@ These are the relevant files and what each provides:
 
 - The `images_path_bucket` variable must contain the name of the Google Storage bucket with the SLES image.
 
-- The `sles4sap_os_image_file` variable must contain the name of the SLES4SAP image.
-
 - The `post_deployment_script` variable specifies the URL location of a script to run after the deployment is complete. This script should be hosted on a web server or in a GCS bucket.
 
 - The `init_type` variable controls what is deployed in the cluster nodes. Valid values are `all` (installs HANA and configures cluster), `skip-hana` (does not install HANA, but configures cluster). Defaults to `all`.
 
 - The `machine_type_iscsi_server` variable must contain the [GCP machine type](https://cloud.google.com/compute/docs/machine-types) for the iSCSI server used for SBD stonith. Ignored if `use_gcp_stonith` is set to `"true"`.
 
-- The `sles_os_image_file` variable the name of the SLES image for the iSCSI server used for SBD stonith. Ignored if `use_gcp_stonith` is set to `"true"`.
-
 - The `iscsi_ip` variable must contain the IP address for the iSCSI server. Ignored if `use_gcp_stonith` is set to `"true"`.
 
 - The `use_gcp_stonith` variable specifies whether GCP-stonith must be used instead of SBD stonith.  Set to `"true"` (string, not boolean) if you want it.
+
+- The `use_custom_image` variable specifies whether to use custom images or not.  Set to `"true"` (string, not boolean) if you want to use custom images for, e.g., testing.
+
+- The `sles4sap_os_image_file` variable must contain the name of the custom SLES4SAP image.  Used if `use_custom_image` is set to `"true"`.
+
+- The `sles_os_image_file` variable must contain the name of the custom SLES image for the iSCSI server used for SBD stonith.  Used if `use_custom_image` is set to `"true"`.  Ignored if `use_gcp_stonith` is set to `"true"`.
+
+- The `sles_os_image` variable must contain the name of the public SLES image for the iSCSI server used for SBD stonith. Ignored if `use_gcp_stonith` is set to `"true"`. Ignored if `use_custom_image` is set to `"true"`.
+
+- The `sles4sap_os_image` variable  variable must contain the name of the SLES4SAP image. Ignored if `use_custom_image` is set to `"true"`.
+
 
 2. Deploy:
 

--- a/gcp/terraform/disks.tf
+++ b/gcp/terraform/disks.tf
@@ -1,5 +1,5 @@
 resource "google_compute_disk" "iscsi_data" {
-  name  = "iscsi-data"
+  name  = "${terraform.workspace}-${var.name}-iscsi-data"
   type  = "pd-standard"
   size  = "10"
   count = "${var.use_gcp_stonith == "true" ? 0 : 1}"
@@ -23,7 +23,8 @@ resource "google_compute_disk" "backup" {
 }
 
 resource "google_compute_image" "sles_bootable_image" {
-  name = "${terraform.workspace}-${var.name}-sles"
+  count = "${var.use_custom_image == "true" ? 1 : 0}"
+  name  = "${terraform.workspace}-${var.name}-sles"
 
   raw_disk {
     source = "${var.storage_url}/${var.images_path_bucket}/${var.sles_os_image_file}"
@@ -31,7 +32,8 @@ resource "google_compute_image" "sles_bootable_image" {
 }
 
 resource "google_compute_image" "sles4sap_bootable_image" {
-  name = "${terraform.workspace}-${var.name}-sles4sap"
+  count = "${var.use_custom_image == "true" ? 1 : 0}"
+  name  = "${terraform.workspace}-${var.name}-sles4sap"
 
   raw_disk {
     source = "${var.storage_url}/${var.images_path_bucket}/${var.sles4sap_os_image_file}"

--- a/gcp/terraform/instances.tf
+++ b/gcp/terraform/instances.tf
@@ -27,7 +27,8 @@ resource "google_compute_instance" "iscsisrv" {
 
   boot_disk {
     initialize_params {
-      image = "${google_compute_image.sles_bootable_image.self_link}"
+      # XXX: The join() is a workaround for https://github.com/hashicorp/terraform/issues/11566
+      image = "${var.use_custom_image == "true" ? "${join("", google_compute_image.sles_bootable_image.*.self_link)}" : "suse-cloud/${var.sles_os_image}"}"
     }
 
     auto_delete = true
@@ -70,7 +71,8 @@ resource "google_compute_instance" "clusternodes" {
 
   boot_disk {
     initialize_params {
-      image = "${google_compute_image.sles4sap_bootable_image.self_link}"
+      # XXX: The join() is a workaround for https://github.com/hashicorp/terraform/issues/11566
+      image = "${var.use_custom_image == "true" ? "${join("", google_compute_image.sles4sap_bootable_image.*.self_link)}" : "suse-sap-cloud/${var.sles4sap_os_image}"}"
     }
 
     auto_delete = true

--- a/gcp/terraform/terraform.tfvars.example
+++ b/gcp/terraform/terraform.tfvars.example
@@ -48,11 +48,6 @@ sap_hana_sidadm_uid = "900"
 # Overrides the backup volume size (2x machine memory size) and sets the size to the number of GB specified.
 sap_hana_backup_size = 200
 
-# GCP bucket with SLES images
-images_path_bucket = "sles-images"
-sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"
-sles_os_image_file = "OS-Image-File-for-SLES-for-GCP.tar.gz"
-
 # Specifies the URL location of a script to run after the deployment is complete.
 # The script should be hosted on a web server or in a GCS bucket.
 post_deployment_script = ""
@@ -62,3 +57,16 @@ init_type = "all"
 
 # If set to false, will use iSCSI for fencing on SBD
 use_gcp_stonith = "false"
+
+# Set to true to use custom images for QA
+use_custom_image = "false"
+
+# GCP bucket with SLES images (used if use_custom_image is "true")
+images_path_bucket = "sles-images"
+sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"
+sles_os_image_file = "OS-Image-File-for-SLES-for-GCP.tar.gz"
+
+# SLES public image (used if use_custom_image is not "true")
+sles_os_image = "sles-12-sp4-v20190221"
+# SLES4SAP public image (used if use_custom_image is not "true")
+sles4sap_os_image = "sles-12-sp4-sap-v20190221"

--- a/gcp/terraform/variables.tf
+++ b/gcp/terraform/variables.tf
@@ -50,6 +50,8 @@ variable "sap_hana_backup_size" {}
 variable "images_path_bucket" {}
 variable "sles4sap_os_image_file" {}
 variable "sles_os_image_file" {}
+variable "sles4sap_os_image" {}
+variable "sles_os_image" {}
 
 variable "storage_url" {
   type    = "string"
@@ -64,5 +66,9 @@ variable "init_type" {
 }
 
 variable "use_gcp_stonith" {
+  type = "string"
+}
+
+variable "use_custom_image" {
   type = "string"
 }


### PR DESCRIPTION
This PR:

- Adds support for public images in GCP using `use_custom_image` variable.
- Fixes the name for iscsi-data.  It should contain the workspace as prefix.