### PR TITLE
Feature/fix monitoring repo

### DIFF
--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -21,9 +21,9 @@
 
 # Quickstart
 
-1) Make sure you use terraform workspaces, create new one with: ```terraform workspace new $USER``` 
+1) Make sure you use terraform workspaces, create new one with: ```terraform workspace new $USER```
 
-  For more doc, see: [workspace](../doc/workspaces-workflow.md). 
+  For more doc, see: [workspace](../doc/workspaces-workflow.md).
   If you don't create a new one, the string `default` will be used as workspace name. This is however highly discouraged since the workspace name is used as prefix for resources names, which can led to conflicts to unique names in a shared server ( when using a default name).
 
 2) Edit the `terraform.tfvars.example` file, following the Readme.md in the provider directory.
@@ -46,9 +46,6 @@ terraform apply
 terraform destroy
 ```
 
-
-
-
 # Design
 
 This project is mainly based in [sumaform](https://github.com/uyuni-project/sumaform/)
@@ -69,7 +66,7 @@ Besides that, the different kind of provisioners are available in this module. B
 `salt` is supported but more could be added just adding other `provisioner` files like
 [salt_provisioner](modules/host/salt_provisioner.tf).
 - [hana_node](modules/hana_node): Specific SAP HANA node defintion. Basically it calls the
-host module with some particular updates. 
+host module with some particular updates.
  The hana node contains also:
  * sbd device definition. Currently a shared disk.
 - [iscsi_server](modules/iscsi_server): Machine to host a iscsi target.
@@ -97,6 +94,7 @@ data.
 - **shared_storage_type**: Shared storage type between iscsi and KVM raw file shared disk. Available options: `iscsi` and `shared-disk`.
 - **iscsi_srv_ip**: IP address of the machine that will host the iscsi target (only used if `iscsi` is used as a shared storage for fencing)
 - **iscsi_image**: Source image of the machine hosting the iscsi target (sles15 or above) (only used if `iscsi` is used as a shared storage for fencing)
+- **monitoring_image**: Source image of the machine hosting the monitoring stack (if not set, the same image as the hana nodes will be used)
 - **monitoring_srv_ip**: IP address of the machine that will host the monitoring stack
 - **ha_sap_deployment_repo**: Repository with HA and Salt formula packages. The latest RPM packages can be found at [https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}](https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/)
 - **devel_mode**: Whether or not to install HA/SAP packages from ha_sap_deployment_repo

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -81,6 +81,7 @@ module "monitoring" {
   source                 = "./modules/monitoring"
   name                   = "monitoring"
   monitoring_count       = var.monitoring_enabled == true ? 1 : 0
+  monitoring_image       = var.monitoring_image
   base_image_id          = libvirt_volume.base_image.id
   vcpu                   = 4
   memory                 = 4095

--- a/libvirt/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/modules/iscsi_server/salt_provisioner.tf
@@ -8,7 +8,7 @@ data "template_file" "salt_provisioner" {
 }
 
 resource "null_resource" "iscsi_provisioner" {
-  count = var.iscsi_count
+  count = var.provisioner == "salt" ? length(libvirt_domain.iscsisrv) : 0
 
   triggers = {
     iscsi_id = libvirt_domain.iscsisrv[count.index].id

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -8,12 +8,13 @@ data "template_file" "monitoring_salt_provisioner" {
 }
 
 resource "null_resource" "monitoring_provisioner" {
+  count = var.provisioner == "salt" ? length(libvirt_domain.monitoring_domain) : 0
   triggers = {
-    monitoring_id = libvirt_domain.monitoring_domain.id
+    monitoring_id = libvirt_domain.monitoring_domain[count.index].id
   }
 
   connection {
-    host     = libvirt_domain.monitoring_domain.network_interface.0.addresses.0
+    host     = libvirt_domain.monitoring_domain[count.index].network_interface.0.addresses.0
     user     = "root"
     password = "linux"
   }

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -1,3 +1,9 @@
+variable "monitoring_image" {
+  description = "monitoring server base image"
+  type        = "string"
+  default     = ""
+}
+
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -19,7 +19,6 @@ ha_sap_deployment_repo = ""
 # Default is false
 devel_mode = false
 
-
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
@@ -39,6 +38,9 @@ devel_mode = false
 #background = true
 
 # Monitoring variables
+
+# Custom sles4sap image for the monitoring server. If not used the same image than the hana nodes will be used
+#monitoring_image = "url-to-your-sles4sap-image"
 
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -59,6 +59,12 @@ variable "monitoring_srv_ip" {
   type        = string
 }
 
+variable "monitoring_image" {
+  description = "monitoring server base image (if not set, the same image as the hana nodes will be used)"
+  type        = string
+  default     = ""
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   default     = ""

--- a/salt/hana_node/monitoring.sls
+++ b/salt/hana_node/monitoring.sls
@@ -1,7 +1,10 @@
+{% set repository = 'SLE_'~grains['osrelease_info'][0] %}
+{% set repository = repository~'_SP'~grains['osrelease_info'][1] if grains['osrelease_info']|length > 1 else repository %}
+
 server_monitoring_repo:
  pkgrepo.managed:
-    - humanname: Server:SLE15:Monitoring
-    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/SLE_15/
+    - humanname: Server:Monitoring
+    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/{{ repository }}/
     - refresh: True
     - gpgautoimport: True
 

--- a/salt/monitoring/init.sls
+++ b/salt/monitoring/init.sls
@@ -1,9 +1,10 @@
-# TODO: this repo should detect the os itself and chooose right repo depending the os
-# for moment ok
+{% set repository = 'SLE_'~grains['osrelease_info'][0] %}
+{% set repository = repository~'_SP'~grains['osrelease_info'][1] if grains['osrelease_info']|length > 1 else repository %}
+
 server_monitoring_repo:
  pkgrepo.managed:
-    - humanname: Server:SLE15:Monitoring
-    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/SLE_15/
+    - humanname: Server:Monitoring
+    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/{{ repository }}/
     - refresh: True
     - gpgautoimport: True
 


### PR DESCRIPTION
Fix:
https://github.com/SUSE/ha-sap-terraform-deployments/issues/199
https://github.com/SUSE/ha-sap-terraform-deployments/issues/202
About this second, now if the `monitoring_image` is set this will be used in the monitoring server. If the value is empty the same image than in the hana nodes will be used.

Besides that, I have fixed the monitoring server usage when the stack is disabled.

Tested and working in:
SLES15 libvirt
SLES12SP3 libvirt
SLES12SP4 azure
