### PR TITLE
Add some linters to the CI

### DIFF
--- a/.ci/validate-terraform.sh
+++ b/.ci/validate-terraform.sh
@@ -2,7 +2,6 @@
 set -e
 find . -name \*.sh -exec bash -n {} \;
 find . -name \*.tpl | while read f ; do head -1 "$f" | grep -qnE '^#! ?/bin/(ba)?sh' && bash -n "$f" ; done
-find . -name \*.json -type f | while read f ; do cat "$f" | python -m json.tool >/dev/null ; done
 
 echo "executing terraform check , init and validate for each provider"
 for provider in $(find * -maxdepth 0 -type d | grep -Ev 'salt|pillar_examples'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,21 @@
 dist: xenial
 
-language: bash
+matrix:
+  include:
+    - language: bash
+      install:
+        - set -e
+        - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
+        - unzip /tmp/terraform -d /tmp
+        - chmod +x /tmp/terraform
+        - /tmp/terraform -version
+      script:
+        - .ci/validate-terraform.sh
+    - language: node
+      install:
+        - npm install -g jsonlint
+      script:
+        - jsonlint salt/monitoring/provisioning/dashboards/*.json
 
 notifications:
   email: true
-
-before_script:
-  - set -e
-  - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
-  - unzip /tmp/terraform -d /tmp
-  - chmod +x /tmp/terraform
-  - /tmp/terraform -version
-
-script:
-  - .ci/validate-terraform.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ matrix:
       install:
         - npm install -g jsonlint
       script:
-        - jsonlint salt/monitoring/provisioning/dashboards/*.json
+        - jsonlint -qc salt/monitoring/provisioning/dashboards/*.json
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ matrix:
       install:
         - npm install -g jsonlint
       script:
-        - jsonlint -qc salt/monitoring/provisioning/dashboards/*.json
+        - git ls-files | grep '.json$' | xargs -I {} jsonlint -qc {}
+    - language: python
+      install:
+        - pip install salt-lint
+      script:
+        - git ls-files | grep '.sls$' | xargs salt-lint
 
 notifications:
   email: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
         - /tmp/terraform -version
       script:
         - .ci/validate-terraform.sh
-    - language: node
+    - language: node_js
       install:
         - npm install -g jsonlint
       script:

--- a/pillar_examples/automatic/hana.sls
+++ b/pillar_examples/automatic/hana.sls
@@ -5,7 +5,7 @@ hana:
   nodes:
     - host: {{ grains['name_prefix'] }}01
       sid: prd
-      instance: 00
+      instance: "00"
       password: YourPassword1234
       install:
         software_path: /root/sap_inst
@@ -38,7 +38,7 @@ hana:
 
     - host: {{ grains['name_prefix'] }}02
       sid: prd
-      instance: 00
+      instance: "00"
       password: YourPassword1234
       {% if grains['scenario_type'] == 'cost-optimized' %}
       scenario_type: 'cost-optimized'
@@ -59,14 +59,14 @@ hana:
       secondary:
         name: SECONDARY_SITE_NAME
         remote_host: {{ grains['name_prefix'] }}01
-        remote_instance: 00
+        remote_instance: "00"
         replication_mode: sync
         operation_mode: logreplay
         primary_timeout: 3000
     {% if grains['scenario_type'] == 'cost-optimized' %}
     - host: {{ grains['name_prefix'] }}02
       sid: qas
-      instance: 01
+      instance: "01"
       password: YourPassword1234
       scenario_type: 'cost-optimized'
       cost_optimized_parameters:

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -18,7 +18,7 @@ cluster:
       source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
-        instance: 00
+        instance: "00"
         virtual_ip: 10.0.1.50
         virtual_ip_mask: 16
         platform: aws

--- a/pillar_examples/aws/hana.sls
+++ b/pillar_examples/aws/hana.sls
@@ -3,7 +3,7 @@ hana:
   nodes:
     - host: 'hana01'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst/'
@@ -26,7 +26,7 @@ hana:
 
     - host: 'hana02'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst/'
@@ -37,6 +37,6 @@ hana:
       secondary:
         name: SECONDARY_SITE_NAME
         remote_host: 'hana01'
-        remote_instance: 00
+        remote_instance: "00"
         replication_mode: 'sync'
         operation_mode: 'logreplay'

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -18,7 +18,7 @@ cluster:
       source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
-        instance: 00
+        instance: "00"
         virtual_ip: 10.74.1.5 # This value must match with the load balancer address: frontend_ip_configuration
         virtual_ip_mask: 24
         platform: azure

--- a/pillar_examples/azure/hana.sls
+++ b/pillar_examples/azure/hana.sls
@@ -2,7 +2,7 @@ hana:
   nodes:
     - host: 'hana01'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst'
@@ -25,7 +25,7 @@ hana:
 
     - host: 'hana02'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst'
@@ -36,7 +36,7 @@ hana:
       secondary:
         name: SECONDARY_SITE_NAME
         remote_host: 'hana01'
-        remote_instance: 00
+        remote_instance: "00"
         replication_mode: 'sync'
         operation_mode: 'logreplay'
         primary_timeout: 3000

--- a/pillar_examples/libvirt/cost_optimized/cluster.sls
+++ b/pillar_examples/libvirt/cost_optimized/cluster.sls
@@ -20,7 +20,7 @@ cluster:
       source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
-        instance: 00
+        instance: "00"
         virtual_ip: 192.168.107.50
         virtual_ip_mask: 24
         platform: libvirt
@@ -28,5 +28,5 @@ cluster:
         auto_register: false
         cost_optimized_parameters:
           sid: qas
-          instance: 01
+          instance: "01"
           remote_host : 'hana01'

--- a/pillar_examples/libvirt/cost_optimized/hana.sls
+++ b/pillar_examples/libvirt/cost_optimized/hana.sls
@@ -2,7 +2,7 @@ hana:
   nodes:
     - host: 'hana01'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst'
@@ -25,7 +25,7 @@ hana:
 
     - host: 'hana02'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       scenario_type: 'cost-optimized'
       cost_optimized_parameters:
@@ -40,13 +40,13 @@ hana:
       secondary:
         name: SECONDARY_SITE_NAME
         remote_host: 'hana01'
-        remote_instance: 00
+        remote_instance: "00"
         replication_mode: 'sync'
         operation_mode: 'logreplay'
 
     - host: 'hana02'
       sid: 'qas'
-      instance: 01
+      instance: "01"
       password: 'SET YOUR PASSWORD'
       scenario_type: 'cost-optimized'
       cost_optimized_parameters:

--- a/pillar_examples/libvirt/performance_optimized/cluster.sls
+++ b/pillar_examples/libvirt/performance_optimized/cluster.sls
@@ -20,7 +20,7 @@ cluster:
       source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
       parameters:
         sid: prd
-        instance: 00
+        instance: "00"
         virtual_ip: 192.168.107.50
         virtual_ip_mask: 24
         platform: libvirt

--- a/pillar_examples/libvirt/performance_optimized/hana.sls
+++ b/pillar_examples/libvirt/performance_optimized/hana.sls
@@ -2,7 +2,7 @@ hana:
   nodes:
     - host: 'hana01'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst'
@@ -25,7 +25,7 @@ hana:
 
     - host: 'hana02'
       sid: 'prd'
-      instance: 00
+      instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
         software_path: '/root/sap_inst'
@@ -36,6 +36,6 @@ hana:
       secondary:
         name: SECONDARY_SITE_NAME
         remote_host: 'hana01'
-        remote_instance: 00
+        remote_instance: "00"
         replication_mode: 'sync'
         operation_mode: 'logreplay'

--- a/salt/hana_node/download_hana_inst.sls
+++ b/salt/hana_node/download_hana_inst.sls
@@ -12,7 +12,10 @@ download_files_from_s3:
 
 hana_inst_partition:
   cmd.run:
-    - name: /usr/sbin/parted -s {{grains['hana_inst_disk_device']}} mklabel msdos && /usr/sbin/parted -s {{grains['hana_inst_disk_device']}} mkpart primary ext2 1M 100% && sleep 1 && /sbin/mkfs -t xfs {{grains['hana_inst_disk_device']}}1
+    - name: |
+        /usr/sbin/parted -s {{ grains['hana_inst_disk_device'] }} mklabel msdos && \
+        /usr/sbin/parted -s {{ grains['hana_inst_disk_device'] }} mkpart primary ext2 1M 100% && sleep 1 && \
+        /sbin/mkfs -t xfs {{ grains['hana_inst_disk_device'] }}1
     - unless: ls {{ grains['hana_inst_disk_device'] }}1
     - require:
       - pkg: parted
@@ -21,7 +24,7 @@ hana_inst_directory:
   file.directory:
     - name: {{ grains['hana_inst_folder'] }}
     - user: root
-    - mode: 755
+    - mode: "0755"
     - makedirs: True
   mount.mounted:
     - name: {{ grains['hana_inst_folder'] }}
@@ -53,8 +56,8 @@ download_files_from_gcp:
   file.directory:
     - user: root
     - group: root
-    - dir_mode: 754
-    - file_mode: 755
+    - dir_mode: "0754"
+    - file_mode: "0755"
     - recurse:
       - user
       - group

--- a/salt/hana_node/formula.sls
+++ b/salt/hana_node/formula.sls
@@ -1,7 +1,7 @@
 /srv/pillar:
   file.directory:
     - user: root
-    - mode: 755
+    - mode: "0755"
     - makedirs: True
 
 /srv/salt/top.sls:

--- a/salt/hana_node/mount.sls
+++ b/salt/hana_node/mount.sls
@@ -6,8 +6,11 @@ parted:
 
 hana_partition:
   cmd.run:
-    - name: /usr/sbin/parted -s {{grains['hana_disk_device']}} mklabel msdos && /usr/sbin/parted -s {{grains['hana_disk_device']}} mkpart primary ext2 1M 100% && sleep 1 && /sbin/mkfs -t {{grains['hana_fstype']}} {{grains['hana_disk_device']}}1
-    - unless: ls {{grains['hana_disk_device']}}1
+    - name: |
+        /usr/sbin/parted -s {{ grains['hana_disk_device'] }} mklabel msdos && \
+        /usr/sbin/parted -s {{ grains['hana_disk_device'] }} mkpart primary ext2 1M 100% && sleep 1 && \
+        /sbin/mkfs -t {{ grains['hana_fstype'] }} {{ grains['hana_disk_device'] }}1
+    - unless: ls {{ grains['hana_disk_device'] }}1
     - require:
       - pkg: parted
 
@@ -15,12 +18,12 @@ hana_directory:
   file.directory:
     - name: /hana
     - user: root
-    - mode: 755
+    - mode: "0755"
     - makedirs: True
   mount.mounted:
     - name: /hana
-    - device: {{grains['hana_disk_device']}}1
-    - fstype: {{grains['hana_fstype']}}
+    - device: {{ grains['hana_disk_device'] }}1
+    - fstype: {{ grains['hana_fstype'] }}
     - mkmnt: True
     - persist: True
     - opts:

--- a/salt/hana_node/sap_inst.sls
+++ b/salt/hana_node/sap_inst.sls
@@ -6,14 +6,14 @@ nfs-client:
 
 sap_inst_directory:
   file.directory:
-    - name: {{grains['hana_inst_folder']}}
+    - name: {{ grains['hana_inst_folder'] }}
     - user: root
-    - mode: 755
+    - mode: "0755"
     - makedirs: True
   {% if grains['provider'] == 'libvirt' %}
   mount.mounted:
-    - name: {{grains['hana_inst_folder']}}
-    - device: {{grains['sap_inst_media']}}
+    - name: {{ grains['hana_inst_folder'] }}
+    - device: {{ grains['sap_inst_media'] }}
     - fstype: nfs
     - mkmnt: True
     - persist: True
@@ -22,12 +22,12 @@ sap_inst_directory:
       - nfs-client
   {% else %}
   mount.mounted:
-    - name: {{grains['hana_inst_folder']}}
-    - device: {{grains['hana_inst_master']}}
+    - name: {{ grains['hana_inst_folder'] }}
+    - device: {{ grains['hana_inst_master'] }}
     - fstype: cifs
     - mkmnt: True
     - persist: True
-    - opts: vers=3.0,username={{grains['storage_account_name']}},password={{grains['storage_account_key']}},dir_mode=0777,file_mode=0777,sec=ntlmssp
+    - opts: vers=3.0,username={{ grains['storage_account_name'] }},password={{ grains['storage_account_key'] }},dir_mode=0777,file_mode=0777,sec=ntlmssp
     - required:
       - nfs-client
   {% endif %}

--- a/salt/hana_node/ssh.sls
+++ b/salt/hana_node/ssh.sls
@@ -1,29 +1,29 @@
 cluster:
   ssh_auth.present:
-    - source: {{grains['cluster_ssh_pub']}}
+    - source: {{ grains['cluster_ssh_pub'] }}
     - user: root
     - config: '/%u/.ssh/authorized_keys'
 
 /root/.ssh/id_rsa:
   file.managed:
-    - source: {{grains['cluster_ssh_key']}}
+    - source: {{ grains['cluster_ssh_key'] }}
     - user: root
     - group: root
-    - mode: 600
+    - mode: "0600"
 
 /root/.ssh/id_rsa.pub:
   file.managed:
-    - source: {{grains['cluster_ssh_pub']}}
+    - source: {{ grains['cluster_ssh_pub'] }}
     - user: root
     - group: root
-    - mode: 644
+    - mode: "0644"
 
 /etc/ssh/sshd_config:
   file.replace:
     - pattern: 'PasswordAuthentication no'
     - repl: 'PasswordAuthentication yes'
     - append_if_not_found: True
- 
+
 sshd:
   service.running:
     - watch:

--- a/salt/iscsi_srv/qa_iscsi.sls
+++ b/salt/iscsi_srv/qa_iscsi.sls
@@ -4,7 +4,7 @@
     - source: salt://iscsi_srv/files/qa_conf/saveconfig.json
     - user: root
     - group: root
-    - mode: 600
+    - mode: "0600"
     - template: jinja
 
 restart_targetcli:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -8,7 +8,6 @@ base:
     - match: grain
     - iscsi_srv
 
- 
   'role:monitoring':
     - match: grain
     - default


### PR DESCRIPTION
This PR adds two jobs to the Travis config to perform `jsonlint` and `salt-lint` on `.json` and `.sls` files respectively.

It also consequently applies linting to the salt files, which did not comply with the default linter rules.