### PR TITLE
Add monitoring doc in tfvars.example

### DIFF
--- a/azure/monitoring.tf
+++ b/azure/monitoring.tf
@@ -15,5 +15,5 @@ variable "devel_mode" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
-  default     = true
+  default     = false
 }

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -14,7 +14,7 @@ ninstances = "2"
 az_region = "westeurope"
 
 # Variable for init-nodes.sh script
-init-type = "all"
+init_type = "all"
 
 # SLES4SAP image information
 # If custom uris are enabled public information will be omitted
@@ -102,6 +102,14 @@ ha_sap_deployment_repo = ""
 
 # Run provisioner execution in background
 #background = true
+
+# Monitoring variables
+
+# Enable the host to be monitored by exporters
+#monitoring_enabled = true
+
+# IP address of the machine where prometheus and grafana are running
+monitoring_srv_ip = "10.74.1.13"
 
 # QA variables
 

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -20,7 +20,7 @@ In order to enable disable the monitoring feature, you need to:
 
 # Variable specification:
 
-`monitoring_enabled` default True. This variable will install all different supported exporters to the hosts. 
+`monitoring_enabled` default False. This variable will install all different supported exporters to the hosts. 
 See the list of supported exporter for more details.
 
 # Hosts Exporters

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -151,7 +151,7 @@ variable "bridge" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
-  default     = true
+  default     = false
 }
 
 // sbd disks

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -39,10 +39,13 @@ devel_mode = false
 # Run provisioner execution in background
 #background = true
 
-# Monitoring:
+# Monitoring variables
 
-# by default monitoring is disabled.
-monitoring_enabled = true
+# Enable the host to be monitored by exporters
+#monitoring_enabled = true
+
+# IP address of the machine where prometheus and grafana are running
+monitoring_srv_ip = "192.168.XXX.Y+2"
 
 # libvirt storage pool, select the libvirt storage pool where the volume will stored
 


### PR DESCRIPTION
As `monitoring_srv_ip` is a mandatory variable and there is no default value. We must add it in `terraform.tfvars.example`.

Otherwise, terraform will ask for value:
```
var.monitoring_srv_ip
  monitoring server address
  Enter a value
```

I could do the same for libvirt but I found something incompatible:
[Monitoring](https://github.com/SUSE/ha-sap-terraform-deployments/blob/master/doc/monitoring.md) doc says `monitoring_enabled default True.`
In libvirt, `monitoring_enabled `default is false.

@arbulu89 @MalloZup WDYT?
