### PR TITLE
Move some Netweaver and HANA OS and Network configurations to variables

### DIFF
--- a/azure/main.tf
+++ b/azure/main.tf
@@ -30,36 +30,41 @@ module "drbd_node" {
 }
 
 module "netweaver_node" {
-  source                     = "./modules/netweaver_node"
-  az_region                  = var.az_region
-  netweaver_count            = var.netweaver_enabled == true ? 4 : 0
-  netweaver_image_uri        = var.netweaver_image_uri
-  netweaver_public_publisher = var.netweaver_public_publisher
-  netweaver_public_offer     = var.netweaver_public_offer
-  netweaver_public_sku       = var.netweaver_public_sku
-  netweaver_public_version   = var.netweaver_public_version
-  resource_group_name        = azurerm_resource_group.myrg.name
-  network_subnet_id          = azurerm_subnet.mysubnet.id
-  sec_group_id               = azurerm_network_security_group.mysecgroup.id
-  storage_account            = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
-  public_key_location        = var.public_key_location
-  private_key_location       = var.private_key_location
-  cluster_ssh_pub            = var.cluster_ssh_pub
-  cluster_ssh_key            = var.cluster_ssh_key
-  admin_user                 = var.admin_user
-  netweaver_nfs_share        = "10.74.1.201:/HA1" # drbd cluster ip address is hardcoded by now
-  storage_account_name       = var.netweaver_storage_account_name
-  storage_account_key        = var.netweaver_storage_account_key
-  storage_account_path       = var.netweaver_storage_account
-  host_ips                   = var.netweaver_ips
-  virtual_host_ips           = var.netweaver_virtual_ips
-  iscsi_srv_ip               = azurerm_network_interface.iscsisrv.private_ip_address
-  reg_code                   = var.reg_code
-  reg_email                  = var.reg_email
-  reg_additional_modules     = var.reg_additional_modules
-  ha_sap_deployment_repo     = var.ha_sap_deployment_repo
-  devel_mode                 = var.devel_mode
-  provisioner                = var.provisioner
-  background                 = var.background
-  monitoring_enabled         = var.monitoring_enabled
+  source                        = "./modules/netweaver_node"
+  az_region                     = var.az_region
+  vm_size                       = var.netweaver_vm_size
+  data_disk_caching             = var.netweaver_data_disk_caching
+  data_disk_size                = var.netweaver_data_disk_size
+  data_disk_type                = var.netweaver_data_disk_type
+  netweaver_count               = var.netweaver_enabled == true ? 4 : 0
+  netweaver_image_uri           = var.netweaver_image_uri
+  netweaver_public_publisher    = var.netweaver_public_publisher
+  netweaver_public_offer        = var.netweaver_public_offer
+  netweaver_public_sku          = var.netweaver_public_sku
+  netweaver_public_version      = var.netweaver_public_version
+  resource_group_name           = azurerm_resource_group.myrg.name
+  network_subnet_id             = azurerm_subnet.mysubnet.id
+  sec_group_id                  = azurerm_network_security_group.mysecgroup.id
+  storage_account               = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
+  public_key_location           = var.public_key_location
+  private_key_location          = var.private_key_location
+  cluster_ssh_pub               = var.cluster_ssh_pub
+  cluster_ssh_key               = var.cluster_ssh_key
+  admin_user                    = var.admin_user
+  netweaver_nfs_share           = "10.74.1.201:/HA1" # drbd cluster ip address is hardcoded by now
+  storage_account_name          = var.netweaver_storage_account_name
+  storage_account_key           = var.netweaver_storage_account_key
+  storage_account_path          = var.netweaver_storage_account
+  enable_accelerated_networking = var.netweaver_enable_accelerated_networking
+  host_ips                      = var.netweaver_ips
+  virtual_host_ips              = var.netweaver_virtual_ips
+  iscsi_srv_ip                  = azurerm_network_interface.iscsisrv.private_ip_address
+  reg_code                      = var.reg_code
+  reg_email                     = var.reg_email
+  reg_additional_modules        = var.reg_additional_modules
+  ha_sap_deployment_repo        = var.ha_sap_deployment_repo
+  devel_mode                    = var.devel_mode
+  provisioner                   = var.provisioner
+  background                    = var.background
+  monitoring_enabled            = var.monitoring_enabled
 }

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -335,7 +335,7 @@ resource "azurerm_network_interface" "netweaver" {
   location                      = var.az_region
   resource_group_name           = var.resource_group_name
   network_security_group_id     = var.sec_group_id
-  enable_accelerated_networking = true
+  enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {
     name                          = "ipconf-primary"
@@ -379,7 +379,7 @@ resource "azurerm_virtual_machine" "netweaver" {
   resource_group_name   = var.resource_group_name
   network_interface_ids = [element(azurerm_network_interface.netweaver.*.id, count.index)]
   availability_set_id   = azurerm_availability_set.netweaver-availability-set[0].id
-  vm_size               = "Standard_D2s_v3"
+  vm_size               = var.vm_size
 
   storage_os_disk {
     name              = "disk-netweaver0${count.index + 1}-Os"
@@ -398,11 +398,11 @@ resource "azurerm_virtual_machine" "netweaver" {
 
   storage_data_disk {
     name              = "disk-netweaver0${count.index + 1}-Data01"
-    caching           = "ReadWrite"
+    caching           = var.data_disk_caching
     create_option     = "Empty"
-    disk_size_gb      = "10"
+    disk_size_gb      = var.data_disk_size
     lun               = "0"
-    managed_disk_type = "Standard_LRS"
+    managed_disk_type = var.data_disk_type
   }
 
   os_profile {

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -35,6 +35,7 @@ variable "data_disk_type" {
 }
 
 variable "data_disk_size" {
+  description = "Size of the Netweaver data disks, informed in GB"
   type    = string
   default = "60"
 }
@@ -90,6 +91,7 @@ variable "storage_account_path" {
 
 variable "enable_accelerated_networking" {
   description = "Enable accelerated networking for netweaver. This function is mandatory for certified Netweaver environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  type = bool
   default     = true
 }
 

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -24,6 +24,26 @@ variable "netweaver_count" {
   default = "2"
 }
 
+variable "vm_size" {
+  type    = string
+  default = "Standard_D4s_v3"
+}
+
+variable "data_disk_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+
+variable "data_disk_size" {
+  type    = string
+  default = "60"
+}
+
+variable "data_disk_caching" {
+  type    = string
+  default = "ReadWrite"
+}
+
 variable "ascs_instance_number" {
   description = "ASCS instance number"
   type        = string
@@ -66,6 +86,11 @@ variable "storage_account_key" {
 variable "storage_account_path" {
   description = "Azure storage account path where SAP Netweaver installation files are stored"
   type        = string
+}
+
+variable "enable_accelerated_networking" {
+  description = "Enable accelerated networking for netweaver. This function is mandatory for certified Netweaver environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  default     = true
 }
 
 variable "host_ips" {

--- a/azure/network.tf
+++ b/azure/network.tf
@@ -239,7 +239,7 @@ resource "azurerm_network_interface" "hana" {
   location                      = var.az_region
   resource_group_name           = azurerm_resource_group.myrg.name
   network_security_group_id     = azurerm_network_security_group.mysecgroup.id
-  enable_accelerated_networking = true
+  enable_accelerated_networking = var.hana_enable_accelerated_networking
 
   ip_configuration {
     name                          = "ipconf-primary"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -37,6 +37,7 @@ variable "hana_data_disk_caching" {
 
 variable "hana_enable_accelerated_networking" {
   description = "Enable accelerated networking. This function is mandatory for certified HANA environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  type        = bool
   default     = true
 }
 
@@ -183,8 +184,9 @@ variable "netweaver_data_disk_type" {
 }
 
 variable "netweaver_data_disk_size" {
-  type    = string
-  default = "60"
+  description = "Size of the Netweaver data disks, informed in GB"
+  type        = string
+  default     = "60"
 }
 
 variable "netweaver_data_disk_caching" {
@@ -224,6 +226,7 @@ variable "netweaver_storage_account" {
 
 variable "netweaver_enable_accelerated_networking" {
   description = "Enable accelerated networking for netweaver. This function is mandatory for certified Netweaver environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  type        = bool
   default     = true
 }
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -171,6 +171,27 @@ variable "netweaver_enabled" {
   default     = false
 }
 
+variable "netweaver_vm_size" {
+  description = "VM size for the Netweaver machines. Default to Standard_D2s_v3"
+  type        = string
+  default     = "Standard_D4s_v3"
+}
+
+variable "netweaver_data_disk_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+
+variable "netweaver_data_disk_size" {
+  type    = string
+  default = "60"
+}
+
+variable "netweaver_data_disk_caching" {
+  type    = string
+  default = "ReadWrite"
+}
+
 variable "netweaver_ips" {
   description = "ip addresses to set to the netweaver cluster nodes"
   type        = list(string)
@@ -199,6 +220,11 @@ variable "netweaver_storage_account" {
   description = "Azure storage account path"
   type        = string
   default     = ""
+}
+
+variable "netweaver_enable_accelerated_networking" {
+  description = "Enable accelerated networking for netweaver. This function is mandatory for certified Netweaver environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  default     = true
 }
 
 # Specific QA variables

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -35,6 +35,11 @@ variable "hana_data_disk_caching" {
   default = "ReadWrite"
 }
 
+variable "hana_enable_accelerated_networking" {
+  description = "Enable accelerated networking. This function is mandatory for certified HANA environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
+  default     = true
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
Remove some Netweaver and HANA hardcodes and move the options to variables to give the possibility to the user to set them.

All of the variables assume as default the values that were hardcoded before.