### PR TITLE
Add .gitattributes to fix EOL under Windows 

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*	text eol=lf


### PR DESCRIPTION
As there is a dependency on Unix style line endings due to the way Salt config files are assembled, I'd suggest to set the line endings style as part of the repository during initial clone/checkout (https://git-scm.com/docs/gitattributes#Documentation/gitattributes.txt-Settostringvalueauto). Otherwise git may by default change to CRLF under Windows.