### PR TITLE
Remove pillar entry as name has been changed

### DIFF
--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -17,7 +17,6 @@ cluster:
     device: /dev/watchdog
   sbd:
     device: {{ grains['sbd_disk_device'] }}
-  join_timer: 20
   ntp: pool.ntp.org
   {% if grains['provider'] == 'libvirt' %}
   sshkeys:


### PR DESCRIPTION
Value has been changed from `join_timer` to `wait_for_initialization`.
https://github.com/SUSE/habootstrap-formula/pull/30
`join_timer` is not used anywhere else.
Default value is 20 anyway.