### PR TITLE
Standardize data disk variables

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -122,6 +122,7 @@ These are the relevant files and what each provides:
 In [terraform.tfvars](terraform.tfvars.example) there are a number of variables that control what is deployed. Some of these variables are:
 
 * **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
+* **hana_data_disk_type**: disk type to use for HANA (gp2 by default).
 * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
 * **aws_region**: AWS region where to deploy the configuration.
 * **public_key_location**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.

--- a/aws/instances.tf
+++ b/aws/instances.tf
@@ -44,7 +44,7 @@ resource "aws_instance" "clusternodes" {
   }
 
   ebs_block_device {
-    volume_type = "gp2"
+    volume_type = "${var.hana_data_disk_type}"
     volume_size = "60"
     device_name = "/dev/xvdd"
   }

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -3,6 +3,9 @@
 # Instance type to use for the cluster nodes
 instancetype = "m4.2xlarge"
 
+# Disk type for HANA
+hana_data_disk_type = "gp2"
+
 # Number of nodes in the cluster
 ninstances = "2"
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -48,6 +48,11 @@ variable "instancetype" {
   default = "t2.micro"
 }
 
+variable "hana_data_disk_type" {
+  type    = string
+  default = "gp2"
+}
+
 variable "ninstances" {
   type    = string
   default = "2"

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -104,6 +104,7 @@ In the file [terraform.tfvars](terraform.tfvars.example) there are a number of v
 * **ip_cidr_range**: must contain the internal IPv4 range.
 * **iscsi_ip**:  must contain the iscsi server IP.
 * **machine_type** and **machine_type_iscsi_server** variables must contain the [GCP machine type](https://cloud.google.com/compute/docs/machine-types) for the SAP HANA nodes as well as the iSCSI server node.
+* **hana_data_disk_type**: disk type to use for HANA (pd-standard by default).
 * **private_key_location**: the path to your SSH private key.  This is used by the provisioner.
 * **public_key_location**: the path to your SSH public key.  This is used to access the instances.
 * **region**: the name of the desired region.

--- a/gcp/disks.tf
+++ b/gcp/disks.tf
@@ -8,7 +8,7 @@ resource "google_compute_disk" "iscsi_data" {
 resource "google_compute_disk" "node_data" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-data-${count.index}"
-  type  = "pd-ssd"
+  type  = "${var.hana_data_disk_type}"
   size  = var.init_type == "all" ? 60 : 30
   zone  = element(data.google_compute_zones.available.names, count.index)
 }
@@ -16,7 +16,7 @@ resource "google_compute_disk" "node_data" {
 resource "google_compute_disk" "node_data2" {
   count = "2"
   name  = "${terraform.workspace}-${var.name}-backup-${count.index}"
-  type  = "pd-ssd"
+  type  = "${var.hana_data_disk_type}"
   size  = "20"
   zone  = element(data.google_compute_zones.available.names, count.index)
 }

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -13,6 +13,9 @@ iscsi_ip = "10.0.0.253"
 machine_type = "n1-highmem-8"
 machine_type_iscsi_server = "custom-1-2048"
 
+# Disk type for HANA
+hana_data_disk_type = "pd-ssd"
+
 # SSH private key file
 private_key_location = "/path/to/your/private/ssh/key"
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -21,6 +21,11 @@ variable "machine_type" {
   default = "n1-highmem-8"
 }
 
+variable "hana_data_disk_type" {
+  type    = string
+  default = "pd-standard"
+}
+
 variable "iscsi_server_boot_image" {
   type    = string
   default = "suse-byos-cloud/sles-15-sap-byos"


### PR DESCRIPTION
This PR standardizes data disk usage for HANA:
For all public cloud providers:
- same variable `hana_data_disk_type`
- README file
- tfvars.example file