### PR TITLE
Fix command that creates issues if file does not exist

### DIFF
--- a/salt/default/repos.sls
+++ b/salt/default/repos.sls
@@ -14,11 +14,11 @@ refresh_repos:
 workaround_susecloud_register:
   cmd.run:
     - name: |
-        rm /etc/SUSEConnect && /
-        rm -f $(ls /etc/zypp/{repos,services,credentials}.d/* | grep -v -e 'ha-factory' -e 'server_monitoring') && /
-        rm -f /usr/lib/zypp/plugins/services/* && /
-        sed -i '/^# Added by SMT reg/,+1d' /etc/hosts && /
-        /usr/sbin/registercloudguest --force-new && /
+        rm -f /etc/SUSEConnect &&
+        rm -f $(ls /etc/zypp/{repos,services,credentials}.d/* | grep -v -e 'ha-factory' -e 'server_monitoring') &&
+        rm -f /usr/lib/zypp/plugins/services/* &&
+        sed -i '/^# Added by SMT reg/,+1d' /etc/hosts &&
+        /usr/sbin/registercloudguest --force-new &&
         zypper --non-interactive --gpg-auto-import-keys refresh
     - retry:
         attempts: 3


### PR DESCRIPTION
The last workaround has an error if the `/etc/SUSEConnect` file doesn't exist;
```     Comment: Command "rm /etc/SUSEConnect && /
              rm -f $(ls /etc/zypp/{repos,services,credentials}.d/* | grep -v -e 'ha-factory' -e 'server_monitoring') && /
              rm -f /usr/lib/zypp/plugins/services/* && /
              sed -i '/^# Added by SMT reg/,+1d' /etc/hosts && /
              /usr/sbin/registercloudguest --force-new && /
              zypper --non-interactive --gpg-auto-import-keys refresh
              " run
     Started: 14:45:45.406444
    Duration: 7096.128 ms
     Changes:   
              ----------
              pid:
                  7140
              retcode:
                  0
              stderr:
                  /bin/bash: /: Is a directory
                  /bin/bash: line 1: /: Is a directory
                  /bin/bash: line 2: /: Is a directory
                  /bin/bash: line 3: /: Is a directory
```