### PR TITLE
Change qa_mode as a boolean

### DIFF
--- a/aws/terraform_salt/terraform.tfvars.example
+++ b/aws/terraform_salt/terraform.tfvars.example
@@ -79,8 +79,8 @@ ha_sap_deployment_repo = ""
 
 # QA variables
 
-# Define if the deployement is using for testing purpose
+# Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-#qa_mode = "true"
+# true or false (default)
+#qa_mode = false

--- a/aws/terraform_salt/variables.tf
+++ b/aws/terraform_salt/variables.tf
@@ -183,6 +183,5 @@ variable "background" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
-  type        = "string"
-  default     = "false"
+  default     = false
 }

--- a/azure/terraform_salt/terraform.tfvars.example
+++ b/azure/terraform_salt/terraform.tfvars.example
@@ -102,5 +102,5 @@ ha_sap_deployment_repo = ""
 # Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-#qa_mode = "false"
+# true or false (default)
+#qa_mode = false

--- a/azure/terraform_salt/variables.tf
+++ b/azure/terraform_salt/variables.tf
@@ -141,6 +141,5 @@ variable "background" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
-  type        = "string"
-  default     = "false"
+  default     = false
 }

--- a/gcp/terraform_salt/terraform.tfvars.example
+++ b/gcp/terraform_salt/terraform.tfvars.example
@@ -84,5 +84,5 @@ ha_sap_deployment_repo = ""
 # Define if the deployment is using for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
-# true or false
-#qa_mode = "false"
+# true or false (default)
+#qa_mode = false

--- a/gcp/terraform_salt/variables.tf
+++ b/gcp/terraform_salt/variables.tf
@@ -185,6 +185,5 @@ variable "background" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
-  type        = "string"
-  default     = "false"
+  default     = false
 }

--- a/libvirt/terraform/modules/iscsi_server/variables.tf
+++ b/libvirt/terraform/modules/iscsi_server/variables.tf
@@ -100,6 +100,5 @@ variable "additional_disk" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
-  type        = "string"
-  default     = "false"
+  default     = false
 }

--- a/libvirt/terraform/terraform.tfvars.example
+++ b/libvirt/terraform/terraform.tfvars.example
@@ -35,11 +35,17 @@ ha_sap_deployment_repo = ""
 # Run provisioner execution in background
 #background = true
 
-
 # Monitoring:
 # add here HOST:PORT. In this example we monitor on same hosts different services
 monitored_services = ["192.168.110.X:8001", "192.168.110.X+1:8001", "192.168.110.X:9100", "192.168.110.X+1:9100"]
 
-
 # by default monitoring is enabled, if you want to disable it on your node set to false
 # monitoring_enabled = false
+
+# QA variables
+
+# Define if the deployement is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false
+#qa_mode = false

--- a/salt/default/registration.sls
+++ b/salt/default/registration.sls
@@ -1,4 +1,4 @@
-{% if grains['qa_mode']|default(false) is sameas false %}
+{% if not grains.get('qa_mode') %}
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:

--- a/salt/hana_node/hana_packages.sls
+++ b/salt/hana_node/hana_packages.sls
@@ -1,4 +1,4 @@
-{% if grains['qa_mode']|default(false) is sameas true %}
+{% if grains.get('qa_mode') %}
 {% if grains['pythonversion'][0] == 2 %}
 python-shaptools:
 {% else %}

--- a/salt/iscsi_srv/init.sls
+++ b/salt/iscsi_srv/init.sls
@@ -2,7 +2,7 @@ include:
   - iscsi_srv.parted
   - iscsi_srv.iscsi_kernel_mod
   - iscsi.target
-{% if grains['qa_mode']|default(false) is sameas true %}
+{% if grains.get('qa_mode') %}
   - iscsi_srv.qa_iscsi
 {% else %}
   # Workaround to restart targetcli service

--- a/salt/iscsi_srv/qa_iscsi.sls
+++ b/salt/iscsi_srv/qa_iscsi.sls
@@ -1,4 +1,4 @@
-{% if grains['qa_mode']|default(false) is sameas true %}
+{% if grains.get('qa_mode') %}
 /etc/target/saveconfig.json:
   file.managed:
     - source: salt://iscsi_srv/files/qa_conf/saveconfig.json


### PR DESCRIPTION
Using "true" and "false" as a string could be misunderstand.
This PR changes qa_mode variable from a string to a boolean type.

**Tests:**
AWS: OK
Azure: OK
GCP: OK
