### PR TITLE
Enable multi-cluster for hacluster (dashboard and configuration in prometheus) + doc

### DIFF
--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -30,7 +30,7 @@ Currently supported exporters:
 
 # Multi-cluster monitoring:
 
-For enabling multi-cluster in prometheus and our monitoring solution, you need to follow the schema in `/etc/prometheus/prometheus.yaml`.
+For enabling multi-cluster in prometheus and in our monitoring solution, you need to follow the schema in `/etc/prometheus/prometheus.yaml`.
 
 Each cluster is a different jobname. So if you have 2 cluster you will add 2 jobnames. like :
 
@@ -58,7 +58,7 @@ scrape_configs:
         - "10.162.32.238:9002" # 9002: ha_cluster_exporter metrics
 ```
 
-This will add in prometheus a label `job="cluster-asia-00" from where you can filter your different metrics.
+This will add in prometheus a label `job="hacluster-01` and  `job="hacluster-01`. In the grafana dashboard you will have a special switch on the top to switch clusters.
 
 
 ### SAP HANA database exporter

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -35,18 +35,27 @@ For enabling multi-cluster in prometheus and our monitoring solution, you need t
 Each cluster is a different jobname. So if you have 2 cluster you will add 2 jobnames. like :
 
 ```
-  - job_name: cluster-europe-00
-    metrics_path: /metrics
+scrape_configs:
+  - job_name: hacluster-01
     static_configs:
       - targets:
+        - "192.168.110.19:8001" # 8001: hanadb exporter port
+        - "192.168.110.20:8001" # 8001: hanadb exporter port
+        - "192.168.110.19:9100" # 9100: node exporter port
+        - "192.168.110.20:9100" # 9100: node exporter port
         - "192.168.110.19:9002" # 9002: ha_cluster_exporter metrics
         - "192.168.110.20:9002" # 9002: ha_cluster_exporter metrics
 
-  - job_name: cluster-asia-00
-    metrics_path: /metrics
+
+  - job_name: hacluster-02
     static_configs:
       - targets:
-        - "10.67.162.43:9002"
+        - "10.162.32.117:8001" # 8001: hanadb exporter port
+        - "10.162.32.238:8001" # 8001: hanadb exporter port
+        - "10.162.32.117:9100" # 9100: node exporter port
+        - "10.162.32.238:9100" # 9100: node exporter port
+        - "10.162.32.117:9002" # 9002: ha_cluster_exporter metrics
+        - "10.162.32.238:9002" # 9002: ha_cluster_exporter metrics
 ```
 
 This will add in prometheus a label `job="cluster-asia-00" from where you can filter your different metrics.

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -28,6 +28,30 @@ Currently supported exporters:
 - SAP-HANA database exporter
 - HA Cluster exporter (hawk-apiserver)
 
+# Multi-cluster monitoring:
+
+For enabling multi-cluster in prometheus and our monitoring solution, you need to follow the schema in `/etc/prometheus/prometheus.yaml`.
+
+Each cluster is a different jobname. So if you have 2 cluster you will add 2 jobnames. like :
+
+```
+  - job_name: cluster-europe-00
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+        - "192.168.110.19:9002" # 9002: ha_cluster_exporter metrics
+        - "192.168.110.20:9002" # 9002: ha_cluster_exporter metrics
+
+  - job_name: cluster-asia-00
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+        - "10.67.162.43:9002"
+```
+
+This will add in prometheus a label `job="cluster-asia-00" from where you can filter your different metrics.
+
+
 ### SAP HANA database exporter
 
 The SAP HANA database data is exporter using the [hanadb_exporter](https://github.com/SUSE/hanadb_exporter) prometheus exporter.

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -14,24 +14,17 @@ rule_files:
     - /etc/prometheus/rules.yml
 
 scrape_configs:
-  - job_name: hanadb
+  # in a multi-cluster scenario, add another job name called
+  #  hacluster-europe-02
+  - job_name: hacluster-europe-01
     static_configs:
       - targets:
         {% for ip in grains['monitored_hosts'] %}
         - "{{ ip }}:8001" # 8001: hanadb exporter port
         {% endfor %}
-
-  - job_name: node
-    static_configs:
-      - targets:
         {% for ip in grains['monitored_hosts'] %}
         - "{{ ip }}:9100" # 9100: node exporter port
         {% endfor %}
-
-  - job_name: cluster
-    metrics_path: /metrics
-    static_configs:
-      - targets:
         {% for ip in grains['monitored_hosts'] %}
         - "{{ ip }}:9002" # 9002: ha_cluster_exporter metrics
         {% endfor %}

--- a/salt/monitoring/prometheus/prometheus.yml
+++ b/salt/monitoring/prometheus/prometheus.yml
@@ -15,8 +15,8 @@ rule_files:
 
 scrape_configs:
   # in a multi-cluster scenario, add another job name called
-  #  hacluster-europe-02
-  - job_name: hacluster-europe-01
+  #  hacluster-02
+  - job_name: hacluster-01
     static_configs:
       - targets:
         {% for ip in grains['monitored_hosts'] %}

--- a/salt/monitoring/provisioning/dashboards/cluster-status-real-time-alerts.json
+++ b/salt/monitoring/provisioning/dashboards/cluster-status-real-time-alerts.json
@@ -1,43 +1,4 @@
 {
-  "__inputs": [],
-  "__requires": [
-    {
-      "type": "panel",
-      "id": "bargauge",
-      "name": "Bar Gauge",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "gauge",
-      "name": "Gauge",
-      "version": ""
-    },
-    {
-      "type": "grafana",
-      "id": "grafana",
-      "name": "Grafana",
-      "version": "6.3.5"
-    },
-    {
-      "type": "datasource",
-      "id": "prometheus",
-      "name": "Prometheus",
-      "version": "1.0.0"
-    },
-    {
-      "type": "panel",
-      "id": "singlestat",
-      "name": "Singlestat",
-      "version": ""
-    },
-    {
-      "type": "panel",
-      "id": "table",
-      "name": "Table",
-      "version": ""
-    }
-  ],
   "annotations": {
     "list": [
       {
@@ -55,8 +16,7 @@
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
-  "id": null,
-  "iteration": 1572885006030,
+  "iteration": 1573134324833,
   "links": [],
   "panels": [
     {
@@ -1444,107 +1404,6 @@
         }
       ],
       "valueName": "current"
-    },
-    {
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 0,
-        "y": 23
-      },
-      "id": 146,
-      "options": {
-        "displayMode": "basic",
-        "fieldOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "defaults": {
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 5001
-              }
-            ]
-          },
-          "override": {},
-          "values": false
-        },
-        "orientation": "horizontal"
-      },
-      "pluginVersion": "6.3.5",
-      "targets": [
-        {
-          "expr": "ha_cluster_pacemaker_migration_threshold{instance=~\"$hana_node_ip:9002\"}",
-          "hide": false,
-          "legendFormat": "{{ node }} {{resource}}",
-          "refId": "B"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Resource migration threshold",
-      "type": "bargauge"
-    },
-    {
-      "cacheTimeout": null,
-      "description": "",
-      "gridPos": {
-        "h": 7,
-        "w": 12,
-        "x": 12,
-        "y": 23
-      },
-      "id": 144,
-      "interval": "",
-      "links": [],
-      "options": {
-        "displayMode": "basic",
-        "fieldOptions": {
-          "calcs": [
-            "mean"
-          ],
-          "defaults": {
-            "mappings": [],
-            "max": 100,
-            "min": 0,
-            "thresholds": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 80
-              }
-            ],
-            "unit": "none"
-          },
-          "override": {},
-          "values": false
-        },
-        "orientation": "horizontal"
-      },
-      "pluginVersion": "6.3.5",
-      "targets": [
-        {
-          "expr": "ha_cluster_pacemaker_fail_count{instance=~\"$hana_node_ip:9002\"}",
-          "intervalFactor": 1,
-          "legendFormat": "{{ node}} {{ resource }}",
-          "refId": "A"
-        }
-      ],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "Cluster resource failcount",
-      "type": "bargauge"
     }
   ],
   "refresh": "5s",
