### PR TITLE
Add hwcct benchmark

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -157,8 +157,9 @@ In [terraform.tfvars](terraform.tfvars.example) there are a number of variables 
 * **additional_packages**: Additional packages to add to the guest machines.
 * **hosts_ips**: Each cluster nodes IP address (sequential order). Mandatory to have a generic `/etc/hosts` file.
 
- Specific QA variable
+ Specific QA variables
 * **qa_mode**: If set to true, it disables extra packages not already present in the image. For example, set this value to true if performing the validation of a new AWS Public Cloud image.
+* **hwcct**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /tmp/provisioning.log.
 
 
 ### Relevant Details

--- a/aws/salt_provisioner.tf
+++ b/aws/salt_provisioner.tf
@@ -128,6 +128,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+hwcct: ${var.hwcct}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules)))}}

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -84,3 +84,8 @@ ha_sap_deployment_repo = ""
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
 #qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -181,3 +181,9 @@ variable "qa_mode" {
   type        = bool
   default     = false
 }
+
+variable "hwcct" {
+  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
+  type        = bool
+  default     = false
+}

--- a/azure/README.md
+++ b/azure/README.md
@@ -162,8 +162,9 @@ In the file [terraform.tfvars.example](terraform.tfvars.example) there are a num
  * **additional_packages**: Additional packages to add to the guest machines.
  * **hosts_ips**: Each cluster nodes IP address (sequential order). Mandatory to have a generic `/etc/hosts` file.
 
- Specific QA variable
+ Specific QA variables
 * **qa_mode**: If set to true, it disables extra packages not already present in the image. For example, set this value to true if performing the validation of a new AWS Public Cloud image.
+* **hwcct**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /tmp/provisioning.log.
 
 ### The pillar files hana.sls and cluster.sls
 

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -130,6 +130,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+hwcct: ${var.hwcct}
 reg_code: ${var.reg_code}
 monitoring_enabled: ${var.monitoring_enabled}
 reg_email: ${var.reg_email}

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -110,3 +110,8 @@ ha_sap_deployment_repo = ""
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
 #qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -149,3 +149,8 @@ variable "qa_mode" {
   default     = false
 }
 
+variable "hwcct" {
+  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
+  type        = bool
+  default     = false
+}

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -138,8 +138,9 @@ In the file [terraform.tfvars](terraform.tfvars.example) there are a number of v
 
  For more information about registration, check the ["Registering SUSE Linux Enterprise and Managing Modules/Extensions"](https://www.suse.com/documentation/sles-15/book_sle_deployment/data/cha_register_sle.html) guide.
 
- Specific QA variable
+ Specific QA variables
 * **qa_mode**: If set to true, it disables extra packages not already present in the image. For example, set this value to true if performing the validation of a new AWS Public Cloud image.
+* **hwcct**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /tmp/provisioning.log.
 
 ### The pillar files hana.sls and cluster.sls
 

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -140,6 +140,7 @@ init_type: ${var.init_type}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 qa_mode: ${var.qa_mode}
+hwcct: ${var.hwcct}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -86,3 +86,8 @@ ha_sap_deployment_repo = ""
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
 #qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -183,3 +183,8 @@ variable "qa_mode" {
   default     = false
 }
 
