### PR TITLE
Add alert showcase for failcount threshold

### DIFF
--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -26,8 +26,18 @@ groups:
     annotations:
       summary: A cluster resource failed
 
-# sbd alerts
 
+# failcount exceed migration threshold (example on saphana specific resource)
+- name: resource-failcount-higher-threshold
+  rules:
+  - alert: resource-failcount-higher-threshold
+    expr: count(ha_cluster_pacemaker_fail_count > ha_cluster_pacemaker_migration_threshold) > 0
+    labels:
+      severity: page
+    annotations:
+      summary: the rsc_SAPHana_PRD_HDB00 has exceeded the limit threshold
+
+# sbd alerts
 - name: sbd-device-alerts
   rules:
   - alert: a-sbd-device-unhealthy


### PR DESCRIPTION
I might need to test this later on.

I couldn't figure out how we can add a generic alert for all resource so it is better to make a specific one and sys-admin can adapt on this showcase