### PR TITLE
simplify monitoring resource references

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -57,21 +57,17 @@ data "aws_instance" "monitoring" {
 }
 
 output "monitoring_ip" {
-  type = "string"
   value = data.aws_instance.monitoring.0.private_ip
 }
 
 output "monitoring_public_ip" {
-  type = "string"
   value = data.aws_instance.monitoring.0.public_ip
 }
 
 output "monitoring_name" {
-  type = "string"
   value = data.aws_instance.monitoring.0.id
 }
 
 output "monitoring_public_name" {
-  type = "string"
   value = data.aws_instance.monitoring.0.public_dns
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -53,21 +53,25 @@ output "cluster_nodes_public_name" {
 
 data "aws_instance" "monitoring" {
   count       = var.monitoring_enabled == true ? 1 : 0
-  instance_id = element(aws_instance.monitoring.*.id, count.index)
+  instance_id = aws_instance.monitoring.0.id
 }
 
 output "monitoring_ip" {
-  value = data.aws_instance.monitoring.*.private_ip
+  type = "string"
+  value = data.aws_instance.monitoring.0.private_ip
 }
 
 output "monitoring_public_ip" {
-  value = data.aws_instance.monitoring.*.public_ip
+  type = "string"
+  value = data.aws_instance.monitoring.0.public_ip
 }
 
 output "monitoring_name" {
-  value = data.aws_instance.monitoring.*.id
+  type = "string"
+  value = data.aws_instance.monitoring.0.id
 }
 
 output "monitoring_public_name" {
-  value = data.aws_instance.monitoring.*.public_dns
+  type = "string"
+  value = data.aws_instance.monitoring.0.public_dns
 }

--- a/aws/salt_provisioner.tf
+++ b/aws/salt_provisioner.tf
@@ -150,14 +150,14 @@ EOF
 }
 
 resource "null_resource" "monitoring_provisioner" {
-  count = var.provisioner == "salt" ? length(aws_instance.monitoring) : 0
+  count = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
 
   triggers = {
-    monitoring_id = join(",", aws_instance.monitoring.*.id)
+    monitoring_id = aws_instance.monitoring.0.id
   }
 
   connection {
-    host        = element(aws_instance.monitoring.*.public_ip, count.index)
+    host        = aws_instance.monitoring.0.public_ip
     type        = "ssh"
     user        = "ec2-user"
     private_key = file(var.private_key_location)

--- a/azure/instances.tf
+++ b/azure/instances.tf
@@ -136,7 +136,7 @@ resource "azurerm_virtual_machine" "monitoring" {
   count                 = var.monitoring_enabled == true ? 1 : 0
   location              = var.az_region
   resource_group_name   = azurerm_resource_group.myrg.name
-  network_interface_ids = [element(azurerm_network_interface.monitoring.*.id, count.index)]
+  network_interface_ids = [azurerm_network_interface.monitoring.0.id]
   availability_set_id   = azurerm_availability_set.myas.id
   vm_size               = "Standard_D2s_v3"
 
@@ -148,7 +148,7 @@ resource "azurerm_virtual_machine" "monitoring" {
   }
 
   storage_image_reference {
-    id        = var.monitoring_uri != "" ? join(",", azurerm_image.monitoring.*.id) : ""
+    id        = var.monitoring_uri != "" ? azurerm_image.monitoring.0.id : ""
     publisher = var.monitoring_uri != "" ? "" : var.monitoring_public_publisher
     offer     = var.monitoring_uri != "" ? "" : var.monitoring_public_offer
     sku       = var.monitoring_uri != "" ? "" : var.monitoring_public_sku

--- a/azure/network.tf
+++ b/azure/network.tf
@@ -181,7 +181,7 @@ resource "azurerm_network_interface" "monitoring" {
     subnet_id                     = azurerm_subnet.mysubnet.id
     private_ip_address_allocation = "static"
     private_ip_address            = var.monitoring_srv_ip
-    public_ip_address_id          = element(azurerm_public_ip.monitoring.*.id, count.index)
+    public_ip_address_id          = azurerm_public_ip.monitoring.0.id
   }
 
   tags = {

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -71,14 +71,14 @@ output "cluster_nodes_public_name" {
 # Monitoring
 
 data "azurerm_public_ip" "monitoring" {
-  count = var.monitoring_enabled == true ? 1 : 0
-  name  = azurerm_public_ip.monitoring.0.name
+  count               = var.monitoring_enabled == true ? 1 : 0
+  name                = azurerm_public_ip.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }
 
 data "azurerm_network_interface" "monitoring" {
-  count = var.monitoring_enabled == true ? 1 : 0
-  name  = azurerm_network_interface.monitoring.0.name
+  count               = var.monitoring_enabled == true ? 1 : 0
+  name                = azurerm_network_interface.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }
 

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -72,34 +72,32 @@ output "cluster_nodes_public_name" {
 
 data "azurerm_public_ip" "monitoring" {
   count = var.monitoring_enabled == true ? 1 : 0
-  name  = element(azurerm_public_ip.monitoring.*.name, count.index)
-  resource_group_name = element(
-    azurerm_virtual_machine.monitoring.*.resource_group_name,
-    count.index,
-  )
+  name  = azurerm_public_ip.monitoring.0.name
+  resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }
 
 data "azurerm_network_interface" "monitoring" {
   count = var.monitoring_enabled == true ? 1 : 0
-  name  = element(azurerm_network_interface.monitoring.*.name, count.index)
-  resource_group_name = element(
-    azurerm_virtual_machine.monitoring.*.resource_group_name,
-    count.index,
-  )
+  name  = element(azurerm_network_interface.monitoring.0.name, count.index)
+  resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }
 
 output "monitoring_ip" {
-  value = data.azurerm_network_interface.monitoring.*.private_ip_address
+  type = "string"
+  value = data.azurerm_network_interface.monitoring.0.private_ip_address
 }
 
 output "monitoring_public_ip" {
-  value = data.azurerm_public_ip.monitoring.*.ip_address
+  type = "string"
+  value = data.azurerm_public_ip.monitoring.0.ip_address
 }
 
 output "monitoring_name" {
-  value = azurerm_virtual_machine.monitoring.*.name
+  type = "string"
+  value = azurerm_virtual_machine.monitoring.0.name
 }
 
 output "monitoring_public_name" {
-  value = data.azurerm_public_ip.monitoring.*.fqdn
+  type = "string"
+  value = data.azurerm_public_ip.monitoring.0.fqdn
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -78,7 +78,7 @@ data "azurerm_public_ip" "monitoring" {
 
 data "azurerm_network_interface" "monitoring" {
   count = var.monitoring_enabled == true ? 1 : 0
-  name  = element(azurerm_network_interface.monitoring.0.name, count.index)
+  name  = azurerm_network_interface.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }
 

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -83,21 +83,17 @@ data "azurerm_network_interface" "monitoring" {
 }
 
 output "monitoring_ip" {
-  type = "string"
   value = data.azurerm_network_interface.monitoring.0.private_ip_address
 }
 
 output "monitoring_public_ip" {
-  type = "string"
   value = data.azurerm_public_ip.monitoring.0.ip_address
 }
 
 output "monitoring_name" {
-  type = "string"
   value = azurerm_virtual_machine.monitoring.0.name
 }
 
 output "monitoring_public_name" {
-  type = "string"
   value = data.azurerm_public_ip.monitoring.0.fqdn
 }

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -153,7 +153,7 @@ EOF
 
 
 resource "null_resource" "monitoring_provisioner" {
-  count = var.provisioner == "salt" ? length(azurerm_virtual_machine.monitoring) : 0
+  count = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
 
   triggers = {
     monitoring_id = azurerm_virtual_machine.monitoring.0.id

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -156,12 +156,12 @@ resource "null_resource" "monitoring_provisioner" {
   count = var.provisioner == "salt" ? length(azurerm_virtual_machine.monitoring) : 0
 
   triggers = {
-    monitoring_id = join(",", azurerm_virtual_machine.monitoring.*.id)
+    monitoring_id = azurerm_virtual_machine.monitoring.0.id
   }
 
   connection {
     host = element(
-      data.azurerm_public_ip.monitoring.*.ip_address,
+      data.azurerm_public_ip.monitoring.0.ip_address,
       count.index,
     )
     type        = "ssh"

--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -160,10 +160,7 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host = element(
-      data.azurerm_public_ip.monitoring.0.ip_address,
-      count.index,
-    )
+    host        = azurerm_public_ip.monitoring.0.ip_address
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -43,21 +43,17 @@ output "cluster_nodes_public_name" {
 # Monitoring
 
 output "monitoring_ip" {
-  type = "string"
   value = google_compute_instance.monitoring.0.network_interface.0.network_ip
 }
 
 output "monitoring_public_ip" {
-  type = "string"
   value = google_compute_instance.monitoring.0.network_interface.0.access_config.0.nat_ip
 }
 
 output "monitoring_name" {
-  type = "string"
   value = google_compute_instance.monitoring.0.name
 }
 
 output "monitoring_public_name" {
-  type = "string"
   value = ""
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -43,17 +43,21 @@ output "cluster_nodes_public_name" {
 # Monitoring
 
 output "monitoring_ip" {
-  value = google_compute_instance.monitoring.*.network_interface.0.network_ip
+  type = "string"
+  value = google_compute_instance.monitoring.0.network_interface.0.network_ip
 }
 
 output "monitoring_public_ip" {
-  value = google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip
+  type = "string"
+  value = google_compute_instance.monitoring.0.network_interface.0.access_config.0.nat_ip
 }
 
 output "monitoring_name" {
-  value = google_compute_instance.monitoring.*.name
+  type = "string"
+  value = google_compute_instance.monitoring.0.name
 }
 
 output "monitoring_public_name" {
-  value = []
+  type = "string"
+  value = ""
 }

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -71,7 +71,7 @@ partitions:
   5:
     start: 80%
     end: 100%
- 
+
 EOF
 
 
@@ -173,12 +173,12 @@ resource "null_resource" "monitoring_provisioner" {
   count = var.provisioner == "salt" ? length(google_compute_instance.monitoring) : 0
 
   triggers = {
-    cluster_instance_ids = join(",", google_compute_instance.monitoring.*.id)
+    cluster_instance_id = google_compute_instance.monitoring.0.id
   }
 
   connection {
     host = element(
-      google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip,
+      google_compute_instance.monitoring.0.network_interface.0.access_config.0.nat_ip,
       count.index,
     )
     type        = "ssh"

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -177,10 +177,7 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host = element(
-      google_compute_instance.monitoring.0.network_interface.0.access_config.0.nat_ip,
-      count.index,
-    )
+    host        = google_compute_instance.monitoring.0.network_interface.0.access_config.0.nat_ip
     type        = "ssh"
     user        = "root"
     private_key = file(var.private_key_location)

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -170,7 +170,7 @@ provisioner "remote-exec" {
 }
 
 resource "null_resource" "monitoring_provisioner" {
-  count = var.provisioner == "salt" ? length(google_compute_instance.monitoring) : 0
+  count = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
 
   triggers = {
     cluster_instance_id = google_compute_instance.monitoring.0.id

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -87,7 +87,7 @@ module "hana_node" {
 module "monitoring" {
   source                 = "./modules/monitoring"
   name                   = "monitoring"
-  monitoring_count       = var.monitoring_enabled == true ? 1 : 0
+  monitoring_enabled     = var.monitoring_enabled
   monitoring_image       = var.monitoring_image
   base_image_id          = libvirt_volume.base_image.id
   vcpu                   = 4

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -7,25 +7,20 @@ resource "libvirt_volume" "monitoring_main_disk" {
   source          = var.monitoring_image
   base_volume_id  = var.monitoring_image == "" ? var.base_image_id: ""
   pool            = var.pool
-  count           = var.monitoring_count
+  count           = var.monitoring_enabled == true ? 1 : 0
 }
 
 resource "libvirt_domain" "monitoring_domain" {
   name       = "${terraform.workspace}-${var.name}"
-  count      = var.monitoring_count
+  count      = var.monitoring_enabled == true ? 1 : 0
   memory     = var.memory
   vcpu       = var.vcpu
   qemu_agent = true
-  dynamic "disk" {
-    for_each = [
-        {
-          "vol_id" = element(libvirt_volume.monitoring_main_disk.*.id, count.index)
-        },
-      ]
-    content {
-      volume_id = disk.value.vol_id
-    }
+
+  disk {
+      volume_id = libvirt_volume.monitoring_main_disk.0.id
   }
+
   network_interface {
     wait_for_lease = true
     network_name   = var.network_name
@@ -37,7 +32,7 @@ resource "libvirt_domain" "monitoring_domain" {
     wait_for_lease = false
     network_id     = var.network_id
     hostname       = "${terraform.workspace}-${var.name}"
-    addresses      = [var. monitoring_srv_ip]
+    addresses      = [var.monitoring_srv_ip]
   }
 
   console {
@@ -65,9 +60,9 @@ resource "libvirt_domain" "monitoring_domain" {
 
 output "output_data" {
   value = {
-    id                = libvirt_domain.monitoring_domain.*.id
-    hostname          = libvirt_domain.monitoring_domain.*.name
-    private_addresses = [var. monitoring_srv_ip]
-    addresses         = libvirt_domain.monitoring_domain.*.network_interface.0.addresses.0
+    id              = libvirt_domain.monitoring_domain.0.id
+    hostname        = libvirt_domain.monitoring_domain.0.name
+    private_address = var.monitoring_srv_ip
+    address         = libvirt_domain.monitoring_domain.0.network_interface.0.addresses.0
   }
 }

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -14,7 +14,7 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host     = libvirt_domain.monitoring_domain[count.index].network_interface.0.addresses.0
+    host     = libvirt_domain.monitoring_domain.0.network_interface.0.addresses.0
     user     = "root"
     password = "linux"
   }

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -8,9 +8,9 @@ data "template_file" "monitoring_salt_provisioner" {
 }
 
 resource "null_resource" "monitoring_provisioner" {
-  count = var.provisioner == "salt" ? length(libvirt_domain.monitoring_domain) : 0
+  count = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
   triggers = {
-    monitoring_id = libvirt_domain.monitoring_domain[count.index].id
+    monitoring_id = libvirt_domain.monitoring_domain.0.id
   }
 
   connection {

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -45,9 +45,10 @@ variable "bridge" {
   default     = ""
 }
 
-variable "monitoring_count" {
-  description = "number of hosts like this one"
-  default     = 1
+variable "monitoring_enabled" {
+  description = "whether or not to enable this module"
+  type        = bool
+  default     = true
 }
 
 variable "vcpu" {

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -33,22 +33,18 @@ output "iscsisrv_public_name" {
 }
 
 output "monitoring_ip" {
-  type = "string"
   value = module.monitoring.output_data.private_address
 }
 
 output "monitoring_public_ip" {
-  type = "string"
   value = module.monitoring.output_data.public_address
 }
 
 output "monitoring_name" {
-  type = "string"
   value = module.monitoring.output_data.hostname
 }
 
 output "monitoring_public_name" {
-  type = "string"
   value = ""
 }
 

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -37,7 +37,7 @@ output "monitoring_ip" {
 }
 
 output "monitoring_public_ip" {
-  value = module.monitoring.output_data.public_address
+  value = module.monitoring.output_data.address
 }
 
 output "monitoring_name" {

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -33,19 +33,23 @@ output "iscsisrv_public_name" {
 }
 
 output "monitoring_ip" {
-  value = module.monitoring.output_data.private_addresses
+  type = "string"
+  value = module.monitoring.output_data.private_address
 }
 
 output "monitoring_public_ip" {
-  value = module.monitoring.output_data.addresses
+  type = "string"
+  value = module.monitoring.output_data.public_address
 }
 
 output "monitoring_name" {
+  type = "string"
   value = module.monitoring.output_data.hostname
 }
 
 output "monitoring_public_name" {
-  value = []
+  type = "string"
+  value = ""
 }
 
 output "netweaver_nodes_ip" {


### PR DESCRIPTION
This PR simplifies HCL code that treats monitoring resources as multiple, because we actually support only one single Prometheus/Grafana host.

All monitoring related resources are now consistently looked up via the `0` index, and the outputs are strings instead of tuples.