### PR TITLE
The port of ha-exporter has changed to 9002 and remove superficial if

### DIFF
--- a/azure/network.tf
+++ b/azure/network.tf
@@ -395,13 +395,13 @@ resource "azurerm_network_security_group" "mysecgroup" {
     destination_address_prefix = "*"
   }
   security_rule {
-    name                       = "hawkExporter"
+    name                       = "ha-exporter"
     priority                   = 1007
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "*"
     source_port_range          = "*"
-    destination_port_range     = "9001"
+    destination_port_range     = "9002"
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -13,7 +13,6 @@ alerting:
 rule_files:
     - /etc/prometheus/rules.yml
 
-{% if grains.get('monitored_hosts') %}
 scrape_configs:
   - job_name: hanadb
     static_configs:
@@ -36,4 +35,3 @@ scrape_configs:
         {% for ip in grains['monitored_hosts'] %}
         - "{{ ip }}:9002" # 9002: ha_cluster_exporter metrics
         {% endfor %}
-{% endif %}


### PR DESCRIPTION
previously it was the hawk-exporter (deprecated)
now the ha-cluster exporter is running on port 9002