### PR TITLE
Update name_prefix by workspace name

### DIFF
--- a/libvirt/terraform/README.md
+++ b/libvirt/terraform/README.md
@@ -61,7 +61,6 @@ Here an example:
 qemu_uri = "qemu+ssh://root@your_machine/system"
 sap_inst_media = "path_to_nfs_server"
 base_image = "path_to_image"
-name_prefix = "demo"
 iprange = "192.168.101.0/24"
 host_ips = ["192.168.101.15", "192.168.101.16"]
 additional_repos = {
@@ -86,6 +85,8 @@ reg_additional_modules = {
 After changing the values, run the terraform commands:
 
 ```bash
+terraform workspace new myworkspace # The workspace name will be used to create the name of the created resources as prefix (`default` by default)
+terraform workspace select myworkspace
 terraform init
 terraform apply -var-file=terraform.tfvars
 ```
@@ -100,7 +101,6 @@ with the needed package and try again.
 
 - **qemu_uri**: Uri of the libvirt provider.
 - **base_image**: The cluster nodes image is selected updating the *image* parameter in the *base* module.
-- **name_prefix**: The prefix of our infrastructure components.
 - **network_name** and **bridge**: If the cluster is deployed locally, the *network_name* should match with a currently available virtual network. If the cluster is deployed remotely, leave the *network_name* empty and set the *bridge* value with remote machine bridge network interface.
 - **sap_inst_media**: Public media where SAPA installation files are stored.
 - **iprange**: IP range addresses for the isolated network.

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -7,9 +7,6 @@ module "base" {
   image   = "${var.base_image}"
   iprange = "${var.iprange}"
 
-  // optional parameters below
-  name_prefix = "${var.name_prefix}"
-
   // pool = "default"
   pool = "terraform"
 

--- a/libvirt/terraform/modules/base/main.tf
+++ b/libvirt/terraform/modules/base/main.tf
@@ -3,14 +3,14 @@ terraform {
 }
 
 resource "libvirt_volume" "base_image" {
-  name   = "${var.name_prefix}baseimage"
+  name   = "${terraform.workspace}-baseimage"
   source = "${var.image}"
   count  = "${var.use_shared_resources ? 0 : 1}"
   pool   = "${var.pool}"
 }
 
 resource "libvirt_network" "isolated_network" {
-  name      = "${var.name_prefix}-isolated"
+  name      = "${terraform.workspace}-isolated"
   mode      = "none"
   addresses = ["${var.iprange}"]
 
@@ -31,7 +31,6 @@ output "configuration" {
     timezone             = "${var.timezone}"
     public_key_location  = "${var.public_key_location}"
     domain               = "${var.domain}"
-    name_prefix          = "${var.name_prefix}"
     use_shared_resources = "${var.use_shared_resources}"
     isolated_network_id  = "${join(",", libvirt_network.isolated_network.*.id)}"
     iprange              = "${var.iprange}"

--- a/libvirt/terraform/modules/base/variables.tf
+++ b/libvirt/terraform/modules/base/variables.tf
@@ -13,11 +13,6 @@ variable "domain" {
   default     = "tf.local"
 }
 
-variable "name_prefix" {
-  description = "a prefix for all names of objects to avoid collisions."
-  default     = ""
-}
-
 variable "use_shared_resources" {
   description = "use true to avoid deploying images, mirrors and other shared infrastructure resources"
   default     = false

--- a/libvirt/terraform/modules/host/main.tf
+++ b/libvirt/terraform/modules/host/main.tf
@@ -3,27 +3,27 @@ terraform {
 }
 
 // Names are calculated as follows:
-// ${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}
+// ${terraform.workspace}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}
 // This means:
-//   name_prefix + name (if count = 1)
-//   name_prefix + name + "-" + index (if count > 1)
+//   workspace + name (if count = 1)
+//   workspace + name + "-" + index (if count > 1)
 
 resource "libvirt_volume" "main_disk" {
-  name             = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-main-disk"
-  base_volume_name = "${var.base_configuration["use_shared_resources"] ? "" : var.base_configuration["name_prefix"]}baseimage"
+  name             = "${terraform.workspace}-${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-main-disk"
+  base_volume_name = "${var.base_configuration["use_shared_resources"] ? "" : terraform.workspace}-baseimage"
   pool             = "${var.base_configuration["pool"]}"
   count            = "${var.count}"
 }
 
 resource "libvirt_volume" "hana_disk" {
-  name  = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-hana-disk"
+  name  = "${terraform.workspace}-${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}-hana-disk"
   pool  = "${var.base_configuration["pool"]}"
   count = "${var.count}"
   size  = "${var.hana_disk_size}"
 }
 
 resource "libvirt_domain" "domain" {
-  name       = "${var.base_configuration["name_prefix"]}${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}"
+  name       = "${terraform.workspace}-${var.name}${var.count > 1 ? "-${count.index  + 1}" : ""}"
   memory     = "${var.memory}"
   vcpu       = "${var.vcpu}"
   running    = "${var.running}"

--- a/libvirt/terraform/modules/sbd/main.tf
+++ b/libvirt/terraform/modules/sbd/main.tf
@@ -1,5 +1,5 @@
 resource "libvirt_volume" "sbd" {
-  name = "${var.base_configuration["name_prefix"]}-sbd.raw"
+  name = "${terraform.workspace}-sbd.raw"
   pool = "${var.base_configuration["pool"]}"
   size = "${var.sbd_disk_size}"
 

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -13,11 +13,6 @@ variable "iprange" {
   default     = "192.168.106.0/24"
 }
 
-variable "name_prefix" {
-  description = "Prefix of the deployment VM, network and disks"
-  default     = "hanatest"
-}
-
 variable "sap_inst_media" {
   description = "URL of the NFS share where the SAP software installer is stored. This media shall be mounted in /root/sap_inst"
   type        = "string"


### PR DESCRIPTION
Until now the resources were not named using the workspace name. Now, `name_prefix` variable is changed to use the current workspace as in the other providers