### PR TITLE
Minor fixup for iscsi partitioning and default repo requirement.

### DIFF
--- a/aws/terraform_salt/salt_provisioner.tf
+++ b/aws/terraform_salt/salt_provisioner.tf
@@ -55,20 +55,20 @@ ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 
 partitions:
   1:
-    start: 0
-    end: 1024
+    start: 1
+    end: 20%
   2:
-    start: 1025
-    end: 2048
+    start: 20%
+    end: 40%
   3:
-    start: 2049
-    end: 3072
+    start: 40%
+    end: 60%
   4:
-    start: 3073
-    end: 4096
+    start: 60%
+    end: 80%
   5:
-    start: 4097
-    end: 5120
+    start: 80%
+    end: 100%
 EOF
 
     destination = "/tmp/grains"

--- a/azure/terraform_salt/salt_provisioner.tf
+++ b/azure/terraform_salt/salt_provisioner.tf
@@ -55,20 +55,20 @@ ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 
 partitions:
   1:
-    start: 0
-    end: 1024
+    start: 1
+    end: 20%
   2:
-    start: 1025
-    end: 2048
+    start: 20%
+    end: 40%
   3:
-    start: 2049
-    end: 3072
+    start: 40%
+    end: 60%
   4:
-    start: 3073
-    end: 4096
+    start: 60%
+    end: 80%
   5:
-    start: 4097
-    end: 5120
+    start: 80%
+    end: 100%
  EOF
 
     destination = "/tmp/grains"

--- a/gcp/terraform_salt/salt_provisioner.tf
+++ b/gcp/terraform_salt/salt_provisioner.tf
@@ -55,20 +55,20 @@ ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 
 partitions:
   1:
-    start: 0
-    end: 1024
+    start: 1
+    end: 20%
   2:
-    start: 1025
-    end: 2048
+    start: 20%
+    end: 40%
   3:
-    start: 2049
-    end: 3072
+    start: 40%
+    end: 60%
   4:
-    start: 3073
-    end: 4096
+    start: 60%
+    end: 80%
   5:
-    start: 4097
-    end: 5120
+    start: 80%
+    end: 100%
  EOF
 
     destination = "/tmp/grains"

--- a/libvirt/terraform/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/terraform/modules/iscsi_server/salt_provisioner.tf
@@ -47,20 +47,20 @@ ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 
 partitions:
   1:
-    start: 0
-    end: 1024
+    start: 1
+    end: 20%
   2:
-    start: 1025
-    end: 2048
+    start: 20%
+    end: 40%
   3:
-    start: 2049
-    end: 3072
+    start: 40%
+    end: 60%
   4:
-    start: 3073
-    end: 4096
+    start: 60%
+    end: 80%
   5:
-    start: 4097
-    end: 5120
+    start: 80%
+    end: 100%
 EOF
 
     destination = "/tmp/grains"

--- a/salt/default/pkgs.sls
+++ b/salt/default/pkgs.sls
@@ -6,5 +6,5 @@ install_additional_packages:
       - {{ package }}
 {% endfor %}
     - require:
-      - sls: repos
+      - sls: default.repos
 {% endif %}


### PR DESCRIPTION
Two minor fixes for:
+ fix the `repos` requirement in `pkgs.sls` with folder name *default*

+ Change start from `0` to `1` to make partition aligned, also use percentage instead of fixed position.