+variable "hwcct" {
+  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
+  type        = bool
+  default     = false
+}

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -118,6 +118,9 @@ data.
 
 For more information about registration, check the ["Registering SUSE Linux Enterprise and Managing Modules/Extensions"](https://www.suse.com/documentation/sles-15/book_sle_deployment/data/cha_register_sle.html) guide.
 
+Specific QA variables
+* **qa_mode**: If set to true, it disables extra packages not already present in the image. For example, set this value to true if performing the validation of a new image.
+* **hwcct**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /tmp/provisioning.log.
 
 If the current *main.tf* is used, only *uri* (usually SAP HANA cluster deployment needs a powerful machine, not recommended to deploy locally) and *sap_inst_media* parameters must be updated.
 

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -63,6 +63,8 @@ module "hana_node" {
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
+  qa_mode                = var.qa_mode
+  hwcct                  = var.hwcct
   devel_mode             = var.devel_mode
   scenario_type          = var.scenario_type
   provisioner            = var.provisioner

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -54,6 +54,8 @@ hana_disk_device: /dev/vdb
 shared_storage_type: ${var.shared_storage_type}
 sbd_disk_device: "${var.shared_storage_type == "iscsi" ? "/dev/sda" : "/dev/vdc"}"
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+qa_mode: ${var.qa_mode}
+hwcct: ${var.hwcct}
 hana_fstype: ${var.hana_fstype}
 hana_inst_folder: ${var.hana_inst_folder}
 sap_inst_media: ${var.sap_inst_media}

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -170,3 +170,14 @@ variable "pool" {
   description = "libvirt storage pool name for VM disks"
   default     = "default"
 }
+
+variable "qa_mode" {
+  description = "define qa mode (Disable extra packages outside images)"
+  default     = false
+}
+
+variable "hwcct" {
+  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
+  type        = bool
+  default     = false
+}

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -58,3 +58,8 @@ monitored_hosts = ["192.168.110.X", "192.168.110.Y"]
 # Except salt-minion (for the moment) and salt formulas
 # true or false
 #qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -131,3 +131,9 @@ variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
   default     = false
 }
+
+variable "hwcct" {
+  description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"
+  type        = bool
+  default     = false
+}

--- a/salt/qa_mode/files/hwcct/hwcct_bench.jinja
+++ b/salt/qa_mode/files/hwcct/hwcct_bench.jinja
@@ -1,0 +1,16 @@
+{% set data = pillar.cluster.configure.template.parameters %}
+{% set sid = data.sid.upper() %}
+{% set instance = '{:0>2}'.format(data.instance) %}
+
+#!/bin/sh
+
+# Extract and execute HWCCT
+
+typeset -r HWCCTCONFIG=/root/salt/qa_mode/files/hwcct/hwcct_config.json
+
+# Extracting HWCCT tool
+/usr/sap/{{ sid }}/HDB{{ instance }}/exe/SAPCAR -xf /root/sap_inst/DATA_UNITS/SAP_HANA_HWCCT_LINUX_X86_64/HWCCT.SAR
+
+# Executing HWCCT tool
+cd hardwareConfigurationCheckTool
+source ./envprofile.sh && ./hwcct -f ${HWCCTCONFIG}

--- a/salt/qa_mode/files/hwcct/hwcct_config.json.jinja
+++ b/salt/qa_mode/files/hwcct/hwcct_config.json.jinja
@@ -1,0 +1,25 @@
+{
+"use_hdb":false,
+"blades":["localhost"],
+"tests": [{
+            "package": "FilesystemTest",
+            "test_timeout": 0,
+            "id": 1,
+            "config": {
+                       "mount":{"{{ grains['host'] }}":["/hana"]},
+                       "duration":"short"
+                      },
+            "class": "DataVolumeIO"
+        },
+        {
+            "package": "FilesystemTest",
+            "test_timeout": 0,
+            "id": 2,
+            "config": {
+                       "mount":{"{{ grains['host'] }}":["/hana"]},
+                       "duration":"short"
+                      },
+            "class": "LogVolumeIO"
+        }],
+"output_dir":"/root/hwcct_out"
+}

--- a/salt/qa_mode/init.sls
+++ b/salt/qa_mode/init.sls
@@ -1,0 +1,23 @@
+{% if grains.get('hwcct') == true and 'hana01' in grains['hostname'] %}
+
+hwcct-config-file:
+ file.managed:
+   - template: jinja
+   - names:
+     - /root/salt/qa_mode/files/hwcct/hwcct_config.json:
+       - source: salt://qa_mode/files/hwcct/hwcct_config.json.jinja
+
+hwcct-bench-file:
+ file.managed:
+   - template: jinja
+   - names:
+     - /root/salt/qa_mode/files/hwcct/hwcct_bench.sh:
+       - source: salt://qa_mode/files/hwcct/hwcct_bench.jinja
+
+hwcct:
+  cmd.run:
+    - name: sh /root/salt/qa_mode/files/hwcct/hwcct_bench.sh
+    - require:
+      - file: hwcct-config-file
+      - file: hwcct-bench-file
+{% endif %}

--- a/salt/qa_mode/run_qa_mode.sh
+++ b/salt/qa_mode/run_qa_mode.sh
@@ -1,0 +1,13 @@
+#!/bin/bash -xe
+
+# We need to export HOST with the new hostname set by Salt
+# Otherwise, hwcct will error out.
+export HOST=$(hostname)
+
+# Execute qa state file
+salt-call --local --file-root=/root/salt/ \
+    --log-level=info \
+    --log-file=/tmp/salt-qa.log \
+    --log-file-level=info \
+    --retcode-passthrough \
+    --force-color state.apply qa_mode || exit 1

--- a/salt/salt_provisioner_script.tpl
+++ b/salt/salt_provisioner_script.tpl
@@ -19,3 +19,8 @@ sh /root/salt/deployment.sh || exit 1
 if grep -q 'role: hana_node' /etc/salt/grains; then
   sh /root/salt/formula.sh || exit 1
 fi
+
+# QA additional tasks
+if grep -q 'qa_mode: true' /etc/salt/grains && grep -q 'role: hana_node' /etc/salt/grains; then
+  sh /root/salt/qa_mode/run_qa_mode.sh || exit 1
+fi


### PR DESCRIPTION
This PR adds a possibility to execute HWCCT (Hardware Configuration Check Tool) in public cloud providers.
It's mainly a new feature for QA testing. The benchmark usually lasts about 2 hours with SSD drive.
The purpose is to execute it when we are doing build validation.
Results will be both in /root/hwcct_out and in the global log file /tmp/provisioning.log

Tested with an without hwcct set to true:
- [x] AWS 
- [x] GCP
- [x] Azure

