### PR TITLE
Improve libvirt output to show ip addresses

### DIFF
--- a/libvirt/terraform/modules/host/main.tf
+++ b/libvirt/terraform/modules/host/main.tf
@@ -82,11 +82,11 @@ resource "libvirt_domain" "domain" {
 
 output "configuration" {
   value {
-    id       = "${join(",", libvirt_domain.domain.*.id)}"
-    hostname = "${join(",", libvirt_domain.domain.*.name)}"
+    id       = "${libvirt_domain.domain.*.id}"
+    hostname = "${libvirt_domain.domain.*.name}"
   }
 }
 
 output "addresses" {
-  value = "${join(",", flatten(libvirt_domain.domain.*.network_interface.0.addresses))}"
+  value = "${flatten(libvirt_domain.domain.*.network_interface.0.addresses)}"
 }

--- a/libvirt/terraform/modules/iscsi_server/main.tf
+++ b/libvirt/terraform/modules/iscsi_server/main.tf
@@ -76,7 +76,5 @@ output "configuration" {
 }
 
 output "addresses" {
-  // Returning only the addresses is not possible right now. Will be available in terraform 12
-  // https://bradcod.es/post/terraform-conditional-outputs-in-modules/
-  value = "${libvirt_domain.iscsisrv.*.network_interface}"
+  value = "${join(",", flatten(libvirt_domain.iscsisrv.*.network_interface.0.addresses))}"
 }

--- a/libvirt/terraform/outputs.tf
+++ b/libvirt/terraform/outputs.tf
@@ -8,6 +8,14 @@ output "cluster_nodes_id" {
   value = "${module.hana_node.configuration["id"]}"
 }
 
-output "cluster_nodes_hostname" {
+output "cluster_nodes_names" {
   value = "${module.hana_node.configuration["hostname"]}"
+}
+
+output "iscsisrv_ip" {
+  value = "${module.iscsi_server.addresses}"
+}
+
+output "iscsisrv_name" {
+  value = "${module.iscsi_server.configuration["hostname"]}"
 }

--- a/libvirt/terraform/outputs.tf
+++ b/libvirt/terraform/outputs.tf
@@ -1,6 +1,6 @@
 # Outputs: IP address and port where the service will be listening on
 
-output "cluster_nodes_addresses" {
+output "cluster_nodes_ip" {
   value = "${module.hana_node.addresses["addresses"]}"
 }
 


### PR DESCRIPTION
The new output is like:
```Apply complete! Resources: 9 added, 0 changed, 0 destroyed.

Outputs:

cluster_nodes_hostname = libvirt-sles12sp4-false-po-hana-1,libvirt-sles12sp4-false-po-hana-2
cluster_nodes_id = 36658331-795b-4480-880b-39bdeafb6dc8,7f1a5d9e-ee8d-47e1-b77a-970c68330a49
cluster_nodes_ip = 10.162.30.197,2620:113:80c0:80a0:10:162:30:d993,fe80::1c59:bff:fe4c:6adc,10.162.30.236,2620:113:80c0:80a0:10:162:31:c88d,fe80::845f:b2ff:fe8c:1da6
```
This way in the nodes ips only addresses are shown