### PR TITLE
Improve the registration process to be optional

### DIFF
--- a/aws/terraform_salt/salt_provisioner.tf
+++ b/aws/terraform_salt/salt_provisioner.tf
@@ -132,6 +132,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+install_salt_minion: ${var.install_salt_minion}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}

--- a/aws/terraform_salt/terraform.tfvars.example
+++ b/aws/terraform_salt/terraform.tfvars.example
@@ -77,6 +77,10 @@ ha_sap_deployment_repo = ""
 # Run provisioner execution in background
 #background = true
 
+# Enable salt-minion installation from SCC. Some cloud images don't bring this package pre-installed.
+# WARNING: This flag requires the usage of `reg_code`
+# install_salt_minion = true
+
 # QA variables
 
 # Define if the deployment is using for testing purpose

--- a/aws/terraform_salt/variables.tf
+++ b/aws/terraform_salt/variables.tf
@@ -179,6 +179,11 @@ variable "background" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}
+
 # Specific QA variables
 
 variable "qa_mode" {

--- a/azure/terraform_salt/salt_provisioner.tf
+++ b/azure/terraform_salt/salt_provisioner.tf
@@ -129,6 +129,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+install_salt_minion: ${var.install_salt_minion}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}

--- a/azure/terraform_salt/terraform.tfvars.example
+++ b/azure/terraform_salt/terraform.tfvars.example
@@ -97,6 +97,10 @@ ha_sap_deployment_repo = ""
 # Run provisioner execution in background
 #background = true
 
+# Enable salt-minion installation from SCC. Some cloud images don't bring this package pre-installed.
+# WARNING: This flag requires the usage of `reg_code`
+# install_salt_minion = true
+
 # QA variables
 
 # Define if the deployment is using for testing purpose

--- a/azure/terraform_salt/variables.tf
+++ b/azure/terraform_salt/variables.tf
@@ -137,6 +137,11 @@ variable "background" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}
+
 # Specific QA variables
 
 variable "qa_mode" {

--- a/gcp/terraform_salt/salt_provisioner.tf
+++ b/gcp/terraform_salt/salt_provisioner.tf
@@ -133,6 +133,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+install_salt_minion: ${var.install_salt_minion}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}

--- a/gcp/terraform_salt/terraform.tfvars.example
+++ b/gcp/terraform_salt/terraform.tfvars.example
@@ -79,6 +79,10 @@ ha_sap_deployment_repo = ""
 # Run provisioner execution in background
 #background = true
 
+# Enable salt-minion installation from SCC. Some cloud images don't bring this package pre-installed.
+# WARNING: This flag requires the usage of `reg_code`
+# install_salt_minion = true
+
 # QA variables
 
 # Define if the deployment is using for testing purpose

