### PR TITLE
Fix HWCCT bench if 'hwcct=false'

### DIFF
--- a/salt/qa_mode/init.sls
+++ b/salt/qa_mode/init.sls
@@ -1,18 +1,17 @@
 {% if grains.get('hwcct') == true and 'hana01' in grains['hostname'] %}
-
 hwcct-config-file:
- file.managed:
-   - template: jinja
-   - names:
-     - /root/salt/qa_mode/files/hwcct/hwcct_config.json:
-       - source: salt://qa_mode/files/hwcct/hwcct_config.json.jinja
+  file.managed:
+    - template: jinja
+    - names:
+      - /root/salt/qa_mode/files/hwcct/hwcct_config.json:
+        - source: salt://qa_mode/files/hwcct/hwcct_config.json.jinja
 
 hwcct-bench-file:
- file.managed:
-   - template: jinja
-   - names:
-     - /root/salt/qa_mode/files/hwcct/hwcct_bench.sh:
-       - source: salt://qa_mode/files/hwcct/hwcct_bench.jinja
+  file.managed:
+    - template: jinja
+    - names:
+      - /root/salt/qa_mode/files/hwcct/hwcct_bench.sh:
+        - source: salt://qa_mode/files/hwcct/hwcct_bench.jinja
 
 hwcct:
   cmd.run:
@@ -20,4 +19,8 @@ hwcct:
     - require:
       - file: hwcct-config-file
       - file: hwcct-bench-file
+{% else %}
+# Do nothing if 'hwcct=false'
+default_nop:
+  test.nop: []
 {% endif %}


### PR DESCRIPTION
if `hwcct` variable is set to `false`, then `qa_mode/init.sls` is executed as an empty file, and so Salt exits with a `RC != 0`.

This commit fix it by adding a `test.nop` if `hwcct=false`.

Successfully manually tested on AWS.