### PR TITLE
Unify outputs with cloud providers in libvirt

### DIFF
--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -99,13 +99,11 @@ resource "libvirt_domain" "hana_domain" {
   }
 }
 
-output "configuration" {
+output "output_data" {
   value = {
-    id       = libvirt_domain.hana_domain.*.id
-    hostname = libvirt_domain.hana_domain.*.name
+    id                = libvirt_domain.hana_domain.*.id
+    hostname          = libvirt_domain.hana_domain.*.name
+    private_addresses = var.host_ips
+    addresses         = libvirt_domain.hana_domain.*.network_interface.0.addresses.0
   }
-}
-
-output "addresses" {
-  value = flatten(libvirt_domain.hana_domain.*.network_interface.0.addresses)
 }

--- a/libvirt/modules/iscsi_server/main.tf
+++ b/libvirt/modules/iscsi_server/main.tf
@@ -3,7 +3,7 @@ terraform {
 }
 
 resource "libvirt_volume" "iscsi_image_disk" {
-  name   = format("%s-iscsi-disk", terraform.workspace) 
+  name   = format("%s-iscsi-disk", terraform.workspace)
   source = var.iscsi_image
   pool   = var.pool
   count  = var.iscsi_count
@@ -35,7 +35,7 @@ resource "libvirt_domain" "iscsisrv" {
       volume_id = disk.value.vol_id
     }
   }
-  
+
   network_interface {
     network_name   = var.network_name
     bridge         = var.bridge
@@ -72,13 +72,11 @@ resource "libvirt_domain" "iscsisrv" {
   }
 }
 
-output "configuration" {
+output "output_data" {
   value = {
-    id       = join(",", libvirt_domain.iscsisrv.*.id)
-    hostname = join(",", libvirt_domain.iscsisrv.*.name)
+    id                = libvirt_domain.iscsisrv.*.id
+    hostname          = libvirt_domain.iscsisrv.*.name
+    private_addresses = [var.iscsi_srv_ip]
+    addresses         = libvirt_domain.iscsisrv.*.network_interface.0.addresses.0
   }
-}
-
-output "addresses" {
-  value = join(",", flatten(libvirt_domain.iscsisrv.*.network_interface.0.addresses))
 }

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -63,13 +63,11 @@ resource "libvirt_domain" "monitoring_domain" {
   }
 }
 
-output "configuration" {
+output "output_data" {
   value = {
-    id       = join(",", libvirt_domain.monitoring_domain.*.id)
-    hostname = join(",", libvirt_domain.monitoring_domain.*.name)
+    id                = libvirt_domain.monitoring_domain.*.id
+    hostname          = libvirt_domain.monitoring_domain.*.name
+    private_addresses = [var. monitoring_srv_ip]
+    addresses         = libvirt_domain.monitoring_domain.*.network_interface.0.addresses.0
   }
-}
-
- output "addresses" {
-   value = flatten(libvirt_domain.monitoring_domain.*.network_interface.0.addresses)
 }

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -1,29 +1,49 @@
 # Outputs: IP address and port where the service will be listening on
 
 output "cluster_nodes_ip" {
-  value = module.hana_node.addresses
+  value = module.hana_node.output_data.private_addresses
 }
 
-output "cluster_nodes_id" {
-  value = module.hana_node.configuration.id
+output "cluster_nodes_public_ip" {
+  value = module.hana_node.output_data.addresses
 }
 
-output "cluster_nodes_names" {
-  value = module.hana_node.configuration.hostname
+output "cluster_nodes_name" {
+  value = module.hana_node.output_data.hostname
+}
+
+output "cluster_nodes_public_name" {
+  value = []
 }
 
 output "iscsisrv_ip" {
-  value = module.iscsi_server.addresses
+  value = module.iscsi_server.output_data.private_addresses
+}
+
+output "iscsisrv_public_ip" {
+  value = module.iscsi_server.output_data.addresses
 }
 
 output "iscsisrv_name" {
-  value = module.iscsi_server.configuration.hostname
+  value = module.iscsi_server.output_data.hostname
 }
 
-output "monitoring_hostname" {
-  value = module.monitoring.configuration.hostname
+output "iscsisrv_public_name" {
+  value = []
 }
 
 output "monitoring_ip" {
-  value = module.monitoring.addresses
+  value = module.monitoring.output_data.private_addresses
+}
+
+output "monitoring_public_ip" {
+  value = module.monitoring.output_data.addresses
+}
+
+output "monitoring_name" {
+  value = module.monitoring.output_data.hostname
+}
+
+output "monitoring_public_name" {
+  value = []
 }


### PR DESCRIPTION
Unify the terraform outputs for libvirt

This the output example:

```
cluster_nodes_ip = [
  "192.168.145.2",
  "192.168.145.3",
]
cluster_nodes_name = [
  "libvirt-sles15-false-po-hana-1",
  "libvirt-sles15-false-po-hana-2",
]
cluster_nodes_public_ip = [
  "10.162.31.1",
  "10.162.30.247",
]
cluster_nodes_public_name = []
iscsisrv_ip = [
  "192.168.145.20",
]
iscsisrv_name = [
  "libvirt-sles15-false-po-iscsi",
]
iscsisrv_public_ip = [
  "10.162.32.61",
]
iscsisrv_public_name = []
monitoring_ip = [
  "192.168.145.21",
]
monitoring_name = [
  "libvirt-sles15-false-po-monitoring",
]
monitoring_public_ip = [
  "10.162.31.12",
]
monitoring_public_name = []
```