### PR TITLE
Includes an alert in case HANA raises alerts with rating higher than 3

### DIFF
--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -16,6 +16,14 @@ groups:
     annotations:
       summary: Slave SAP-HANA resource absent
 
+  - alert: sap-hana-internal-alerts
+    expr: hanadb_alerts_current_rating > 3
+    labels:
+      severity: page
+    annotations:
+      summary: "HANA Internal alert raised for SID {{ $labels.sid }} InsNr {{ $labels.insnr }} DBName {{ $labels.database_name }}"
+      description: "Alert Details: {{ $labels.alert_details }} User Action: {{ $labels.alert_useraction }}"
+
 # ha cluster alerts
 - name: cluster-resources-monitoring
   rules:


### PR DESCRIPTION
It will raise an alert for each alert raised by HANA that is higher than 3 and what actions the user needs to take in order to solve that.
![Screenshot from 2019-12-18 10-35-11](https://user-images.githubusercontent.com/8420718/71074171-17fad100-2182-11ea-8b77-69d69192861b.png)