--- a/gcp/terraform_salt/variables.tf
+++ b/gcp/terraform_salt/variables.tf
@@ -181,6 +181,11 @@ variable "background" {
   default     = false
 }
 
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}
+
 # Specific QA variables
 
 variable "qa_mode" {

--- a/libvirt/terraform/main.tf
+++ b/libvirt/terraform/main.tf
@@ -37,6 +37,7 @@ module "iscsi_server" {
   ha_sap_deployment_repo = "${var.ha_sap_deployment_repo}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
+  install_salt_minion    = "${var.install_salt_minion}"
 }
 
 module "hana_node" {
@@ -66,6 +67,7 @@ module "hana_node" {
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
   monitoring_enabled     = "${var.monitoring_enabled}"
+  install_salt_minion    = "${var.install_salt_minion}"
 }
 
 module "monitoring" {
@@ -85,4 +87,5 @@ module "monitoring" {
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
   monitored_services     = "${var.monitored_services}"
+  install_salt_minion    = "${var.install_salt_minion}"
 }

--- a/libvirt/terraform/modules/hana_node/main.tf
+++ b/libvirt/terraform/modules/hana_node/main.tf
@@ -13,6 +13,7 @@ module "hana_node" {
   host_ips               = "${var.host_ips}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
+  install_salt_minion    = "${var.install_salt_minion}"
 
   grains = <<EOF
 

--- a/libvirt/terraform/modules/hana_node/variables.tf
+++ b/libvirt/terraform/modules/hana_node/variables.tf
@@ -130,3 +130,8 @@ variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   default     = true
 }
+
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}

--- a/libvirt/terraform/modules/host/salt_provisioner.tf
+++ b/libvirt/terraform/modules/host/salt_provisioner.tf
@@ -53,6 +53,7 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 authorized_keys: [${trimspace(file(var.base_configuration["public_key_location"]))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
+install_salt_minion: ${var.install_salt_minion}
 ${var.grains}
 
 EOF

--- a/libvirt/terraform/modules/host/variables.tf
+++ b/libvirt/terraform/modules/host/variables.tf
@@ -92,3 +92,8 @@ variable "additional_disk" {
   description = "disk block definition(s) to be added to this host"
   default     = []
 }
+
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}

--- a/libvirt/terraform/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/terraform/modules/iscsi_server/salt_provisioner.tf
@@ -44,6 +44,7 @@ reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_addi
 additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
+install_salt_minion: ${var.install_salt_minion}
 
 partitions:
   1:

--- a/libvirt/terraform/modules/iscsi_server/variables.tf
+++ b/libvirt/terraform/modules/iscsi_server/variables.tf
@@ -91,6 +91,11 @@ variable "additional_disk" {
   default     = []
 }
 
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}
+
 # Specific QA variables
 
 variable "qa_mode" {

--- a/libvirt/terraform/modules/monitoring/main.tf
+++ b/libvirt/terraform/modules/monitoring/main.tf
@@ -13,6 +13,7 @@ module "monitoring" {
   host_ips               = "${list(var.monitoring_srv_ip)}"
   provisioner            = "${var.provisioner}"
   background             = "${var.background}"
+  install_salt_minion    = "${var.install_salt_minion}"
 
   grains = <<EOF
 role: monitoring

--- a/libvirt/terraform/modules/monitoring/variables.tf
+++ b/libvirt/terraform/modules/monitoring/variables.tf
@@ -92,3 +92,8 @@ variable "monitored_services" {
   description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
   type        = "list"
 }
+
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}

--- a/libvirt/terraform/terraform.tfvars.example
+++ b/libvirt/terraform/terraform.tfvars.example
@@ -42,6 +42,10 @@ monitored_services = ["192.168.110.X:8001", "192.168.110.X+1:8001", "192.168.110
 # by default monitoring is enabled, if you want to disable it on your node set to false
 # monitoring_enabled = false
 
+# Enable salt-minion installation from SCC. Some cloud images don't bring this package pre-installed.
+# WARNING: This flag requires the usage of `reg_code`
+# install_salt_minion = true
+
 # QA variables
 
 # Define if the deployement is using for testing purpose

--- a/libvirt/terraform/variables.tf
+++ b/libvirt/terraform/variables.tf
@@ -121,3 +121,8 @@ variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   default     = true
 }
+
+variable "install_salt_minion" {
+  description = "Trigger a system registration to install salt-minion package and then de-register"
+  default     = true
+}

--- a/salt/salt_provisioner_script.tpl
+++ b/salt/salt_provisioner_script.tpl
@@ -4,9 +4,13 @@ mv /tmp/salt /root || true
 
 # SCC Registration to install salt-minion
 
+# The iSCSI server won't be de-registered as it needs to install some additional packages.
 if grep -q 'role: iscsi_srv' /tmp/grains; then
   sh /root/salt/install-salt-minion.sh -r ${regcode}
-elif [[ ! -e /usr/bin/salt-minion ]]; then
+
+# System is registered to install salt-minion and de-registered afterwards
+# if the variable install_salt_minion is true
+elif grep -q 'install_salt_minion: 1' /tmp/grains; then
   sh /root/salt/install-salt-minion.sh -d -r ${regcode}
 fi
 


### PR DESCRIPTION
Now we (QA) have public cloud images with salt-minion pre-installed, so the registration process could be optional to let the user choose the proper way.
That's why this PR add the variable `install_salt_minion`.

To be the most clear as possible, a file is created in /tmp to know if the system was registered or not:
`register_to_install_salt` or `not_register_to_install_salt`
You could easily know in which scenario you are.

From a QA perspective, we prefer not to register the system.

**Tests:**
AWS: **OK with and without salt-minion pre-installed with SLE12SP4**
GCP: **OK with and without salt-minion pre-installed with SLE15**
Azure: **OK with and without salt-minion pre-installed with SLE15SP1**