### PR TITLE
Accept the license during update

### DIFF
--- a/salt/default/update.sls
+++ b/salt/default/update.sls
@@ -2,7 +2,7 @@
 {% if grains['os_family'] == 'Suse' %}
 update_system_packages:
   cmd.run:
-    - name: zypper --non-interactive --gpg-auto-import-keys update --no-recommends
+    - name: zypper --non-interactive --gpg-auto-import-keys update --no-recommends --auto-agree-with-licenses
     - retry:
         attempts: 3
         interval: 15

--- a/salt/pre_installation/packages.sls
+++ b/salt/pre_installation/packages.sls
@@ -8,7 +8,7 @@ iscsi-formula:
 {% if grains.get('devel_mode') %}
 update_systems_packages_from_devel:
   cmd.run:
-    - name: zypper --non-interactive --gpg-auto-import-keys update
+    - name: zypper --non-interactive --gpg-auto-import-keys update --auto-agree-with-licenses
     - retry:
         attempts: 3
         interval: 15


### PR DESCRIPTION
The deployment fails in the `update` command due: 
```
Do you agree with the terms of the license? [yes/no] (no): no
                  Aborting installation due to the need for license confirmation.
                  Please restart the operation in interactive mode and confirm your agreement with required licenses, or use the --auto-agree-with-licenses option.
```

This change accepts the license