### PR TITLE
Use SSD disks for DATA in GCP

### DIFF
--- a/gcp/disks.tf
+++ b/gcp/disks.tf
@@ -8,7 +8,7 @@ resource "google_compute_disk" "iscsi_data" {
 resource "google_compute_disk" "node_data" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-data-${count.index}"
-  type  = "pd-standard"
+  type  = "pd-ssd"
   size  = var.init_type == "all" ? 60 : 30
   zone  = element(data.google_compute_zones.available.names, count.index)
 }
@@ -16,7 +16,7 @@ resource "google_compute_disk" "node_data" {
 resource "google_compute_disk" "node_data2" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-backup-${count.index}"
-  type  = "pd-standard"
+  type  = "pd-ssd"
   size  = "20"
   zone  = element(data.google_compute_zones.available.names, count.index)
 }


### PR DESCRIPTION
When I was doing benchmark tests in GCP, I noticed that we don't use SSD as DATA disks in GCP like we are doing in AWS.
This PR changes default DATA disks from pd-standard to pd-ssd.