### PR TITLE
Fix the registration error of 'Valid metadata not found'.

### DIFF
--- a/salt/default/registration.sls
+++ b/salt/default/registration.sls
@@ -2,7 +2,8 @@
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:
-    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }} {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }}
+    - name: /usr/bin/SUSEConnect -r {{ grains['reg_code'] }} {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }} ||
+        (zypper --non-interactive --gpg-auto-import-keys refresh --force --services && exit 1)
     - retry:
         attempts: 3
         interval: 15


### PR DESCRIPTION
Error message when register like:
[Error]
...
Error building the cache:
[SUSE_Linux_Enterprise_Server_15_SP1_x86_64:
SLE-Product-SLES15-SP1-Updates|https://updates.suse.com/SUSE/Updates/
SLE-Product-SLES/15-SP1/x86_64/update?XXXX]
Valid metadata not found at specified URL
Some of the repositories have not been refreshed because of an error.
No provider of 'sle-module-basesystem' found.'
...

Bad consequence:
The SLE module is not succeed register. Then the following
modules like "SLE-HA" may fail due to lack of requirement.
'Unmet product dependencies. Activate one of these products
first: Server Applications Module 15 SP1 x86_64'

Fix:
1. Refresh the repo with key import:
Retrieving repository 'SLE-Module-Basesystem15-SP1-Pool' metadata [.
Automatically importing the following key:
  Repository:       SLE-Module-Basesystem15-SP1-Pool
  Key Name:         SuSE Package Signing Key <build@suse.de>
  Key Fingerprint:  FEAB5025 39D846DB 2C0961CA 70AF9E81 39DB7C82
  Key Created:      Wed Dec  7 11:57:35 2016
  Key Expires:      Sun Dec  6 11:57:35 2020
  Rpm Name:         gpg-pubkey-39db7c82-5847eb1f
done]
Forcing building of repository cache
Building repository 'SLE-Module-Basesystem15-SP1-Pool' cache [....done]
2. Redo the registration of base module.

Step to reproduce:
1. Register against SLE15SP1.
2. register modules like:
reg_additional_modules = {
    "sle-module-server-applications/15.1/x86_64" = ""
    "sle-module-containers/15.1/x86_64" = ""
    "sle-ha/15.1/x86_64" = "<HA_REG_CODE>"
}