### PR TITLE
Refresh zypper repos not only on libvirt

### DIFF
--- a/salt/default/init.sls
+++ b/salt/default/init.sls
@@ -11,10 +11,4 @@ include:
 {% if grains['provider'] == 'libvirt' %}
   - default.timezone
   - default.auth_keys
-refresh_repos:
-  cmd.run:
-    - name: zypper --non-interactive --gpg-auto-import-keys refresh
-    - retry:
-        attempts: 3
-        interval: 15
 {% endif %}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -1,3 +1,11 @@
+{% if grains['os_family'] == 'Suse' %}
+refresh_repos:
+  cmd.run:
+    - name: zypper --non-interactive --gpg-auto-import-keys refresh
+    - retry:
+        attempts: 3
+        interval: 15
+{% endif %}
 {% if grains['additional_repos'] %}
 {% for label, url in grains['additional_repos'].items() %}
 {{ label }}_repo:


### PR DESCRIPTION
Zypper refresh in Salt code is only executed on libvirt but it can be useful to do this on all cloud provider.