### PR TITLE
Fix count argument backwards compat

### DIFF
--- a/aws/salt_provisioner.tf
+++ b/aws/salt_provisioner.tf
@@ -79,7 +79,7 @@ EOF
 }
 
 resource "null_resource" "hana_node_provisioner" {
-  count = var.provisioner == "salt" ? length(aws_instance.clusternodes) : 0
+  count = var.provisioner == "salt" ? var.ninstances : 0
 
   triggers = {
     cluster_instance_ids = join(",", aws_instance.clusternodes.*.id)

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -80,7 +80,7 @@ EOF
 }
 
 resource "null_resource" "hana_node_provisioner" {
-  count = var.provisioner == "salt" ? length(azurerm_virtual_machine.clusternodes) : 0
+  count = var.provisioner == "salt" ? var.ninstances : 0
 
   triggers = {
     cluster_instance_ids = join(",", azurerm_virtual_machine.clusternodes.*.id)

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -71,7 +71,7 @@ partitions:
   5:
     start: 80%
     end: 100%
- 
+
 EOF
 
 
@@ -87,7 +87,7 @@ provisioner "remote-exec" {
 }
 
 resource "null_resource" "hana_node_provisioner" {
-  count = var.provisioner == "salt" ? length(google_compute_instance.clusternodes) : 0
+  count = var.provisioner == "salt" ? var.ninstances : 0
 
   triggers = {
     cluster_instance_ids = join(",", google_compute_instance.clusternodes.*.id)

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -12,7 +12,7 @@ data "template_file" "hana_salt_provisioner" {
 }
 
 resource "null_resource" "hana_node_provisioner" {
-  count = var.provisioner == "salt" ? length(libvirt_domain.hana_domain) : 0
+  count = var.provisioner == "salt" ? var.hana_count : 0
   triggers = {
     hana_ids = libvirt_domain.hana_domain[count.index].id
   }

--- a/libvirt/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/modules/iscsi_server/salt_provisioner.tf
@@ -8,7 +8,7 @@ data "template_file" "salt_provisioner" {
 }
 
 resource "null_resource" "iscsi_provisioner" {
-  count = var.provisioner == "salt" ? length(libvirt_domain.iscsisrv) : 0
+  count = var.provisioner == "salt" ? var.iscsi_count : 0
 
   triggers = {
     iscsi_id = libvirt_domain.iscsisrv[count.index].id

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -12,7 +12,7 @@ data "template_file" "netweaver_salt_provisioner" {
 }
 
 resource "null_resource" "netweaver_node_provisioner" {
-  count = var.provisioner == "salt" ? length(libvirt_domain.netweaver_domain) : 0
+  count = var.provisioner == "salt" ? var.netweaver_count : 0
   triggers = {
     netweaver_ids = libvirt_domain.netweaver_domain[count.index].id
   }


### PR DESCRIPTION
After pulling the latest updates, running any `terraform` command (including destroy)  on existing deployments will fail with the following:

```
Error: Invalid count argument

  on modules/netweaver_node/salt_provisioner.tf line 15, in resource "null_resource" "netweaver_node_provisioner":
  15:   count = var.provisioner == "salt" ? length(libvirt_domain.netweaver_domain) : 0

The "count" value depends on resource attributes that cannot be determined
until apply, so Terraform cannot predict how many instances will be created.
To work around this, use the -target argument to first apply only the
resources that the count depends on.
```

This is due to the `libvirt_domain.netweaver_domain` resource not being initialized.
Using the `netweaver_count` var directly fixes the problem and allows to migrate to the new tfstate.