### PR TITLE
Add DRBD handler mechanism for splitbrain metrics

### DIFF
--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -64,15 +64,15 @@ This will add in prometheus a label `job="hacluster-01` and  `job="hacluster-01`
 
 # Drbd splitbrain metric enablement.
 
-In order to activate a specific metric for detecting the splitbrain occuring on drbd, you need to activate the custom handler. 
+In order to activate the metric for detecting the splitbrain occuring on drbd, you need to activate the custom handler via pillars.
 
 In the automatic pillar `drdb` directory this is already done.
 
-This handler will create a temporary file, which the `ha_cluster_exporter` will convert to a metric split brain.
+The handler will create a temporary file, which the `ha_cluster_exporter` will convert to a metric split brain.
 
 After the split brain occurs, the sysadmin/user should remove the file manually and taking other action on drbd.
 
-If the file persist, the ha_expoerter will alwasy detect the splitbrain mechanism
+If the file persist, the ha_expoerter will always detect the splitbrain mechanism.
 
 
 

--- a/doc/monitoring.md
+++ b/doc/monitoring.md
@@ -61,6 +61,21 @@ scrape_configs:
 This will add in prometheus a label `job="hacluster-01` and  `job="hacluster-01`. In the grafana dashboard you will have a special switch on the top to switch clusters.
 
 
+
+# Drbd splitbrain metric enablement.
+
+In order to activate a specific metric for detecting the splitbrain occuring on drbd, you need to activate the custom handler. 
+
+In the automatic pillar `drdb` directory this is already done.
+
+This handler will create a temporary file, which the `ha_cluster_exporter` will convert to a metric split brain.
+
+After the split brain occurs, the sysadmin/user should remove the file manually and taking other action on drbd.
+
+If the file persist, the ha_expoerter will alwasy detect the splitbrain mechanism
+
+
+
 ### SAP HANA database exporter
 
 The SAP HANA database data is exporter using the [hanadb_exporter](https://github.com/SUSE/hanadb_exporter) prometheus exporter.

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -59,7 +59,6 @@ drbd:
   #    after_resync_target: "/usr/lib/drbd/unsnapshot-resync-target-lvm.sh"
   #    # Optional: DRBD detected a split brain situation but remains unresolved. This handler should alert someone.
        split_brain: "/usr/lib/drbd/notify-split-brain-haclusterexporter-suse-metric.sh"
-       
   resource:
     - name: "sapdata"
       device: "/dev/drbd1"

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -66,7 +66,7 @@ drbd:
   #    # Optional: This handler is called after a resync operation finished on the node.
   #    after_resync_target: "/usr/lib/drbd/unsnapshot-resync-target-lvm.sh"
   #    # Optional: DRBD detected a split brain situation but remains unresolved. This handler should alert someone.
-  #    split_brain: "/usr/lib/drbd/notify-split-brain.sh root"
+       split_brain: "/usr/lib/drbd/notify-split-brain-haclusterexporter-suse-metric.sh"
 
 
   resource:

--- a/salt/drbd_node/custom_handlers.sls
+++ b/salt/drbd_node/custom_handlers.sls
@@ -1,4 +1,4 @@
 # install the custom handler for splitbrain
-/var/lib/drbd/notify-split-brain-haclusterexporter-suse-metric.sh
+/var/lib/drbd/notify-split-brain-haclusterexporter-suse-metric.sh:
   file.managed:
     - source: salt://drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh

--- a/salt/drbd_node/custom_handlers.sls
+++ b/salt/drbd_node/custom_handlers.sls
@@ -1,0 +1,4 @@
+# install the custom handler for splitbrain
+/var/lib/drbd/notify-split-brain-haclusterexporter-suse-metric.sh
+  file.managed:
+    - source: salt://drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh

--- a/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
+++ b/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
@@ -1,0 +1,13 @@
+#! /bin/bash
+
+# this is a custom handler for drbd splitbrain
+# see upstream doc https://docs.linbit.com/docs/users-guide-8.4/#s-configure-split-brain-behavior
+
+# the main goal of this handler signal via file when the splitbrain mechanism occurs.
+# the handler create a simple file which is then tracked by the ha_cluster_exporter https://github.com/ClusterLabs/ha_cluster_exporter
+# and from this file we create a metrics for detecting splitbrain and monitor it
+
+# remember to remove the file once the drbd splitbrain is over, otherwise the exporter will always set the metric of splitbrain to present
+
+mkdir -p /var/lib/drbd/ 
+echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected

--- a/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
+++ b/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
@@ -10,4 +10,4 @@
 # remember to remove the file once the drbd splitbrain is over, otherwise the exporter will always set the metric of splitbrain to present
 
 mkdir -p /var/lib/drbd/ 
-echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected
+echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected-$DRBD_RESOURCE

--- a/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
+++ b/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
@@ -10,4 +10,4 @@
 # remember to remove the file once the drbd splitbrain is over, otherwise the exporter will always set the metric of splitbrain to present
 
 mkdir -p /var/lib/drbd/ 
-echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected-$DRBD_RESOURCE
+echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected-$DRBD_RESOURCE-$DRBD_VOLUME

--- a/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
+++ b/salt/drbd_node/files/notify-split-brain-haclusterexporter-suse-metric.sh
@@ -9,5 +9,5 @@
 
 # remember to remove the file once the drbd splitbrain is over, otherwise the exporter will always set the metric of splitbrain to present
 
-mkdir -p /var/lib/drbd/ 
-echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/lib/drbd/drbd-split-brain-detected-$DRBD_RESOURCE-$DRBD_VOLUME
+mkdir -p /var/run/drbd/splitbrain
+echo "DRBD split-brain detected! Remember to remove the file /var/lib/drbd/drbd-split-brain-detected once the splitbrain is solved!" > /var/run/drbd/splitbrain/drbd-split-brain-detected-$DRBD_RESOURCE-$DRBD_VOLUME

--- a/salt/drbd_node/init.sls
+++ b/salt/drbd_node/init.sls
@@ -4,3 +4,4 @@ include:
   - drbd_node.cluster_packages
   - drbd_node.parted
   - drbd_node.formula
+  - drbd_node.custom_handlers


### PR DESCRIPTION
# Desc

This PR add :

1) documentation for the splitbrain handler.

2) By default we set to the pillars https://github.com/SUSE/ha-sap-terraform-deployments/pull/266/files#diff-8e808cd5eda64f32034e6f8c362eecbaR69 that we want to use our handler

3) it implement the basic custom handler which create a temp file

4) We install this handler via saltstack for each node.

# info
I tested this pr works fine