### PR TITLE
WIP: Add alerts for ha-metrics

### DIFF
--- a/salt/hana_node/monitoring.sls
+++ b/salt/hana_node/monitoring.sls
@@ -19,3 +19,18 @@ node_exporter_service:
     - require:
       - pkg: prometheus_node_exporter
       - pkgrepo: server_monitoring_repo
+
+prometheus_ha_cluster_exporter:
+  pkg.installed:
+    - name: prometheus-ha_cluster_exporter
+    - require:
+      - pkgrepo: server_monitoring_repo
+
+ha_cluster_exporter_service:
+  service.running:
+    - name: prometheus-ha_cluster_exporter
+    - enable: True
+    - restart: True
+    - require:
+      - pkg: prometheus_ha_cluster_exporter
+      - pkgrepo: server_monitoring_repo

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -36,6 +36,6 @@ scrape_configs:
     static_configs:
       - targets:
         {% for ip in grains['monitored_hosts'] %}
-        - "{{ ip }}:9001" # 9001: hawk-apiserver exporter port
+        - "{{ ip }}:9002" # 9002: ha_cluster_exporter metrics
         {% endfor %}
 {% endif %}

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -4,6 +4,15 @@ global:
   scrape_timeout: 5s
   evaluation_interval: 5s
 
+alerting:
+  alertmanagers:
+  - static_configs:
+    - targets:
+      - localhost:9093
+
+rule_files:
+    - /etc/prometheus/rules.yml
+
 {% if grains.get('monitored_hosts') %}
 scrape_configs:
   - job_name: hanadb
@@ -20,10 +29,8 @@ scrape_configs:
         - "{{ ip }}:9100" # 9100: node exporter port
         {% endfor %}
 
-
   - job_name: cluster
     metrics_path: /metrics
-    scheme: https
     tls_config:
       insecure_skip_verify: true
     static_configs:

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -31,8 +31,6 @@ scrape_configs:
 
   - job_name: cluster
     metrics_path: /metrics
-    tls_config:
-      insecure_skip_verify: true
     static_configs:
       - targets:
         {% for ip in grains['monitored_hosts'] %}

--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -1,13 +1,9 @@
 groups:
-
-# this is only a boostrap/initial alert to setup things
-- name: hana-node01-network-latency
+- name: primary-resource-saphana-down
   rules:
-  - alert: HighRequestLatency
-    expr: job:request_latency_seconds:mean5m{job=hanadb"} > 0.5
-    for: 10m
+  - alert: SAPHANAMasterResourcesDown
+    expr: absent(cluster_node_resources{resource_name="rsc_saphana_prd_hdb00",role="master"})
     labels:
       severity: page
     annotations:
-      summary: High request latency
-
+      summary: Primary SAP-HANA resource down


### PR DESCRIPTION
# Desc:

This PR rely on the new ha metrics exporter defined here: 

`https://github.com/MalloZup/ha_cluster_exporter`
This export cluster metrics. From this we create alerts and dashboards.


- Add a 1st useful alert when, in our case when the master resource is down we will have an alert.  This is 

- Add needed configuration for enabling alerts in prometheus.

# done 

- This alert rely on the new `ha_metrics_exporter` which we need pkg first
