### PR TITLE
Update the pre configuration states to support sle15sp1 (and bugfixing)

### DIFF
--- a/libvirt/terraform/README.md
+++ b/libvirt/terraform/README.md
@@ -21,7 +21,7 @@
 
 # Howto
 
-To deploy the cluster only the parameters of three files should be changed: 
+To deploy the cluster only the parameters of three files should be changed:
 
 * [main.tf](main.tf)
 
@@ -34,14 +34,14 @@ You can between following profiles:  performance optimized, cost optimized
 
 ___
 Performance optimized:
-   * [hana.sls](../../pillar_examples/libvirt/performance_optimized/hana.sls) 
+   * [hana.sls](../../pillar_examples/libvirt/performance_optimized/hana.sls)
    * [cluster.sls](../../pillar_examples/libvirt/performance_optimized/cluster.sls).
 
 ___
 
 Cost optimized:
 
-   * [hana.sls](../../pillar_examples/libvirt/cost_optimized/hana.sls) 
+   * [hana.sls](../../pillar_examples/libvirt/cost_optimized/hana.sls)
    * [cluster.sls](../../pillar_examples/libvirt/cost_optimized/cluster.sls).
 
 
@@ -66,6 +66,9 @@ additional_repos = {}
 shared_storage_type = "iscsi"
 iscsi_srv_ip = "192.168.XXX.Y+2"
 iscsi_image = "url-to-your-sles4sap-image" # sles15 or above
+
+# Monitoring system data
+monitoring_srv_ip = "192.168.XXX.Y+3"
 
 
 # Repository url used to install install HA/SAP deployment packages"
