### PR TITLE
Fix netweaver hostname

### DIFF
--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -57,7 +57,6 @@ resource "libvirt_domain" "drbd_domain" {
   network_interface {
     wait_for_lease = false
     network_id     = var.network_id
-    hostname       = "${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -57,7 +57,6 @@ resource "libvirt_domain" "hana_domain" {
   network_interface {
     wait_for_lease = false
     network_id     = var.network_id
-    hostname       = "${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -31,7 +31,6 @@ resource "libvirt_domain" "monitoring_domain" {
   network_interface {
     wait_for_lease = false
     network_id     = var.network_id
-    hostname       = "${terraform.workspace}-${var.name}"
     addresses      = [var.monitoring_srv_ip]
   }
 

--- a/libvirt/modules/netweaver_node/main.tf
+++ b/libvirt/modules/netweaver_node/main.tf
@@ -36,7 +36,6 @@ resource "libvirt_domain" "netweaver_domain" {
   network_interface {
     wait_for_lease = false
     network_id     = var.network_id
-    hostname       = "${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -36,7 +36,7 @@ resource "null_resource" "netweaver_node_provisioner" {
   provisioner "file" {
 content = <<EOF
 name_prefix: ${var.name}
-hostname: ${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}
+hostname: ${terraform.workspace}-${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}


### PR DESCRIPTION
This PR removes the `hostname` parameter from all the libvirt network interfaces, because it doesn't seem to have any actual effect, and fixes the hostname of the NetWeaver nodes which wasn't correctly interpolated in the salt provisioner grains.