### PR TITLE
Use public OS image on GCE

### DIFF
--- a/gcp/terraform_salt/README.md
+++ b/gcp/terraform_salt/README.md
@@ -52,7 +52,15 @@ gsutil mb gs://sles-images
 
 7. Upload the image you want to use with:
 
-`gsutil cp OS-Image-File-for-SLES4SAP-for-GCP.tar.gz gs://sles-images`
+```
+gsutil cp OS-Image-File-for-SLES4SAP-for-GCP.tar.gz gs://sles-images/OS-Image-File-for-SLES4SAP-for-GCP.tar.gz
+```
+
+8. Create a bootable image
+
+```
+gcloud compute images create OS-Image-File-for-SLES4SAP-for-GCP --source-uri gs://sles-images/OS-Image-File-for-SLES4SAP-for-GCP.tar.gz
+```
 
 ## Relevant files
 
@@ -99,11 +107,10 @@ In the file [terraform.tfvars](terraform.tfvars.example) there are a number of v
 * **public_key_location**: the path to your SSH public key.  This is used to access the instances.
 * **region**: the name of the desired region.
 * **sap_hana_deployment_bucket**: the name of the Google Storage bucket with the HANA installation files.
-* **images_path_bucket**: the name of the Google Storage bucket with the SLES image.
-* **sles4sap_os_image_file**: the name of the SLES4SAP image.
+* **sles4sap_boot_image**: the name of the SLES4SAP image.
 
-**Important:** The image used for the iSCSI server **must be at least SLES 15 version** since the iSCSI salt formula is not compatible with lower versions. Use the variable `sles_os_image_file` below.
-* **sles_os_image_file**: the name of the SLES image for the iSCSI server used for SBD stonith.
+**Important:** The image used for the iSCSI server **must be at least SLES 15 version** since the iSCSI salt formula is not compatible with lower versions. Use the variable `iscsi_server_boot_image` below.
+* **iscsi_server_boot_image**: the name of the SLES image for the iSCSI server used for SBD stonith.
 * **init_type**: variable controls what is deployed in the cluster nodes. Valid values are `all` (installs HANA and configures cluster), `skip-hana` (does not install HANA, but configures cluster). Defaults to `all`.
 * **iscsidev**: device used by the iSCSI server to provide LUNs.
 * **cluster_ssh_pub**: path to a custom ssh public key to upload to the nodes.

--- a/gcp/terraform_salt/disks.tf
+++ b/gcp/terraform_salt/disks.tf
@@ -20,19 +20,3 @@ resource "google_compute_disk" "node_data2" {
   size  = "20"
   zone  = "${element(data.google_compute_zones.available.names, count.index)}"
 }
-
-resource "google_compute_image" "sles_bootable_image" {
-  name = "${terraform.workspace}-${var.name}-sles"
-
-  raw_disk {
-    source = "${var.storage_url}/${var.images_path_bucket}/${var.sles_os_image_file}"
-  }
-}
-
-resource "google_compute_image" "sles4sap_bootable_image" {
-  name = "${terraform.workspace}-${var.name}-sles4sap"
-
-  raw_disk {
-    source = "${var.storage_url}/${var.images_path_bucket}/${var.sles4sap_os_image_file}"
-  }
-}

--- a/gcp/terraform_salt/instances.tf
+++ b/gcp/terraform_salt/instances.tf
@@ -25,7 +25,7 @@ resource "google_compute_instance" "iscsisrv" {
 
   boot_disk {
     initialize_params {
-      image = "${google_compute_image.sles_bootable_image.self_link}"
+      image = "${var.iscsi_server_boot_image}"
     }
 
     auto_delete = true
@@ -67,7 +67,7 @@ resource "google_compute_instance" "clusternodes" {
 
   boot_disk {
     initialize_params {
-      image = "${google_compute_image.sles4sap_bootable_image.self_link}"
+      image = "${var.sles4sap_boot_image}"
     }
 
     auto_delete = true

--- a/gcp/terraform_salt/terraform.tfvars.example
+++ b/gcp/terraform_salt/terraform.tfvars.example
@@ -25,14 +25,8 @@ region = "europe-west1"
 # The name of the GCP storage bucket in your project that contains the SAP HANA installation files
 sap_hana_deployment_bucket = "MyHanaBucket"
 
-# GCP bucket with SLES images
-images_path_bucket = "MySlesBucket"
-
 # Custom sles4sap image
-sles4sap_os_image_file = "OS-Image-File-for-SLES4SAP-for-GCP.tar.gz"
-
-# Custom iscsi server image
-sles_os_image_file = "OS-Image-File-for-SLES-for-GCP.tar.gz"
+sles4sap_boot_image = "MySles4SapImage"
 
 # Variable for init-nodes.tpl script. Can be all, skip-hana or skip-all
 init_type = "all"

--- a/gcp/terraform_salt/variables.tf
+++ b/gcp/terraform_salt/variables.tf
@@ -21,6 +21,11 @@ variable "machine_type" {
   default = "n1-highmem-8"
 }
 
+variable "iscsi_server_boot_image" {
+  type    = "string"
+  default = "suse-byos-cloud/sles-15-sap-byos"
+}
+
 variable "machine_type_iscsi_server" {
   type    = "string"
   default = "custom-1-2048"
@@ -30,16 +35,9 @@ variable "region" {
   type = "string"
 }
 
-variable "images_path_bucket" {
+variable "sles4sap_boot_image" {
   type = "string"
-}
-
-variable "sles4sap_os_image_file" {
-  type = "string"
-}
-
-variable "sles_os_image_file" {
-  type = "string"
+  default = "suse-byos-cloud/sles-15-sap-byos"
 }
 
 variable "storage_url" {


### PR DESCRIPTION
We currently use the same image provided for SAP nodes for the iSCSI server, which is not really needed.

This commit modify this to use a public OS image, by default the SLES4SAP-15 image.

An improvement could be to use a non-SAP image but we will need to add/use another regcode for this image.

These changes have been successfully tested.