### PR TITLE
Change instance type for SAP certified systems

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ ___
 This project is organized in folders containing the Terraform configuration files per Public or Private Cloud providers, each also containing documentation relevant to the use of the configuration files and to the cloud provider itself.
 
 This project uses Terraform for the deployment and Saltstack for the provisioning.
+
+**Be carreful what instance type you will use because default choice is systems certified by SAP, so cost could be expensive if you let default value.**

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -1,7 +1,7 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
 # Instance type to use for the cluster nodes
-instancetype = "m4.2xlarge"
+instancetype = "r3.8xlarge"
 
 # Disk type for HANA
 hana_data_disk_type = "gp2"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -45,7 +45,7 @@ variable "iscsi_srv" {
 
 variable "instancetype" {
   type    = string
-  default = "t2.micro"
+  default = "r3.8xlarge"
 }
 
 variable "hana_data_disk_type" {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # Instance type to use for the cluster nodes
-instancetype = "Standard_E4s_v3"
+instancetype = "Standard_M128s"
 
 # Disk type for HANA
 hana_data_disk_type = "StandardSSD_LRS"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -5,7 +5,7 @@
 
 variable "instancetype" {
   type    = string
-  default = "Standard_E4s_v3"
+  default = "Standard_M128s"
 }
 
 # For reference:

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -10,7 +10,7 @@ ip_cidr_range = "10.0.0.0/24"
 iscsi_ip = "10.0.0.253"
 
 # Type of VM (vCPUs and RAM)
-machine_type = "n1-highmem-8"
+machine_type = "n1-highmem-32"
 machine_type_iscsi_server = "custom-1-2048"
 
 # Disk type for HANA

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -18,7 +18,7 @@ variable "private_key_location" {
 
 variable "machine_type" {
   type    = string
-  default = "n1-highmem-8"
+  default = "n1-highmem-32"
 }
 
 variable "hana_data_disk_type" {


### PR DESCRIPTION
This PR changes all instance type default value to systems certified by SAP.

Recommendations found [here](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#) (Certified and supported SAP HANA Hardware Directory)

I choose systems with filter `Clustering = yes`

**AWS**:
 r3.8xlarge - [SAP Certified IaaS Platforms for AWS](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Amazon%20Web%20Services)

**GCP**:
 n1-highmem-32 - [SAP Certified IaaS Platforms for GCP](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Google%20Cloud%20Platform)

**Azure**: 
Standard_M128s - [SAP Certified IaaS Platforms for Azure](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Microsoft%20Azure)

TODO:


- [x] Waiting feedback about chosen instance type

- [x] Update README to warn the user that instance type is configured for production, that means cost could be very expensive and should be change for testing purpose.