### PR TITLE
Fix ssh connection to monitoring provisioner in azure

### DIFF
--- a/azure/salt_provisioner.tf
+++ b/azure/salt_provisioner.tf
@@ -160,7 +160,7 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host        = azurerm_public_ip.monitoring.0.ip_address
+    host        = data.azurerm_public_ip.monitoring.0.ip_address
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)

--- a/gcp/salt_provisioner.tf
+++ b/gcp/salt_provisioner.tf
@@ -19,7 +19,7 @@ resource "null_resource" "iscsi_provisioner" {
   }
 
   connection {
-    host        = google_compute_instance.iscsisrv.network_interface[0].access_config[0].nat_ip
+    host        = google_compute_instance.iscsisrv.network_interface.0.access_config.0.nat_ip
     type        = "ssh"
     user        = "root"
     private_key = file(var.private_key_location)


### PR DESCRIPTION
Fix ssh connection to monitoring provisioner in azure.

PD: The change in gcp is just to have same syntax