### PR TITLE
Fix azurerm provider version <= 1.33

### DIFF
--- a/azure/provider.tf
+++ b/azure/provider.tf
@@ -1,6 +1,6 @@
 # Configure the Azure Provider
 provider "azurerm" {
-  version = "~> 1.13"
+  version = "<= 1.33"
 }
 
 provider "template" {


### PR DESCRIPTION
Workaround for #188
Tested this morning in Azure with custom image.