### PR TITLE
FIX: inject the develmode grain in salt-provisioner

### DIFF
--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -40,6 +40,7 @@ hostname: ${terraform.workspace}-${var.name}${var.hana_count > 1 ? "0${count.ind
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}
+devel_mode: ${var.devel_mode}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
 additional_repos: {${join(", ",formatlist("'%s': '%s'",keys(var.additional_repos),values(var.additional_repos),),)}}


### PR DESCRIPTION
# current behaviour:

currently the variable develmode is set but is not injected via a grain (salt-provisioner.tf)

This pr fix this.

Also, I think that we don't need a global variable. We just make a variable belong to `hana_node` module and we set it to `main.tf`. 

In future we will need to remove this  but for moment let's get it working :)