### PR TITLE
Update cluster pillar files to remove platform

### DIFF
--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -34,7 +34,6 @@ cluster:
       parameters:
         virtual_ip: {{ ".".join(grains['host_ips'][0].split('.')[0:-1]) }}.201
         virtual_ip_mask: 24
-        platform: {{ grains['provider'] }}
         {% if grains['provider']== "azure" %}
         probe: 61000
         {% endif %}

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -48,7 +48,6 @@ cluster:
         {% else %}
         virtual_ip_mask: 24
         {% endif %}
-        platform: {{ grains['provider'] }}
         {% if grains['scenario_type'] == 'cost-optimized' %}
         prefer_takeover: false
         {% else %}

--- a/pillar_examples/aws/cluster.sls
+++ b/pillar_examples/aws/cluster.sls
@@ -21,6 +21,5 @@ cluster:
         instance: "00"
         virtual_ip: 10.0.1.50
         virtual_ip_mask: 16
-        platform: aws
         prefer_takeover: true
         auto_register: false

--- a/pillar_examples/azure/cluster.sls
+++ b/pillar_examples/azure/cluster.sls
@@ -21,6 +21,5 @@ cluster:
         instance: "00"
         virtual_ip: 10.74.1.5 # This value must match with the load balancer address: frontend_ip_configuration
         virtual_ip_mask: 24
-        platform: azure
         prefer_takeover: true
         auto_register: false

--- a/pillar_examples/libvirt/cost_optimized/cluster.sls
+++ b/pillar_examples/libvirt/cost_optimized/cluster.sls
@@ -23,7 +23,6 @@ cluster:
         instance: "00"
         virtual_ip: 192.168.107.50
         virtual_ip_mask: 24
-        platform: libvirt
         prefer_takeover: false
         auto_register: false
         cost_optimized_parameters:

--- a/pillar_examples/libvirt/performance_optimized/cluster.sls
+++ b/pillar_examples/libvirt/performance_optimized/cluster.sls
@@ -23,6 +23,5 @@ cluster:
         instance: "00"
         virtual_ip: 192.168.107.50
         virtual_ip_mask: 24
-        platform: libvirt
         prefer_takeover: true
         auto_register: false

--- a/salt/drbd_node/files/templates/drbd_cluster.j2
+++ b/salt/drbd_node/files/templates/drbd_cluster.j2
@@ -1,4 +1,5 @@
 {% set data = pillar.cluster.configure.template.parameters %}
+{% set cloud_provider = grains['cloud_provider'] %}
 {% set drbd = salt['pillar.get']('drbd', merge=True) %}
 {% set nfsid = 1 %}
 
@@ -39,7 +40,7 @@ primitive fs_{{ res.name }} ocf:heartbeat:Filesystem \
 primitive vip-{{ res.name }}-nfs IPaddr2 \
         params ip={{ res.virtual_ip }} cidr_netmask=24 op monitor interval=10 timeout=20
 
-{% if data.platform == "azure" %}
+{% if cloud_provider == "microsoft-azure" %}
 primitive nc_{{ res.name }}_nfs anything \
   params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:{{ data.probe }},backlog=10,fork,reuseaddr /dev/null" \
   op monitor timeout=20s interval=10 depth=0
@@ -50,7 +51,7 @@ primitive exportfs_work_{{ res.name }} exportfs \
         options="rw,no_root_squash" clientspec="*" wait_for_leasetime_on_stop=true \
         op monitor interval=30s
 
-group g-nfs_{{ res.name }} fs_{{ res.name }} test-IP_{{ res.name }} exportfs_work_{{ res.name }} {% if data.platform == "azure" %} nc_{{ res.name }}_nfs {% endif %}
+group g-nfs_{{ res.name }} fs_{{ res.name }} test-IP_{{ res.name }} exportfs_work_{{ res.name }} {% if cloud_provider == "microsoft-azure" %} nc_{{ res.name }}_nfs {% endif %}
 
 order o_drbd_{{ res.name }}-before-fs_{{ res.name }} \
   ms_{{ res.name }}:promote g-nfs_{{ res.name }}:start

--- a/salt/netweaver_node/files/pillar/cluster.sls
+++ b/salt/netweaver_node/files/pillar/cluster.sls
@@ -35,7 +35,6 @@ cluster:
     template:
       source: /usr/share/salt-formulas/states/netweaver/templates/cluster_resources.j2
       parameters:
-        platform: {{ grains['provider'] }}
         sid: {{ netweaver.netweaver.nodes[0].sid }}
         ascs_instance: {{ grains['ascs_instance_number'] }}
         ers_instance: {{ grains['ers_instance_number'] }}


### PR DESCRIPTION
Use the new `cloud_provider` parameter. I think eventually we could completely remove the provider usage in the project with some restructuration.

Depends on:
SUSE/habootstrap-formula#38

https://github.com/SUSE/habootstrap-formula/pull/38/files#diff-ede8388134830516402a39e126add733R6