### PR TITLE
Fix iscsi-data disk name on GCE

### DIFF
--- a/gcp/terraform_salt/disks.tf
+++ b/gcp/terraform_salt/disks.tf
@@ -1,5 +1,5 @@
 resource "google_compute_disk" "iscsi_data" {
-  name = "iscsi-data"
+  name = "${terraform.workspace}-${var.name}-iscsi-data"
   type = "pd-standard"
   size = "10"
   zone = "${element(data.google_compute_zones.available.names, count.index)}"


### PR DESCRIPTION
iSCSI data disk should be prefixed with the workspace name like other resources.