### PR TITLE
Rename usage of resources template file

### DIFF
--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -31,7 +31,7 @@ cluster:
   configure:
     method: update
     template:
-      source: /srv/salt/hana/templates/performance_optimized.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2
       parameters:
         sid: {{ hana.hana.nodes[0].sid }}
         instance: {{ hana.hana.nodes[0].instance }}

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -13,7 +13,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/performance_optimized.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: 00

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -13,7 +13,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/performance_optimized.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: 00

--- a/pillar_examples/libvirt/cluster.sls
+++ b/pillar_examples/libvirt/cluster.sls
@@ -16,7 +16,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/performance_optimized.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: 00


### PR DESCRIPTION
Based on the update in saphanabootstrap-formula related to update and renaming of resources template file, its usage needs to be updated in ha-sap-terraform-deployments project.