### PR TITLE
Add retry to repositories refresh to avoid 502 err

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -14,4 +14,7 @@ include:
 refresh_repos:
   cmd.run:
     - name: zypper --non-interactive --gpg-auto-import-keys refresh
+    - retry:
+        attempts: 3
+        interval: 15
 {% endif %}

--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -4,3 +4,6 @@ ha-factory-repo:
     - baseurl: {{ grains['ha_sap_deployment_repo'] }}
     - gpgautoimport: True
     - priority: 110
+    - retry:
+        attempts: 3
+        interval: 15


### PR DESCRIPTION
The repositories refresh fails sometimes with 502 bad gateway error. In order to fix (or workaround) this error the retries are added.