### PR TITLE
remove additional_repos variable

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -154,7 +154,6 @@ In [terraform.tfvars](terraform.tfvars.example) there are a number of variables 
 
  For more information about registration, check the ["Registering SUSE Linux Enterprise and Managing Modules/Extensions"](https://www.suse.com/documentation/sles-15/book_sle_deployment/data/cha_register_sle.html) guide.
 
-* **additional_repos**: Additional repos to add to the guest machines.
 * **additional_packages**: Additional packages to add to the guest machines.
 * **hosts_ips**: Each cluster nodes IP address (sequential order). Mandatory to have a generic `/etc/hosts` file.
 

--- a/aws/salt_provisioner.tf
+++ b/aws/salt_provisioner.tf
@@ -45,7 +45,6 @@ qa_mode: ${var.qa_mode}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}
-additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 
@@ -132,7 +131,6 @@ qa_mode: ${var.qa_mode}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}
-additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 EOF

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -140,11 +140,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default     = {}
-}
-
 variable "additional_packages" {
   description = "extra packages which should be installed"
   default     = []

--- a/azure/README.md
+++ b/azure/README.md
@@ -104,7 +104,6 @@ In the file [terraform.tfvars.example](terraform.tfvars.example) there are a num
 
  For more information about registration, check the ["Registering SUSE Linux Enterprise and Managing Modules/Extensions"](https://www.suse.com/documentation/sles-15/book_sle_deployment/data/cha_register_sle.html) guide.
 
-* **additional_repos**: Additional repos to add to the guest machines.
  * **additional_packages**: Additional packages to add to the guest machines.
  * **hosts_ips**: Each cluster nodes IP address (sequential order). Mandatory to have a generic `/etc/hosts` file.
 

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -51,14 +51,6 @@ reg_additional_modules: {${join(
       keys(var.reg_additional_modules),
       values(var.reg_additional_modules),
     ),
-    )}}
-additional_repos: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_repos),
-      values(var.additional_repos),
-    ),
 )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
@@ -152,14 +144,6 @@ reg_additional_modules: {${join(
       "'%s': '%s'",
       keys(var.reg_additional_modules),
       values(var.reg_additional_modules),
-    ),
-    )}}
-additional_repos: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_repos),
-      values(var.additional_repos),
     ),
 )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -98,11 +98,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default     = {}
-}
-
 variable "additional_packages" {
   description = "extra packages which should be installed"
   default     = []

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -51,14 +51,6 @@ reg_additional_modules: {${join(
       keys(var.reg_additional_modules),
       values(var.reg_additional_modules),
     ),
-    )}}
-additional_repos: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_repos),
-      values(var.additional_repos),
-    ),
 )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
@@ -156,14 +148,6 @@ reg_additional_modules: {${join(
       "'%s': '%s'",
       keys(var.reg_additional_modules),
       values(var.reg_additional_modules),
-    ),
-    )}}
-additional_repos: {${join(
-    ", ",
-    formatlist(
-      "'%s': '%s'",
-      keys(var.additional_repos),
-      values(var.additional_repos),
     ),
 )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -131,11 +131,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default     = {}
-}
-
 variable "additional_packages" {
   description = "extra packages which should be installed"
   default     = []

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -100,7 +100,6 @@ data.
 - **monitoring_srv_ip**: IP address of the machine that will host the monitoring stack
 - **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 - **devel_mode**: Whether or not to install HA/SAP packages from ha_sap_deployment_repo
-- **additional_repos**: Additional repos to add to the guest machines.
 - **scenario_type**: SAP HANA scenario type. Available options: `performance-optimized` and `cost-optimized`.
 - **provisioner**: Select the desired provisioner to configure the nodes. Salt is used by default: [salt](../salt). Let it empty to disable the provisioning part.
 - **background**: Run the provisioning process in background finishing terraform execution.

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -62,7 +62,6 @@ module "hana_node" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
-  additional_repos       = var.additional_repos
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   devel_mode             = var.devel_mode
   scenario_type          = var.scenario_type
@@ -88,7 +87,6 @@ module "monitoring" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
-  additional_repos       = var.additional_repos
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   provisioner            = var.provisioner
   background             = var.background

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -43,7 +43,6 @@ reg_code: ${var.reg_code}
 devel_mode: ${var.devel_mode}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
-additional_repos: {${join(", ",formatlist("'%s': '%s'",keys(var.additional_repos),values(var.additional_repos),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -25,11 +25,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default     = {}
-}
-
 // hana
 variable "ha_sap_deployment_repo" {
   description = "Repository url used to install HA/SAP deployment packages"

--- a/libvirt/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/modules/iscsi_server/salt_provisioner.tf
@@ -41,7 +41,6 @@ qa_mode: ${var.qa_mode}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}
-additional_repos: {${join(", ", formatlist("'%s': '%s'", keys(var.additional_repos), values(var.additional_repos)))}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 

--- a/libvirt/modules/iscsi_server/variables.tf
+++ b/libvirt/modules/iscsi_server/variables.tf
@@ -34,11 +34,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "extra repositories in the form {label = url}"
-  default     = {}
-}
-
 variable "additional_packages" {
   description = "extra packages to install"
   default     = []

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -39,7 +39,6 @@ network_domain: ${var.network_domain}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
-additional_repos: {${join(", ",formatlist("'%s': '%s'",keys(var.additional_repos),values(var.additional_repos),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))},${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", [var.monitoring_srv_ip]))}]

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -54,11 +54,6 @@ variable "additional_packages" {
   default     = []
 }
 
-variable "additional_repos" {
-  description = "extra repositories used for installation {label = url}"
-  default     = {}
-}
-
 variable "ha_sap_deployment_repo" {
   description = "Repository url used to install HA/SAP deployment packages"
   type        = "string"

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -4,7 +4,6 @@ base_image = "url-to-your-sles4sap-image"
 name_prefix = "your-name"
 iprange = "192.168.XXX.Y/24"
 host_ips = ["192.168.XXX.Y", "192.168.XXX.Y+1"]
-additional_repos = {}
 
 # Shared storage type information
 shared_storage_type = "iscsi"

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -82,12 +82,6 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
-variable "additional_repos" {
-  description = "Map of the repositories to add to the images. Repo name = url"
-  type        = map(string)
-  default     = {}
-}
-
 # Repository url used to install HA/SAP deployment packages"
 # The latest RPM packages can be found at:
 # https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}

--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -6,13 +6,3 @@ refresh_repos:
         attempts: 3
         interval: 15
 {% endif %}
-{% if grains['additional_repos'] %}
-{% for label, url in grains['additional_repos'].items() %}
-{{ label }}_repo:
-  pkgrepo.managed:
-    - humanname: {{ label }}
-    - baseurl: {{ url }}
-    - priority: 120
-    - gpgcheck: 0
-{% endfor %}
-{% endif %}


### PR DESCRIPTION
we never used this variable and it can be tricky to manage.
An user can add always later additional repos after the deployment

I will test this PR just in case of but it should be already ok