### PR TITLE
add node_exporter for nodes and sles15 only

### DIFF
--- a/libvirt/terraform/doc/monitoring.md
+++ b/libvirt/terraform/doc/monitoring.md
@@ -6,6 +6,13 @@ The monitoring module will need an extra VM. The packages are the same from Uyun
 
 The terraform module follows the same conventions as other modules
 
+
+By default each hana host will be monitored.
+
+If you want to disable monitoring for hosts, use:
+`monitoring_enabled: false`
+
+
 # Enable the SAP HANA database exporters
 
 The SAP HANA database data is exported using the [hanadb_exporter](https://github.com/SUSE/hanadb_exporter) prometheus exporter.

--- a/libvirt/terraform/doc/monitoring.md
+++ b/libvirt/terraform/doc/monitoring.md
@@ -6,8 +6,15 @@ The monitoring module will need an extra VM. The packages are the same from Uyun
 
 The terraform module follows the same conventions as other modules
 
+* mandatory:
 
-By default each hana host will be monitored.
+`monitored_services` this is a list containing the services to be monitored. Format: `HOST_IP:PORT`. Under the hood this var tell prometheus the IP and port where to scrape.
+
+See tfvars.example
+```
+monitored_services = ["192.168.110.X:8001", "192.168.110.X+1:8001", "192.168.110.X:9100", "192.168.110.X+1:9100"]
+```
+
 
 If you want to disable monitoring for hosts, use:
 `monitoring_enabled: false`

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -83,4 +83,5 @@ module "monitoring" {
   ha_sap_deployment_repo = "${var.ha_sap_deployment_repo}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
+  monitored_services     = "${var.monitored_services}"
 }

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -65,6 +65,7 @@ module "hana_node" {
   scenario_type          = "${var.scenario_type}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
+  monitoring_enabled     = "${var.monitoring_enabled}"
 }
 
 module "monitoring" {

--- a/libvirt/terraform/modules/hana_node/main.tf
+++ b/libvirt/terraform/modules/hana_node/main.tf
@@ -27,7 +27,7 @@ hana_fstype: ${var.hana_fstype}
 hana_inst_folder: ${var.hana_inst_folder}
 sap_inst_media: ${var.sap_inst_media}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
-
+monitoring_enabled: ${var.monitoring_enabled}
 EOF
 
   // Provider-specific variables

--- a/libvirt/terraform/modules/hana_node/variables.tf
+++ b/libvirt/terraform/modules/hana_node/variables.tf
@@ -130,3 +130,8 @@ variable "mac" {
   description = "a MAC address in the form AA:BB:CC:11:22:22"
   default     = ""
 }
+
+variable "monitoring_enabled" {
+  description = "enable the host to be monitored by exporters, e.g node_exporter"
+  default     = true
+}

--- a/libvirt/terraform/modules/host/salt_provisioner.tf
+++ b/libvirt/terraform/modules/host/salt_provisioner.tf
@@ -53,7 +53,6 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 authorized_keys: [${trimspace(file(var.base_configuration["public_key_location"]))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-monitoring_enabled: ${var.monitoring_enabled}
 ${var.grains}
 
 EOF

--- a/libvirt/terraform/modules/host/salt_provisioner.tf
+++ b/libvirt/terraform/modules/host/salt_provisioner.tf
@@ -53,7 +53,7 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 authorized_keys: [${trimspace(file(var.base_configuration["public_key_location"]))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-
+monitoring_enabled: ${var.monitoring_enabled}
 ${var.grains}
 
 EOF

--- a/libvirt/terraform/modules/host/variables.tf
+++ b/libvirt/terraform/modules/host/variables.tf
@@ -97,3 +97,8 @@ variable "additional_disk" {
   description = "disk block definition(s) to be added to this host"
   default     = []
 }
+
+variable "monitoring_enabled" {
+  description = "enable the host to be monitored by exporters, e.g node_exporter"
+  default     = true
+}

--- a/libvirt/terraform/modules/host/variables.tf
+++ b/libvirt/terraform/modules/host/variables.tf
@@ -97,8 +97,3 @@ variable "additional_disk" {
   description = "disk block definition(s) to be added to this host"
   default     = []
 }
-
-variable "monitoring_enabled" {
-  description = "enable the host to be monitored by exporters, e.g node_exporter"
-  default     = true
-}

--- a/libvirt/terraform/modules/monitoring/main.tf
+++ b/libvirt/terraform/modules/monitoring/main.tf
@@ -18,6 +18,7 @@ module "monitoring" {
 role: monitoring
 provider: libvirt
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
+monitored_services: [${join(", ", formatlist("'%s'", var.monitored_services))}]
 EOF
 
   // Provider-specific variables

--- a/libvirt/terraform/modules/monitoring/variables.tf
+++ b/libvirt/terraform/modules/monitoring/variables.tf
@@ -92,3 +92,8 @@ variable "cpu_model" {
   description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
   default     = ""
 }
+
+variable "monitored_services" {
+  description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
+  type        = "list"
+}

--- a/libvirt/terraform/terraform.tfvars.example
+++ b/libvirt/terraform/terraform.tfvars.example
@@ -34,3 +34,8 @@ ha_sap_deployment_repo = ""
 
 # Run provisioner execution in background
 #background = true
+
+
+# Monitoring:
+# add here HOST:PORT. In this example we monitor on same hosts different services
+monitored_services = ["192.168.110.X:8001", "192.168.110.X+1:8001", "192.168.110.X:9100", "192.168.110.X+1:9100"]

--- a/libvirt/terraform/terraform.tfvars.example
+++ b/libvirt/terraform/terraform.tfvars.example
@@ -39,3 +39,7 @@ ha_sap_deployment_repo = ""
 # Monitoring:
 # add here HOST:PORT. In this example we monitor on same hosts different services
 monitored_services = ["192.168.110.X:8001", "192.168.110.X+1:8001", "192.168.110.X:9100", "192.168.110.X+1:9100"]
+
+
+# by default monitoring is enabled, if you want to disable it on your node set to false
+# monitoring_enabled = false

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -116,3 +116,8 @@ variable "monitored_services" {
   description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
   type        = "list"
 }
+
+variable "monitoring_enabled" {
+  description = "enable the host to be monitored by exporters, e.g node_exporter"
+  default     = true
+}

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -111,3 +111,8 @@ variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   default     = false
 }
+
+variable "monitored_services" {
+  description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
+  type        = "list"
+}

--- a/salt/hana_node/init.sls
+++ b/salt/hana_node/init.sls
@@ -18,3 +18,6 @@ include:
   - hana_node.hana_packages
   - hana_node.cluster_packages
   - hana_node.formula
+  {% if grains['monitoring_enabled'] %}
+  - hana_node.monitoring
+  {% endif %}

--- a/salt/hana_node/monitoring.sls
+++ b/salt/hana_node/monitoring.sls
@@ -1,0 +1,40 @@
+server_monitoring_repo:
+ pkgrepo.managed:
+    - humanname: Server:SLE15:Monitoring
+    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/SLE_15/
+    - refresh: True
+    - gpgautoimport: True
+
+sle_15_update:
+ pkgrepo.managed:
+    - humanname: SLE15:Update
+    - baseurl: http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
+    - refresh: True
+    - gpgautoimport: True
+
+sle_15_pool:
+ pkgrepo.managed:
+    - humanname: SLE15:Pool
+    - baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
+    - refresh: True
+    - gpgautoimport: True
+
+prometheus_node_exporter:
+  pkg.installed:
+    - name: golang-github-prometheus-node_exporter
+    - require:
+      - pkgrepo: server_monitoring_repo
+      - pkgrepo: sle_15_update
+      - pkgrepo: sle_15_pool
+
+node_exporter_service:
+  service.running:
+    - name: prometheus-node_exporter
+    - enable: True
+    - restart: True
+    - require:
+      - pkg: prometheus_node_exporter
+      - pkgrepo: server_monitoring_repo
+      - pkgrepo: sle_15_update
+      - pkgrepo: sle_15_pool
+

--- a/salt/hana_node/monitoring.sls
+++ b/salt/hana_node/monitoring.sls
@@ -5,27 +5,11 @@ server_monitoring_repo:
     - refresh: True
     - gpgautoimport: True
 
-sle_15_update:
- pkgrepo.managed:
-    - humanname: SLE15:Update
-    - baseurl: http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
-    - refresh: True
-    - gpgautoimport: True
-
-sle_15_pool:
- pkgrepo.managed:
-    - humanname: SLE15:Pool
-    - baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
-    - refresh: True
-    - gpgautoimport: True
-
 prometheus_node_exporter:
   pkg.installed:
     - name: golang-github-prometheus-node_exporter
     - require:
       - pkgrepo: server_monitoring_repo
-      - pkgrepo: sle_15_update
-      - pkgrepo: sle_15_pool
 
 node_exporter_service:
   service.running:
@@ -35,6 +19,3 @@ node_exporter_service:
     - require:
       - pkg: prometheus_node_exporter
       - pkgrepo: server_monitoring_repo
-      - pkgrepo: sle_15_update
-      - pkgrepo: sle_15_pool
-

--- a/salt/monitoring/init.sls
+++ b/salt/monitoring/init.sls
@@ -7,27 +7,11 @@ server_monitoring_repo:
     - refresh: True
     - gpgautoimport: True
 
-sle_15_update:
- pkgrepo.managed:
-    - humanname: SLE15:Update
-    - baseurl: http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
-    - refresh: True
-    - gpgautoimport: True
-
-sle_15_pool:
- pkgrepo.managed:
-    - humanname: SLE15:Pool
-    - baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
-    - refresh: True
-    - gpgautoimport: True
-
 prometheus:
   pkg.installed:
     - name: golang-github-prometheus-prometheus
     - require:
       - pkgrepo: server_monitoring_repo
-      - pkgrepo: sle_15_update
-      - pkgrepo: sle_15_pool
 
 prometheus_shap_configuration:
   file.recurse:
@@ -51,8 +35,6 @@ grafana:
     - name: grafana
     - require:
       - pkgrepo: server_monitoring_repo
-      - pkgrepo: sle_15_update
-      - pkgrepo: sle_15_pool
 
 grafana_anonymous_login_configuration:
   file.blockreplace:

--- a/salt/monitoring/init.sls
+++ b/salt/monitoring/init.sls
@@ -1,20 +1,20 @@
 # TODO: this repo should detect the os itself and chooose right repo depending the os
 # for moment ok
-suse-manager-head-repo:
+server_monitoring_repo:
  pkgrepo.managed:
-    - humanname: Head:SLE15:Manager:Tools
-    - baseurl: http://download.suse.de/ibs/Devel:/Galaxy:/Manager:/Head:/SLE15-SUSE-Manager-Tools/SLE_15/
+    - humanname: Server:SLE15:Monitoring
+    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/SLE_15/
     - refresh: True
     - gpgautoimport: True
 
-sle-15-update:
+sle_15_update:
  pkgrepo.managed:
     - humanname: SLE15:Update
     - baseurl: http://download.suse.de/ibs/SUSE/Updates/SLE-Module-Basesystem/15/x86_64/update/
     - refresh: True
     - gpgautoimport: True
 
-sle-15-pool:
+sle_15_pool:
  pkgrepo.managed:
     - humanname: SLE15:Pool
     - baseurl: http://download.suse.de/ibs/SUSE/Products/SLE-Module-Basesystem/15/x86_64/product/
@@ -25,9 +25,9 @@ prometheus:
   pkg.installed:
     - name: golang-github-prometheus-prometheus
     - require:
-      - pkgrepo: suse-manager-head-repo
-      - pkgrepo: sle-15-update
-      - pkgrepo: sle-15-pool
+      - pkgrepo: server_monitoring_repo
+      - pkgrepo: sle_15_update
+      - pkgrepo: sle_15_pool
 
 prometheus_shap_configuration:
   file.recurse:
@@ -50,9 +50,9 @@ grafana:
   pkg.installed:
     - name: grafana
     - require:
-      - pkgrepo: suse-manager-head-repo
-      - pkgrepo: sle-15-update
-      - pkgrepo: sle-15-pool
+      - pkgrepo: server_monitoring_repo
+      - pkgrepo: sle_15_update
+      - pkgrepo: sle_15_pool
 
 grafana_anonymous_login_configuration:
   file.blockreplace:

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -3,13 +3,13 @@ global:
   scrape_interval: 10s # By default, scrape targets every 15 seconds.
   evaluation_interval: 5s
 
+{% if grains.get('monitored_services') %}
 scrape_configs:
   - job_name: 'hanadb'
     scrape_interval: 5s
     static_configs:
       # servive is an entry like : HOST_IP:PORT 192.XX.XX.1:8001
-      {% if grains.get['monitored_services'] %}
       {% for service in grains['monitored_services'] %}
       - targets: ['{{ service }}'] # service to be monitored
       {% endfor %}
-      {% endif %}
+{% endif %}

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -7,6 +7,7 @@ scrape_configs:
   - job_name: 'hanadb'
     scrape_interval: 5s
     static_configs:
-      {% for ip in grains['host_ips'] %}
-      - targets: ['{{ ip }}:8001'] # hanadb_exporter port TODO: we can improve this 
+      {% for ip in grains['monitored_hosts'] %}
+      - targets: ['{{ ip }}:8001'] # hanadb_exporter port
+      - targets: ['{{ ip }}:9100'] # node_exporter   
       {% endfor %}

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -8,6 +8,8 @@ scrape_configs:
     scrape_interval: 5s
     static_configs:
       # servive is an entry like : HOST_IP:PORT 192.XX.XX.1:8001
+      {% if grains.get['monitored_services'] %}
       {% for service in grains['monitored_services'] %}
       - targets: ['{{ service }}'] # service to be monitored
       {% endfor %}
+      {% endif %}

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -7,7 +7,7 @@ scrape_configs:
   - job_name: 'hanadb'
     scrape_interval: 5s
     static_configs:
-      {% for ip in grains['monitored_hosts'] %}
-      - targets: ['{{ ip }}:8001'] # hanadb_exporter port
-      - targets: ['{{ ip }}:9100'] # node_exporter   
+      # servive is an entry like : HOST_IP:PORT 192.XX.XX.1:8001
+      {% for service in grains['monitored_services'] %}
+      - targets: ['{{ service }}'] # service to be monitored
       {% endfor %}

--- a/salt/monitoring/provisioning/datasources/prometheus_localhost.yml
+++ b/salt/monitoring/provisioning/datasources/prometheus_localhost.yml
@@ -2,11 +2,11 @@
 apiVersion: 1
 
 deleteDatasources:
-  - name: Prometheus on localhost
+  - name: Prometheus SHAP
     orgId: 1
 
 datasources:
-- name: Prometheus on localhost
+- name: Prometheus SHAP
   type: prometheus
   access: proxy
   url: http://localhost:9090/

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -11,4 +11,5 @@ base:
  
   'role:monitoring':
     - match: grain
+    - default
     - monitoring


### PR DESCRIPTION
# Description:

- add `node_exporter service` to each host. This can be disabled with `monitoring_enabled option`, by default is set to True (enabled). The rationale behind this is that we will need to have other exporter, so a monitoring_enabled will just install them. It is not fine_grained but I think it should be ok, also in future we might move the node_exporter etc to formulas when the pkg repository are morestable. So I think for moment is pretty ok.

- add a mechanism to monitor multiple service, monitored_services. We have a list of HOST:PORT.
  see https://github.com/SUSE/ha-sap-terraform-deployments/pull/114/files#diff-20a93b26850139589fffe838def26807R41

- add repos pkg needed, also this `https://download.opensuse.org/repositories/server:/monitoring/SLE_15/` for monitoring

- add documentation needed.