@@ -106,7 +109,7 @@ Have a look at  [specifications](#specifications) for more details.
 
 This project is mainly based in [sumaform](https://github.com/uyuni-project/sumaform/)
 
-Components: 
+Components:
 
 - **modules**: Terraform modules to deploy a basic two nodes SAP HANA environment.
 - **salt**: Salt provisioning states to configure the deployed machines with the
@@ -124,6 +127,7 @@ Besides that, the different kind of provisioners are available in this module. B
 - [hana_node](modules/hana_node): Specific SAP HANA node defintion. Basically it calls the
 host module with some particular updates.
 - [iscsi_server](modules/iscsi_server): Machine to host a iscsi target.
+- [monitoring](modules/monitoring): Machine to host the monitoring stack.
 - [sbd](modules/sbd): SBD device definition. Currently a shared disk.
 
 ### Salt modules
@@ -148,6 +152,7 @@ data.
 - **shared_storage_type**: Shared storage type between iscsi and KVM raw file shared disk. Available options: `iscsi` and `shared-disk`.
 - **iscsi_srv_ip**: IP address of the machine that will host the iscsi target (only used if `iscsi` is used as a shared storage for fencing)
 - **iscsi_image**: Source image of the machine hosting the iscsi target (sles15 or above) (only used if `iscsi` is used as a shared storage for fencing)
+- **monitoring_srv_ip**: IP address of the machine that will host the monitoring stack
 - **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 - **additional_repos**: Additional repos to add to the guest machines.
 - **scenario_type**: SAP HANA scenario type. Available options: `performance-optimized` and `cost-optimized`.
@@ -218,5 +223,5 @@ with elevated privileges: `sudo ls -Faihl /var/lib/libvirt/images/`
 #### Packages failures
 
 If some package installation fails during the salt provisioning, the
-most possible thing is that some repository is missing. 
+most possible thing is that some repository is missing.
 Add the new repository with the needed package and try again.

--- a/libvirt/terraform/doc/monitoring.md
+++ b/libvirt/terraform/doc/monitoring.md
@@ -1,11 +1,34 @@
 # Monitoring deploymenet for SHAP:
 
-The monitoring module will deploy and install all tool necessary to monitor your SHAP stack. (grafana, prometheus).
+The monitoring module will deploy and install the required tools (grafana, prometheus) to monitor your SHAP stack (SAP HANA, HA cluster, etc).
 
-The monitor module will need an extra VM. The packages are the same from Uyuny/Suse manager so we use the same pkg repository.
+The monitoring module will need an extra VM. The packages are the same from Uyuni/Suse manager, so we use the same pkg repository.
 
-The terraform module follow the same conventions as other modules
+The terraform module follows the same conventions as other modules
+
+# Enable the SAP HANA database exporters
+
+The SAP HANA database data is exported using the [hanadb_exporter](https://github.com/SUSE/hanadb_exporter) prometheus exporter.
+In order to enable the exporters for each HANA database the `hana` pillar entries must be modified.
+
+Here an example:
+
+```
+hana:
+  nodes:
+    - host: {{ grains['name_prefix'] }}01
+      sid: prd
+      instance: 00
+      password: YourPassword1234
+      # Any other additional data
+      exporter:
+        exposition_port: 8001 # http port where the data is exported
+        user: SYSTEM # HANA db user
+        password: YourPassword1234 # HANA db password
+```
+
+**Attention**: SAP HANA already uses some ports in the 8000 range (specifically the port 80{instance number} where instance number usually is '00').
 
 # Examples:
 
-For an example look at main.tf.example file and `monitoring` module
+For an example look at [main.tf](../main.tf) file and `monitoring` module.

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -75,7 +75,7 @@ module "monitoring" {
   count                  = 1
   vcpu                   = 4
   memory                 = 4095
-  host_ips               = "${var.host_ips}"
+  monitoring_srv_ip      = "${var.monitoring_srv_ip}"
   reg_code               = "${var.reg_code}"
   reg_email              = "${var.reg_email}"
   reg_additional_modules = "${var.reg_additional_modules}"

--- a/libvirt/terraform/modules/monitoring/main.tf
+++ b/libvirt/terraform/modules/monitoring/main.tf
@@ -10,7 +10,7 @@ module "monitoring" {
   additional_repos       = "${var.additional_repos}"
   additional_packages    = "${var.additional_packages}"
   public_key_location    = "${var.public_key_location}"
-  host_ips               = "${var.host_ips}"
+  host_ips               = "${list(var.monitoring_srv_ip)}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
 

--- a/libvirt/terraform/modules/monitoring/variables.tf
+++ b/libvirt/terraform/modules/monitoring/variables.tf
@@ -66,9 +66,9 @@ variable "background" {
   default     = false
 }
 
-variable "host_ips" {
-  description = "ip addresses to set to the nodes"
-  type        = "list"
+variable "monitoring_srv_ip" {
+  description = "monitoring server address"
+  type        = "string"
 }
 
 // Provider-specific variables

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -53,6 +53,11 @@ variable "iscsi_srv_ip" {
   default     = "192.168.106.17"
 }
 
+variable "monitoring_srv_ip" {
+  description = "monitoring server address"
+  type        = "string"
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   default     = ""

--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -31,6 +31,7 @@ cluster:
   configure:
     method: update
     template:
+      # When the package salt-standalone-formulas-configuration is finally released, only the first path will be used
       {% if grains['osrelease_info'][0] == 15 and grains['osrelease_info']|length > 1 and grains['osrelease_info'][1] >= 1 %}
       source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       {% else %}

--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -31,7 +31,11 @@ cluster:
   configure:
     method: update
     template:
+      {% if grains['osrelease_info'][0] == 15 and grains['osrelease_info']|length > 1 and grains['osrelease_info'][1] >= 1 %}
+      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
+      {% else %}
       source: /srv/salt/hana/templates/scale_up_resources.j2
+      {% endif %}
       parameters:
         sid: {{ hana.hana.nodes[0].sid }}
         instance: {{ hana.hana.nodes[0].instance }}

--- a/pillar_examples/automatic/hana.sls
+++ b/pillar_examples/automatic/hana.sls
@@ -29,6 +29,10 @@ hana:
           user_name: SYSTEM
           user_password: YourPassword1234
           database: SYSTEMDB
+      exporter:
+        exposition_port: 8001
+        user: SYSTEM
+        password: YourPassword1234
 
     - host: {{ grains['name_prefix'] }}02
       sid: prd
@@ -76,4 +80,8 @@ hana:
         {% endif %}
         system_user_password: YourPassword1234
         sapadm_password: YourPassword1234
+      exporter:
+        exposition_port: 8002
+        user: SYSTEM
+        password: YourPassword1234
     {% endif %}

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -13,7 +13,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
         instance: 00

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -13,7 +13,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
         instance: 00

--- a/pillar_examples/libvirt/cost_optimized/cluster.sls
+++ b/pillar_examples/libvirt/cost_optimized/cluster.sls
@@ -16,7 +16,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
         instance: 00

--- a/pillar_examples/libvirt/performance_optimized/cluster.sls
+++ b/pillar_examples/libvirt/performance_optimized/cluster.sls
@@ -16,7 +16,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2
+      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
         instance: 00

--- a/salt/deployment.sh
+++ b/salt/deployment.sh
@@ -1,13 +1,13 @@
 #!/bin/bash -xe
 
-salt-call --local --file-root=/root/salt/ \
+salt-call --local --file-root=/root/salt \
     --log-level=info \
     --log-file=/tmp/salt-pre-installation.log \
     --log-file-level=all \
     --retcode-passthrough \
     --force-color state.apply pre_installation || exit 1
 
-salt-call --local --file-root=/root/salt/ \
+salt-call --local \
     --pillar-root=/root/salt/pillar/ \
     --log-level=info \
     --log-file=/tmp/salt-deployment.log \

--- a/salt/hana_node/cluster_packages.sls
+++ b/salt/hana_node/cluster_packages.sls
@@ -1,6 +1,5 @@
 habootstrap-formula:
   pkg.installed:
-    - fromrepo: ha-factory
     - retry:
         attempts: 3
         interval: 15

--- a/salt/hana_node/hana_packages.sls
+++ b/salt/hana_node/hana_packages.sls
@@ -13,7 +13,6 @@ python3-shaptools:
 
 saphanabootstrap-formula:
   pkg.installed:
-    - fromrepo: ha-factory
     - retry:
         attempts: 3
         interval: 15

--- a/salt/pre_installation/init.sls
+++ b/salt/pre_installation/init.sls
@@ -1,5 +1,6 @@
 include:
   - pre_installation.ha_repos
+  - pre_installation.minion_configuration
   - pre_installation.packages
   {% if grains['provider'] == 'libvirt' %}
   - pre_installation.ip_workaround

--- a/salt/pre_installation/minion_configuration.sls
+++ b/salt/pre_installation/minion_configuration.sls
@@ -1,0 +1,14 @@
+backup-salt-configuration:
+  file.rename:
+    - name: /etc/salt/minion.backup
+    - source: /etc/salt/minion
+
+configure-file-roots:
+  file.append:
+    - name: /etc/salt/minion
+    - text: |
+        file_roots:
+          base:
+            - /srv/salt
+            - /usr/share/salt-formulas/states
+            - /root/salt

--- a/salt/pre_installation/packages.sls
+++ b/salt/pre_installation/packages.sls
@@ -1,18 +1,5 @@
 iscsi-formula:
   pkg.installed:
-    - fromrepo: ha-factory
     - retry:
         attempts: 3
         interval: 15
-
-move-iscsi-folder:
-  cmd.run:
-    - name: mv /srv/salt/iscsi /root/salt/
-    - unless: file.path_exists_glob('/root/salt/iscsi')
-
-{% if grains['role'] == 'iscsi_srv' %}
-/srv/salt:
-  file.absent:
-  - require:
-    - move-iscsi-folder
-{% endif %}


### PR DESCRIPTION
Salt formula sates are installed in different path beyond sle15sp1.

Besides that, some hardcoded repository names has been removed, as the packages might come from packageHub now the salt formulas are released there.