### PR TITLE
Add informations and fix 'output.tf'

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -1,19 +1,32 @@
-# Launch SLES-HAE of SLES4SAP cluster nodes
+# Outputs:
+# - Private IP
+# - Public IP
+# - Private node name
+# - Public node name
 
-# Outputs: IP address and port where the service will be listening on
+# iSCSI server
 
 data "aws_instance" "iscsisrv" {
   instance_id = aws_instance.iscsisrv.id
 }
 
 output "iscsisrv_ip" {
-  value = data.aws_instance.iscsisrv.public_ip
+  value = [data.aws_instance.iscsisrv.private_ip]
+}
+
+output "iscsisrv_public_ip" {
+  value = [data.aws_instance.iscsisrv.public_ip]
 }
 
 output "iscsisrv_name" {
-  value = data.aws_instance.iscsisrv.public_dns
+  value = [data.aws_instance.iscsisrv.id]
 }
 
+output "iscsisrv_public_name" {
+  value = [data.aws_instance.iscsisrv.public_dns]
+}
+
+# Cluster nodes
 
 data "aws_instance" "clusternodes" {
   count       = var.ninstances
@@ -21,23 +34,40 @@ data "aws_instance" "clusternodes" {
 }
 
 output "cluster_nodes_ip" {
+  value = data.aws_instance.clusternodes.*.private_ip
+}
+
+output "cluster_nodes_public_ip" {
   value = data.aws_instance.clusternodes.*.public_ip
 }
 
-output "cluster_nodes_names" {
+output "cluster_nodes_name" {
+  value = data.aws_instance.clusternodes.*.id
+}
+
+output "cluster_nodes_public_name" {
   value = data.aws_instance.clusternodes.*.public_dns
 }
 
+# Monitoring
 
 data "aws_instance" "monitoring" {
   count       = var.monitoring_enabled == true ? 1 : 0
   instance_id = element(aws_instance.monitoring.*.id, count.index)
 }
 
-output "monitoring_node_ip" {
+output "monitoring_ip" {
+  value = data.aws_instance.monitoring.*.private_ip
+}
+
+output "monitoring_public_ip" {
   value = data.aws_instance.monitoring.*.public_ip
 }
 
-output "monitoring_node_name" {
+output "monitoring_name" {
+  value = data.aws_instance.monitoring.*.id
+}
+
+output "monitoring_public_name" {
   value = data.aws_instance.monitoring.*.public_dns
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -1,26 +1,38 @@
-# Launch SLES-HAE of SLES4SAP cluster nodes
+# Outputs:
+# - Private IP
+# - Public IP
+# - Private node name
+# - Public node name
 
-data "azurerm_public_ip" "monitoring" {
-  count = var.monitoring_enabled == true ? 1 : 0
-  name  = element(azurerm_public_ip.monitoring.*.name, count.index)
-  resource_group_name = element(
-    azurerm_virtual_machine.monitoring.*.resource_group_name,
-    count.index,
-  )
-}
-
-output "monitoring_ip" {
-  value = data.azurerm_public_ip.monitoring.*.ip_address
-}
+# iSCSI server
 
 data "azurerm_public_ip" "iscsisrv" {
   name                = azurerm_public_ip.iscsisrv.name
   resource_group_name = azurerm_virtual_machine.iscsisrv.resource_group_name
 }
 
-output "iscsisrv_ip" {
-  value = data.azurerm_public_ip.iscsisrv.ip_address
+data "azurerm_network_interface" "iscsisrv" {
+  name                = azurerm_network_interface.iscsisrv.name
+  resource_group_name = azurerm_virtual_machine.iscsisrv.resource_group_name
 }
+
+output "iscsisrv_ip" {
+  value = [data.azurerm_network_interface.iscsisrv.private_ip_address]
+}
+
+output "iscsisrv_public_ip" {
+  value = [data.azurerm_public_ip.iscsisrv.ip_address]
+}
+
+output "iscsisrv_name" {
+  value = [azurerm_virtual_machine.iscsisrv.name]
+}
+
+output "iscsisrv_public_name" {
+  value = [data.azurerm_public_ip.iscsisrv.fqdn]
+}
+
+# Cluster nodes
 
 data "azurerm_public_ip" "clusternodes" {
   count = var.ninstances
@@ -31,6 +43,63 @@ data "azurerm_public_ip" "clusternodes" {
   )
 }
 
+data "azurerm_network_interface" "clusternodes" {
+  count = var.ninstances
+  name  = element(azurerm_network_interface.clusternodes.*.name, count.index)
+  resource_group_name = element(
+    azurerm_virtual_machine.clusternodes.*.resource_group_name,
+    count.index,
+  )
+}
+
 output "cluster_nodes_ip" {
+  value = data.azurerm_network_interface.clusternodes.*.private_ip_address
+}
+
+output "cluster_nodes_public_ip" {
   value = data.azurerm_public_ip.clusternodes.*.ip_address
+}
+
+output "cluster_nodes_name" {
+  value = azurerm_virtual_machine.clusternodes.*.name
+}
+
+output "cluster_nodes_public_name" {
+  value = data.azurerm_public_ip.clusternodes.*.fqdn
+}
+
+# Monitoring
+
+data "azurerm_public_ip" "monitoring" {
+  count = var.monitoring_enabled == true ? 1 : 0
+  name  = element(azurerm_public_ip.monitoring.*.name, count.index)
+  resource_group_name = element(
+    azurerm_virtual_machine.monitoring.*.resource_group_name,
+    count.index,
+  )
+}
+
+data "azurerm_network_interface" "monitoring" {
+  count = var.monitoring_enabled == true ? 1 : 0
+  name  = element(azurerm_network_interface.monitoring.*.name, count.index)
+  resource_group_name = element(
+    azurerm_virtual_machine.monitoring.*.resource_group_name,
+    count.index,
+  )
+}
+
+output "monitoring_ip" {
+  value = data.azurerm_network_interface.monitoring.*.private_ip_address
+}
+
+output "monitoring_public_ip" {
+  value = data.azurerm_public_ip.monitoring.*.ip_address
+}
+
+output "monitoring_name" {
+  value = azurerm_virtual_machine.monitoring.*.name
+}
+
+output "monitoring_public_name" {
+  value = data.azurerm_public_ip.monitoring.*.fqdn
 }


### PR DESCRIPTION
`output.tf` file is not consistent across each providers.

This commit fixes this and also add some information.

This is needed to be able to use this project in our Public Cloud tests in openQA.

Tested on AWS, GCP and Azure.
I can't test on libvirt, so if anyone can check if it's good a relevant.

EDIT: libvirt modifications have been removed, to different, will be done in another PR
EDIT2: GCP change is handled in @juadk 's PR #219.