@@ -1574,14 +1433,14 @@
         "allValue": null,
         "current": {},
         "datasource": "$hanadb_data_source",
-        "definition": "label_values(node_uname_info, nodename)",
+        "definition": "label_values(node_uname_info{job=\"$hacluster\"}, nodename)",
         "hide": 0,
         "includeAll": false,
         "label": "HANA Node",
         "multi": false,
         "name": "hana_node_name",
         "options": [],
-        "query": "label_values(node_uname_info, nodename)",
+        "query": "label_values(node_uname_info{job=\"$hacluster\"}, nodename)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1596,14 +1455,14 @@
         "allValue": null,
         "current": {},
         "datasource": "$hanadb_data_source",
-        "definition": "label_values(node_uname_info{nodename=~\"$hana_node_name\"}, instance)",
+        "definition": "label_values(node_uname_info{nodename=~\"$hana_node_name\", job=\"$hacluster\"}, instance)",
         "hide": 0,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "hana_node_ip",
         "options": [],
-        "query": "label_values(node_uname_info{nodename=~\"$hana_node_name\"}, instance)",
+        "query": "label_values(node_uname_info{nodename=~\"$hana_node_name\", job=\"$hacluster\"}, instance)",
         "refresh": 2,
         "regex": "^(.*):\\d+$",
         "skipUrlSync": false,
