### PR TITLE
Fix sshkey documentation for AWS and GCP

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -13,7 +13,7 @@
 2) **Generate private and public keys for the cluster nodes with**
 
 ```
-mkdir provision/hana_node/files/sshkeys; ssh-keygen -t rsa -f provision/hana_node/files/sshkeys/cluster.id_rsa
+mkdir ../salt/hana_node/files/sshkeys; ssh-keygen -t rsa -f ../salt/hana_node/files/sshkeys/cluster.id_rsa
 ```
 
 The key files need to have same name as defined in [terraform.tfvars](terraform.tfvars.example)

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -91,10 +91,10 @@ These are the relevant files and what each provides:
 
 1. Rename [terraform.tfvars.example](terraform.tfvars.example) to *terraform.tfvars* and edit to suit your needs or use `terraform [-var VARIABLE=VALUE]...` to override defaults.
 
- Then, from your working directory, generate private and public keys for the cluster nodes with the following commands:
+ Then, from the gcp directory, generate private and public keys for the cluster nodes with the following commands:
 ```
- mkdir provision/hana_node/files/sshkeys; ssh-keygen -t rsa -f provision/hana_node/files/sshkeys/cluster.id_rsa
- ```
+mkdir ../salt/hana_node/files/sshkeys; ssh-keygen -t rsa -f ../salt/hana_node/files/sshkeys/cluster.id_rsa
+```
  The key files need to be named as you defined it in `terraform.tfvars` file.
 
 In the file [terraform.tfvars](terraform.tfvars.example) there are a number of variables that control what is deployed. Some of these variables are:


### PR DESCRIPTION
As the provision symlink was removed, we need to update documentations about where to generate sshkeys.