### PR TITLE
Update pillar files to work with latest salt formulas

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -65,6 +65,8 @@ ha_sap_deployment_repo = ""
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -84,6 +84,8 @@ ha_sap_deployment_repo = ""
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -67,6 +67,8 @@ ha_sap_deployment_repo = ""
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -22,6 +22,8 @@ devel_mode = false
 # Optional SUSE Customer Center Registration parameters
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
+
+# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
 #reg_additional_modules = {
 #    "sle-module-adv-systems-management/12/x86_64" = ""
 #    "sle-module-containers/12/x86_64" = ""

--- a/pillar_examples/automatic/cluster.sls
+++ b/pillar_examples/automatic/cluster.sls
@@ -34,12 +34,7 @@ cluster:
   configure:
     method: update
     template:
-      # When the package salt-standalone-formulas-configuration is finally released, only the first path will be used
-      {% if grains['osrelease_info'][0] == 15 and grains['osrelease_info']|length > 1 and grains['osrelease_info'][1] >= 1 %}
       source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
-      {% else %}
-      source: /srv/salt/hana/templates/scale_up_resources.j2
-      {% endif %}
       parameters:
         sid: {{ hana.hana.nodes[0].sid }}
         instance: {{ hana.hana.nodes[0].instance }}

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -15,7 +15,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
+      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: "00"

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -15,7 +15,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
+      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: "00"

--- a/pillar_examples/libvirt/cost_optimized/cluster.sls
+++ b/pillar_examples/libvirt/cost_optimized/cluster.sls
@@ -17,7 +17,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
+      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: "00"

--- a/pillar_examples/libvirt/performance_optimized/cluster.sls
+++ b/pillar_examples/libvirt/performance_optimized/cluster.sls
@@ -17,7 +17,7 @@ cluster:
   configure:
     method: 'update'
     template:
-      source: /srv/salt/hana/templates/scale_up_resources.j2 #This path changes beyond SLES15SP1
+      source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       parameters:
         sid: prd
         instance: "00"


### PR DESCRIPTION
A quick PR to adapt the pillar files to work with the latest salt formulas.

To make you see which is the requirement for sle12 version mainly.