### PR TITLE
Add option to set disk type and caching for HANA

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -134,6 +134,8 @@ In the file [terraform.tfvars.example](terraform.tfvars.example) there are a num
 * **hana_inst_master**: path to the storage account where SAP HANA installation files are stored.
 * **hana_fstype**: filesystem type used for HANA installation (xfs by default).
 * **instancetype**: SKU to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the VM.
+* **hana_data_disk_type**: disk type to use for HANA (Standard_LRS by default).
+* **hana_data_disk_caching**: caching mode for HANA disk, could be None, ReadOnly or ReadWrite (ReadWrite by default).
 * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
 * **az_region**: Azure region where to deploy the configuration.
 * **init-type**: initilization script parameter that controls what is deployed in the cluster nodes. Valid values are `all` (installs Hana and configures cluster), `skip-hana` (does not install Hana, but configures cluster) and `skip-cluster` (installs hana, but does not configure cluster). Defaults to `all`.

--- a/azure/instances.tf
+++ b/azure/instances.tf
@@ -100,10 +100,11 @@ resource "azurerm_virtual_machine" "clusternodes" {
 
   storage_data_disk {
     name              = "node-data-disk-${count.index}"
-    managed_disk_type = "Standard_LRS"
+    managed_disk_type = "${var.hana_data_disk_type}"
     create_option     = "Empty"
     lun               = 0
     disk_size_gb      = "60"
+    caching           = "${var.hana_data_disk_caching}"
   }
 
   os_profile {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -1,6 +1,12 @@
 # Instance type to use for the cluster nodes
 instancetype = "Standard_E4s_v3"
 
+# Disk type for HANA
+hana_data_disk_type = "StandardSSD_LRS"
+
+# Caching used for HANA disk
+hana_data_disk_caching = "ReadWrite"
+
 # Number of nodes in the cluster
 ninstances = "2"
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -20,6 +20,16 @@ variable "ninstances" {
   default = "2"
 }
 
+variable "hana_data_disk_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+
+variable "hana_data_disk_caching" {
+  type    = string
+  default = "ReadWrite"
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
When I was doing benchmark tests in Azure, I noticed that we don't use SSD as DATA disks in Azure like we are doing in other cloud providers.

This PR changes:

- Default DATA disks from `Standard_LRS` to `StandardSSD_LRS`.
Disk type could be set with `hana_data_disk_type` variable.

- New variable `hana_data_disk_caching` added to manage data disk caching.
Could be None, ReadOnly or ReadWrite (ReadWrite by default).