### PR TITLE
remove `monitored_hosts` var from the outer layer of the tf config API

### DIFF
--- a/azure/monitoring.tf
+++ b/azure/monitoring.tf
@@ -3,11 +3,6 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
-variable "monitored_hosts" {
-  description = "IPs of hosts you want to monitor"
-  type        = list(string)
-}
-
 variable "monitoring_srv_ip" {
   description = "monitoring server address"
   type        = string

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -64,7 +64,7 @@ partitions:
   5:
     start: 80%
     end: 100%
- 
+
 EOF
 
 
@@ -176,6 +176,7 @@ resource "null_resource" "monitoring_provisioner" {
     content     = data.template_file.salt_provisioner.rendered
     destination = "/tmp/salt_provisioner.sh"
   }
+
   provisioner "file" {
     content = <<EOF
 provider: azure
@@ -188,10 +189,10 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))},${trimspace(file(var.public_key_location))}]
-host_ips: [${join(", ", formatlist("'%s'", [var.monitoring_srv_ip]))}]
+host_ips: [${join(", ", formatlist("'%s'", [var.host_ips]))}]
 host_ip: ${var.monitoring_srv_ip}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
-monitored_hosts: [${join(", ", formatlist("'%s'", var.monitored_hosts))}]
+monitored_hosts: [${join(", ", formatlist("'%s'", var.host_ips))}]
 network_domain: "tf.local"
 EOF
 

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -189,7 +189,7 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))},${trimspace(file(var.public_key_location))}]
-host_ips: [${join(", ", formatlist("'%s'", [var.host_ips]))}]
+host_ips: [${join(", ", formatlist("'%s'", [var.monitoring_srv_ip]))}]
 host_ip: ${var.monitoring_srv_ip}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 monitored_hosts: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -20,15 +20,6 @@ In order to enable disable the monitoring feature, you need to:
 
 # Variable specification:
 
-* mandatory:
-
-`monitored_hosts` Default empty. A list containing the IP addresses of hosts to be monitored. Under the hood list var tell prometheus the IP where to scrape.
-```
-monitored_hosts = ["192.168.110.X", "192.168.110.Y"]
-```
-
-* optional:
-
 `monitoring_enabled` default True. This variable will install all different supported exporters to the hosts. 
 See the list of supported exporter for more details.
 

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -92,7 +92,7 @@ module "monitoring" {
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   provisioner            = var.provisioner
   background             = var.background
-  monitored_hosts        = var.monitored_hosts
+  monitored_hosts        = var.host_ips
   pool                   = var.storage_pool
   network_id             = libvirt_network.isolated_network.id
 }

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -40,8 +40,6 @@ devel_mode = false
 #background = true
 
 # Monitoring:
-# Add here IP addresses of the hosts to be monitored:
-monitored_hosts = ["192.168.110.X", "192.168.110.Y"]
 
 # by default monitoring is disabled.
 monitoring_enabled = true

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -111,12 +111,6 @@ variable "background" {
   default     = false
 }
 
-variable "monitored_hosts" {
-  description = "IPs of hosts to be monitored"
-  type        = list(string)
-  default     = []
-}
-
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   default     = false


### PR DESCRIPTION
Addresses #190.

The `monitored_hosts` variable is now just an internal detail of the `monitoring` module (in libvirt).

For the time being, it has also been removed entirely from the Azure provisioning (except in the salt grain), but it will probably be reintroduced as a module input variable later.