### PR TITLE
fix devel_mode for deployment

### DIFF
--- a/azure/instances.tf
+++ b/azure/instances.tf
@@ -3,10 +3,11 @@
 # Availability set for the VMs
 
 resource "azurerm_availability_set" "myas" {
-  name                = "myas"
-  location            = var.az_region
-  resource_group_name = azurerm_resource_group.myrg.name
-  managed             = "true"
+  name                        = "myas"
+  location                    = var.az_region
+  resource_group_name         = azurerm_resource_group.myrg.name
+  managed                     = "true"
+  platform_fault_domain_count = 2
 
   tags = {
     workspace = terraform.workspace
@@ -132,9 +133,9 @@ resource "azurerm_virtual_machine" "clusternodes" {
 
 
 resource "azurerm_virtual_machine" "monitoring" {
-  name     = "${terraform.workspace}-monitoring"
-  location = var.az_region
-  resource_group_name = azurerm_resource_group.myrg.name
+  name                  = "${terraform.workspace}-monitoring"
+  location              = var.az_region
+  resource_group_name   = azurerm_resource_group.myrg.name
   network_interface_ids = [azurerm_network_interface.monitoring.id]
   availability_set_id   = azurerm_availability_set.myas.id
   vm_size               = "Standard_D2s_v3"
@@ -145,7 +146,7 @@ resource "azurerm_virtual_machine" "monitoring" {
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
   }
-  
+
   storage_image_reference {
     id        = azurerm_image.monitoring.0.id
     publisher = "SUSE"

--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -13,3 +13,10 @@ ha-factory-repo:
     - retry:
         attempts: 3
         interval: 15
+
+{% if grains.get('devel_mode') %}
+allow_all_vendor_changes:
+  file.append:
+    - name: /etc/zypp/zypp.conf
+    - text: solver.allowVendorChange = true
+{% endif %}

--- a/salt/pre_installation/ha_repos.sls
+++ b/salt/pre_installation/ha_repos.sls
@@ -20,3 +20,9 @@ allow_all_vendor_changes:
     - name: /etc/zypp/zypp.conf
     - text: solver.allowVendorChange = true
 {% endif %}
+
+refresh_repos:
+  cmd.run:
+    - name: zypper --non-interactive --gpg-auto-import-keys refresh
+    - requre:
+      - pkgrepo: ha-factory-repo

--- a/salt/pre_installation/packages.sls
+++ b/salt/pre_installation/packages.sls
@@ -3,3 +3,15 @@ iscsi-formula:
     - retry:
         attempts: 3
         interval: 15
+
+# with devel mode, vendor changes are allowed
+{% if grains.get('devel_mode') %}
+update_systems_packages_from_devel:
+  cmd.run:
+    - name: zypper --non-interactive --gpg-auto-import-keys update
+    - retry:
+        attempts: 3
+        interval: 15
+    - require:
+      - pkg: iscsi-formula
+{% endif %}


### PR DESCRIPTION
# what does this PR:

we had issues with devel_mode espcially with azure. but was a coincidence.

This pr will allow to safe update pkgs.



When we update the system in pre-install phase, this fix issues we have
encountered in Azure cloud, where the image had already some pkgs
installed like hawk-api-server.

If we now do a allow-vendor changes and zypper up in devel mode, if
there are already this pkgs we will update them, and fix the issues.

If the pkgs aren't installed, we will install them to latest since we allow the vendor changes.
