### PR TITLE
Declare qamode variable for libvirt

### DIFF
--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -123,3 +123,7 @@ variable "monitoring_enabled" {
   default     = true
 }
 
+variable "qa_mode" {
+  description = "define qa mode (Disable extra packages outside images)"
+  default     = false
+}


### PR DESCRIPTION
# why this is needed?

I found out that the new terraform TF12 is more strict on variables.

In the libvirt CI we are passing qa_mode variable but this isn't defined/declared. 
TF12 is more strict on values and error out :(

```
11:40:24 Error: Value for undeclared variable
11:40:24 
11:40:24 A variable named "qa_mode" was assigned on the command line, but the root
11:40:24 module does not declare a variable of that name. To use this value, add a
11:40:24 "variable" block to the configuration.
11:40:24 
```

This pr will fix this problem on CI. It doesn't support qa-mode fully on libvirt, for this I don't have the time. But it is a good step to it for the future :)
