### PR TITLE
add system-wide disk usage statistics and update previous panel accordingly

### DIFF
--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -83,8 +83,8 @@ groups:
       summary: hanadb exporter service not running
 
   - alert: node-filesystem-space-low
-    expr: ((node_filesystem_size_bytes{fstype!="tmpfs"} - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100) > 90
+    expr: ((node_filesystem_size_bytes{fstype!="tmpfs"} - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100) > 85
     labels:
       severity: page
     annotations:
-      summary: node filesystem space usage is higher than 90%
+      summary: node filesystem space usage is higher than 85%

--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -74,7 +74,7 @@ groups:
       severity: page
     annotations:
       summary: ha cluster exporter service not running
- 
+
   - alert: service-down-hanadb-exporter
     expr: node_systemd_unit_state{name=~"hanadb_exporter@.*.service", state="active"} == 0
     labels:

--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -81,3 +81,10 @@ groups:
       severity: page
     annotations:
       summary: hanadb exporter service not running
+
+  - alert: node-filesystem-space-low
+    expr: ((node_filesystem_size_bytes{fstype!="tmpfs"} - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100) > 90
+    labels:
+      severity: page
+    annotations:
+      summary: node filesystem space usage is higher than 90%

--- a/salt/monitoring/provisioning/dashboards/ha-sap-hana-detailed-timestamp.json
+++ b/salt/monitoring/provisioning/dashboards/ha-sap-hana-detailed-timestamp.json
@@ -1,4 +1,46 @@
 {
+  "__inputs": [
+    {
+      "name": "DS_PROMETHEUS_SHAP",
+      "label": "Prometheus SHAP",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "prometheus",
+      "pluginName": "Prometheus"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "6.3.5"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": ""
+    },
+    {
+      "type": "datasource",
+      "id": "prometheus",
+      "name": "Prometheus",
+      "version": "1.0.0"
+    },
+    {
+      "type": "panel",
+      "id": "singlestat",
+      "name": "Singlestat",
+      "version": ""
+    },
+    {
+      "type": "panel",
+      "id": "table",
+      "name": "Table",
+      "version": ""
+    }
+  ],
   "annotations": {
     "list": [
       {
@@ -624,7 +666,7 @@
       "fill": 1,
       "fillGradient": 0,
       "gridPos": {
-        "h": 9,
+        "h": 11,
         "w": 10,
         "x": 3,
         "y": 26
@@ -710,49 +752,32 @@
     },
     {
       "columns": [],
-      "datasource": "$hanadb_data_source",
-      "description": "Disk usage based on usage type.",
+      "datasource": "${DS_PROMETHEUS_SHAP}",
+      "description": "System-wide filesystem statistics",
       "fontSize": "100%",
       "gridPos": {
-        "h": 9,
+        "h": 5,
         "w": 11,
         "x": 13,
         "y": 26
       },
-      "id": 18,
+      "id": 97,
       "interval": "30s",
       "links": [],
       "options": {},
       "pageSize": null,
-      "repeat": null,
       "scroll": true,
       "showHeader": true,
       "sort": {
-        "col": 0,
-        "desc": true
+        "col": 1,
+        "desc": false
       },
       "styles": [
         {
-          "alias": "PATH",
+          "alias": "Mount point",
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "pattern": "path",
+          "pattern": "mountpoint",
           "type": "string"
-        },
-        {
-          "alias": "USAGE TYPE",
-          "colorMode": null,
-          "colors": [
-            "rgba(245, 54, 54, 0.9)",
-            "rgba(237, 129, 40, 0.89)",
-            "rgba(50, 172, 45, 0.97)"
-          ],
-          "dateFormat": "YYYY-MM-DD HH:mm:ss",
-          "decimals": 2,
-          "mappingType": 1,
-          "pattern": "usage_type",
-          "thresholds": [],
-          "type": "string",
-          "unit": "short"
         },
         {
           "alias": "Used Space",
@@ -768,10 +793,10 @@
           "pattern": "Value #A",
           "thresholds": [],
           "type": "number",
-          "unit": "decmbytes"
+          "unit": "bytes"
         },
         {
-          "alias": "FILE SYSTEM",
+          "alias": "Filesystem type",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -781,7 +806,7 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "filesystem_type",
+          "pattern": "fstype",
           "thresholds": [],
           "type": "string",
           "unit": "short"
@@ -800,7 +825,7 @@
           "pattern": "Value #B",
           "thresholds": [],
           "type": "number",
-          "unit": "decmbytes"
+          "unit": "bytes"
         },
         {
           "alias": "% Used",
@@ -822,7 +847,7 @@
           "unit": "percent"
         },
         {
-          "alias": "Device Size",
+          "alias": "Device",
           "colorMode": null,
           "colors": [
             "rgba(245, 54, 54, 0.9)",
@@ -832,10 +857,10 @@
           "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
           "mappingType": 1,
-          "pattern": "Value #D",
+          "pattern": "device",
           "thresholds": [],
           "type": "number",
-          "unit": "decmbytes"
+          "unit": "short"
         },
         {
           "alias": "",
@@ -845,7 +870,9 @@
             "rgba(237, 129, 40, 0.89)",
             "rgba(50, 172, 45, 0.97)"
           ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
           "decimals": 2,
+          "mappingType": 1,
           "pattern": "/.*/",
           "thresholds": [],
           "type": "hidden",
@@ -854,8 +881,9 @@
       ],
       "targets": [
         {
-          "expr": "hanadb_disk_used_size_mb{host=~\"$hana_node_name\"} + 0",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$hana_node_ip:\\\\d+$\", fstype!=\"tmpfs\"} - node_filesystem_avail_bytes",
           "format": "table",
+          "hide": false,
           "instant": true,
           "interval": "",
           "intervalFactor": 1,
@@ -863,33 +891,27 @@
           "refId": "A"
         },
         {
-          "expr": "hanadb_disk_total_size_mb{host=~\"$hana_node_name\"} + 0",
+          "expr": "node_filesystem_size_bytes{instance=~\"^$hana_node_ip:\\\\d+$\", fstype!=\"tmpfs\"}",
           "format": "table",
+          "hide": false,
           "instant": true,
           "intervalFactor": 1,
           "legendFormat": "Disk Total Size",
           "refId": "B"
         },
         {
-          "expr": "((hanadb_disk_used_size_mb{host=~\"$hana_node_name\"} / hanadb_disk_total_size_mb{host=~\"$hana_node_name\"}) * 100) ",
+          "expr": "(node_filesystem_size_bytes{instance=~\"^$hana_node_ip:\\\\d+$\", fstype!=\"tmpfs\"} - node_filesystem_avail_bytes) / node_filesystem_size_bytes * 100",
           "format": "table",
+          "hide": false,
           "instant": true,
           "intervalFactor": 1,
           "legendFormat": "Percent Used",
           "refId": "C"
-        },
-        {
-          "expr": "hanadb_disk_total_device_size_mb {host=~\"$hana_node_name\"} ",
-          "format": "table",
-          "instant": true,
-          "intervalFactor": 1,
-          "legendFormat": "Total Device Size",
-          "refId": "D"
         }
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Disk Usage",
+      "title": "Disk usage",
       "transform": "table",
       "type": "table"
     },
@@ -979,6 +1001,143 @@
         }
       ],
       "valueName": "current"
+    },
+    {
+      "columns": [],
+      "datasource": "$hanadb_data_source",
+      "description": "Details HANA on how HANA uses the filesystem in its various directories",
+      "fontSize": "100%",
+      "gridPos": {
+        "h": 6,
+        "w": 11,
+        "x": 13,
+        "y": 31
+      },
+      "id": 18,
+      "interval": "30s",
+      "links": [],
+      "options": {},
+      "pageSize": null,
+      "repeat": null,
+      "scroll": true,
+      "showHeader": true,
+      "sort": {
+        "col": 5,
+        "desc": false
+      },
+      "styles": [
+        {
+          "alias": "Path",
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "pattern": "path",
+          "type": "string"
+        },
+        {
+          "alias": "Usage type",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "usage_type",
+          "thresholds": [],
+          "type": "string",
+          "unit": "short"
+        },
+        {
+          "alias": "Used Space",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Value #A",
+          "thresholds": [],
+          "type": "number",
+          "unit": "mbytes"
+        },
+        {
+          "alias": "% Used",
+          "colorMode": "cell",
+          "colors": [
+            "rgba(50, 172, 45, 0.97)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(245, 54, 54, 0.9)"
+          ],
+          "dateFormat": "YYYY-MM-DD HH:mm:ss",
+          "decimals": 2,
+          "mappingType": 1,
+          "pattern": "Value #C",
+          "thresholds": [
+            "85",
+            "85"
+          ],
+          "type": "number",
+          "unit": "percent"
+        },
+        {
+          "alias": "",
+          "colorMode": null,
+          "colors": [
+            "rgba(245, 54, 54, 0.9)",
+            "rgba(237, 129, 40, 0.89)",
+            "rgba(50, 172, 45, 0.97)"
+          ],
+          "decimals": 2,
+          "pattern": "/.*/",
+          "thresholds": [],
+          "type": "hidden",
+          "unit": "short"
+        }
+      ],
+      "targets": [
+        {
+          "expr": "hanadb_disk_used_size_mb{host=~\"$hana_node_name\"} + 0",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "intervalFactor": 1,
+          "legendFormat": "Used Disk",
+          "refId": "A"
+        },
+        {
+          "expr": "hanadb_disk_total_size_mb{host=~\"$hana_node_name\"} + 0",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Disk Total Size",
+          "refId": "B"
+        },
+        {
+          "expr": "(hanadb_disk_used_size_mb{host=~\"$hana_node_name\"} / hanadb_disk_total_size_mb) * 100",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Percent Used",
+          "refId": "C"
+        },
+        {
+          "expr": "hanadb_disk_total_device_size_mb{host=~\"$hana_node_name\"}",
+          "format": "table",
+          "instant": true,
+          "intervalFactor": 1,
+          "legendFormat": "Total Device Size",
+          "refId": "D"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "HANA filesystem usage",
+      "transform": "table",
+      "type": "table"
     },
     {
       "cacheTimeout": null,
@@ -1090,7 +1249,7 @@
         "h": 5,
         "w": 3,
         "x": 3,
-        "y": 35
+        "y": 37
       },
       "id": 12,
       "interval": null,
@@ -1176,7 +1335,7 @@
         "h": 5,
         "w": 3,
         "x": 6,
-        "y": 35
+        "y": 37
       },
       "id": 28,
       "interval": null,
@@ -1262,7 +1421,7 @@
         "h": 5,
         "w": 3,
         "x": 9,
-        "y": 35
+        "y": 37
       },
       "id": 30,
       "interval": null,
@@ -1347,7 +1506,7 @@
         "h": 5,
         "w": 3,
         "x": 12,
-        "y": 35
+        "y": 37
       },
       "id": 26,
       "interval": null,
@@ -1433,7 +1592,7 @@
         "h": 5,
         "w": 3,
         "x": 15,
-        "y": 35
+        "y": 37
       },
       "id": 24,
       "interval": null,
@@ -1519,7 +1678,7 @@
         "h": 5,
         "w": 3,
         "x": 18,
-        "y": 35
+        "y": 37
       },
       "id": 20,
       "interval": null,
@@ -1606,7 +1765,7 @@
         "h": 5,
         "w": 3,
         "x": 21,
-        "y": 35
+        "y": 37
       },
       "id": 22,
       "interval": null,

--- a/salt/monitoring/provisioning/dashboards/ha-sap-hana-detailed-timestamp.json
+++ b/salt/monitoring/provisioning/dashboards/ha-sap-hana-detailed-timestamp.json
@@ -1,14 +1,5 @@
 {
-  "__inputs": [
-    {
-      "name": "DS_PROMETHEUS_SHAP",
-      "label": "Prometheus SHAP",
-      "description": "",
-      "type": "datasource",
-      "pluginId": "prometheus",
-      "pluginName": "Prometheus"
-    }
-  ],
+  "__inputs": [],
   "__requires": [
     {
       "type": "grafana",
@@ -752,7 +743,6 @@
     },
     {
       "columns": [],
-      "datasource": "${DS_PROMETHEUS_SHAP}",
       "description": "System-wide filesystem statistics",
       "fontSize": "100%",
       "gridPos": {


### PR DESCRIPTION
This PR changes the disk usage statistics presentation as illustrated.

Before:
![before](https://user-images.githubusercontent.com/2952427/66560893-a5092480-eb58-11e9-84f2-e0b532a3556c.png)

After:
![after](https://user-images.githubusercontent.com/2952427/66560896-a63a5180-eb58-11e9-8283-00cfe2ad253d.png)