### PR TITLE
Make monitoring module indipendent from host

### DIFF
--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -49,11 +49,11 @@ module "hana_node" {
   hana_count             = 2
   vcpu                   = 4
   memory                 = 32678
+  host_ips               = var.host_ips
   hana_inst_folder       = var.hana_inst_folder
   sap_inst_media         = var.sap_inst_media
   hana_disk_size         = "68719476736"
   hana_fstype            = var.hana_fstype
-  host_ips               = var.host_ips
   shared_storage_type    = var.shared_storage_type
   sbd_disk_id            = module.sbd_disk.id
   iscsi_srv_ip           = var.iscsi_srv_ip
@@ -76,7 +76,6 @@ module "monitoring" {
   monitoring_count       = 1
   vcpu                   = 4
   memory                 = 4095
-  host_ips               = var.host_ips
   monitoring_srv_ip      = var.monitoring_srv_ip
   reg_code               = var.reg_code
   reg_email              = var.reg_email
@@ -87,4 +86,3 @@ module "monitoring" {
   background             = var.background
   monitored_services     = var.monitored_services
 }
-

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -76,6 +76,7 @@ module "monitoring" {
   monitoring_count       = 1
   vcpu                   = 4
   memory                 = 4095
+  host_ips               = var.host_ips
   monitoring_srv_ip      = var.monitoring_srv_ip
   reg_code               = var.reg_code
   reg_email              = var.reg_email

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -2,42 +2,79 @@ terraform {
   required_version = ">= 0.12"
 }
 
-module "monitoring" {
-  source = "../host"
 
-  base_configuration     = var.base_configuration
-  name                   = var.name
-  host_count             = var.monitoring_count
-  reg_code               = var.reg_code
-  reg_email              = var.reg_email
-  reg_additional_modules = var.reg_additional_modules
-  additional_repos       = var.additional_repos
-  additional_packages    = var.additional_packages
-  public_key_location    = var.public_key_location
-  host_ips               = [var.monitoring_srv_ip]
-  provisioner            = var.provisioner
-  background             = var.background
-
-  grains = <<EOF
-role: monitoring
-provider: libvirt
-ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
-monitored_services: [${join(", ", formatlist("'%s'", var.monitored_services))}]
-EOF
+resource "libvirt_volume" "main_disk" {
+  name             = "${terraform.workspace}-${var.name}${var.monitoring_count > 1 ? "-${count.index + 1}" : ""}-main-disk"
+  base_volume_name = var.base_configuration["use_shared_resources"] ? "" : "${terraform.workspace}-baseimage"
+  pool             = var.base_configuration["pool"]
+  count            = var.monitoring_count
+}
 
 
-  // Provider-specific variables
-  memory = 4096
-  vcpu = var.vcpu
-  mac = var.mac
+resource "libvirt_domain" "domain" {
+  name       = "${terraform.workspace}-${var.name}${var.monitoring_count > 1 ? "-${count.index + 1}" : ""}"
+  memory     = var.memory
+  vcpu       = var.vcpu
+  count      = var.monitoring_count
+  qemu_agent = true
+  dynamic "disk" {
+    for_each = [
+        {
+          "vol_id" = element(libvirt_volume.main_disk.*.id, count.index)
+        },
+      ]
+    content {
+      volume_id = disk.value.vol_id
+    }
+  }
+  network_interface {
+    wait_for_lease = true
+    network_name   = var.base_configuration["network_name"]
+    bridge         = var.base_configuration["bridge"]
+    mac            = var.mac
+  }
+
+  network_interface {
+    wait_for_lease = false
+    network_id     = var.base_configuration["isolated_network_id"]
+    hostname       = "${var.name}${var.monitoring_count > 1 ? "0${count.index + 1}" : ""}"
+    addresses      = [element(var.host_ips, count.index)]
+  }
+
+  xml {
+    xslt = file("modules/host/shareable.xsl")
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  console {
+    type        = "pty"
+    target_type = "virtio"
+    target_port = "1"
+  }
+
+  graphics {
+    type        = "spice"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cpu = {
+    mode = "host-passthrough"
+  }
 }
 
 output "configuration" {
-  value = module.monitoring.configuration
+  value = {
+    id       = libvirt_domain.domain.*.id
+    hostname = libvirt_domain.domain.*.name
+  }
 }
 
-output "addresses" {
-  value = {
-    addresses = module.monitoring.addresses
-  }
+ output "addresses" {
+   value = flatten(libvirt_domain.domain.*.network_interface.0.addresses)
 }

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -1,0 +1,65 @@
+# Template file to launch the salt provisioning script
+data "template_file" "salt_provisioner" {
+  template = file("../salt/salt_provisioner_script.tpl")
+
+  vars = {
+    regcode = var.reg_code
+  }
+}
+
+resource "null_resource" "host_provisioner" {
+  count = var.provisioner == "salt" ? length(libvirt_domain.domain) : 0
+
+  triggers = {
+    cluster_instance_ids = join(",", libvirt_domain.domain.*.id)
+  }
+
+  connection {
+    host = element(
+      libvirt_domain.domain.*.network_interface.0.addresses.0,
+      count.index,
+    )
+    user     = "root"
+    password = "linux"
+  }
+
+  provisioner "file" {
+    source      = "../salt"
+    destination = "/tmp"
+  }
+
+  provisioner "file" {
+    content     = data.template_file.salt_provisioner.rendered
+    destination = "/tmp/salt_provisioner.sh"
+  }
+
+  provisioner "file" {
+    content = <<EOF
+
+name_prefix: ${terraform.workspace}-${var.name}
+hostname: ${terraform.workspace}-${var.name}${var.monitoring_count > 1 ? "0${count.index + 1}" : ""}
+domain: ${var.base_configuration["domain"]}
+timezone: ${var.base_configuration["timezone"]}
+reg_code: ${var.reg_code}
+reg_email: ${var.reg_email}
+reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
+additional_repos: {${join(", ",formatlist("'%s': '%s'",keys(var.additional_repos),values(var.additional_repos),),)}}
+additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
+authorized_keys: [${trimspace(file(var.base_configuration["public_key_location"]))},${trimspace(file(var.public_key_location))}]
+host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
+host_ip: ${element(var.host_ips, count.index)}
+role: monitoring
+provider: libvirt
+ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
+monitored_services: [${join(", ", formatlist("'%s'", var.monitored_services))}]
+EOF
+      destination = "/tmp/grains"
+      }
+
+      provisioner "remote-exec" {
+        inline = [
+          "${var.background ? "nohup" : ""} sh /tmp/salt_provisioner.sh > /tmp/provisioning.log ${var.background ? "&" : ""}",
+          "return_code=$? && sleep 1 && exit $return_code",
+        ] # Workaround to let the process start in background properly
+      }
+    }

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -74,7 +74,7 @@ variable "monitoring_srv_ip" {
 
 variable "memory" {
   description = "RAM memory in MiB"
-  default     = 512
+  default     = 4096
 }
 
 variable "mac" {
@@ -91,4 +91,7 @@ variable "monitored_services" {
   description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
   type        = list(string)
 }
-
+variable "host_ips" {
+  description = "ip addresses to set to the nodes"
+  type        = list(string)
+}

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -91,7 +91,3 @@ variable "monitored_services" {
   description = "HOST:PORT of service you want to monitor, it can contain same host with different ports number (diff services)"
   type        = list(string)
 }
-variable "host_ips" {
-  description = "ip addresses to set to the nodes"
-  type        = list(string)
-}

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -25,6 +25,6 @@ output "monitoring_hostname" {
 }
 
 output "monitoring_ip" {
-  value = module.monitoring.addresses["addresses"]
+  value = module.monitoring.addresses
 }
 


### PR DESCRIPTION
# Checklist:

- [x] This pr was tested by a deployment. Everything OK. 


# Info:

This PR is part of the RFC i wrote. (https://confluence.suse.com/pages/viewpage.action?pageId=302186655)


This PR will make the monitoring module indipendent from HANA/and host disks, so we don't have any dependency from other modules.


I will test this shortly and removing the WIP. Should work already but I will deploy for safety
fix #123