@@ -1618,14 +1477,14 @@
         "allValue": null,
         "current": {},
         "datasource": "$hanadb_data_source",
-        "definition": "label_values(node_uname_info{nodename=~\".*1\"}, nodename)",
+        "definition": "label_values(node_uname_info{nodename=~\".*1\", job=\"$hacluster\"}, nodename)",
         "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "hana_node_name_1",
         "options": [],
-        "query": "label_values(node_uname_info{nodename=~\".*1\"}, nodename)",
+        "query": "label_values(node_uname_info{nodename=~\".*1\", job=\"$hacluster\"}, nodename)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1640,14 +1499,14 @@
         "allValue": null,
         "current": {},
         "datasource": "$hanadb_data_source",
-        "definition": "label_values(node_uname_info{nodename=~\".*2\"}, nodename)",
+        "definition": "label_values(node_uname_info{nodename=~\".*2\", job=\"$hacluster\"}, nodename)",
         "hide": 2,
         "includeAll": false,
         "label": null,
         "multi": false,
         "name": "hana_node_name_2",
         "options": [],
-        "query": "label_values(node_uname_info{nodename=~\".*2\"}, nodename)",
+        "query": "label_values(node_uname_info{nodename=~\".*2\", job=\"$hacluster\"}, nodename)",
         "refresh": 2,
         "regex": "",
         "skipUrlSync": false,
@@ -1666,6 +1525,28 @@
         "name": "Filters",
         "skipUrlSync": false,
         "type": "adhoc"
+      },
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "Prometheus SHAP",
+        "definition": "label_values(job)",
+        "hide": 0,
+        "includeAll": false,
+        "label": "hacluster",
+        "multi": false,
+        "name": "hacluster",
+        "options": [],
+        "query": "label_values(job)",
+        "refresh": 2,
+        "regex": "",
+        "skipUrlSync": false,
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
       }
     ]
   },
@@ -1701,5 +1582,5 @@
   "timezone": "",
   "title": "HA Cluster Status",
   "uid": "Q5YJpwtZk1",
-  "version": 9
+  "version": 6
 }


### PR DESCRIPTION


- Add documentation
- Modify prometheus config accordingly
- adapt dashboard to reflect change with multi-cluster


# Play with:
http://10.162.31.91/d/Q5YJpwtZk1/ha-cluster-status?orgId=1&refresh=5s


# how it looks like:

See the botton in the top `hacluster` where you can switch



![new-dash](https://user-images.githubusercontent.com/10886597/68319182-2ef7cf00-00be-11ea-98cc-492731d7f311.png)