### PR TITLE
Fix jinja rendering for the prometheus alert rules

### DIFF
--- a/salt/monitoring/prometheus/rules.yml
+++ b/salt/monitoring/prometheus/rules.yml
@@ -21,8 +21,10 @@ groups:
     labels:
       severity: page
     annotations:
+      {%- raw %}
       summary: "HANA Internal alert raised for SID {{ $labels.sid }} InsNr {{ $labels.insnr }} DBName {{ $labels.database_name }}"
       description: "Alert Details: {{ $labels.alert_details }} User Action: {{ $labels.alert_useraction }}"
+      {%- endraw %}
 
 # ha cluster alerts
 - name: cluster-resources-monitoring


### PR DESCRIPTION
Fix jinja rendering in prometheus rules file: 

```
null_resource.monitoring_provisioner[0] (remote-exec): [ERROR   ] Rendering exception occurred
null_resource.monitoring_provisioner[0] (remote-exec): Traceback (most recent call last):
null_resource.monitoring_provisioner[0] (remote-exec):   File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 169, in render_tmpl
null_resource.monitoring_provisioner[0] (remote-exec):     output = render_str(tmplstr, context, tmplpath)
null_resource.monitoring_provisioner[0] (remote-exec):   File "/usr/lib/python2.7/site-packages/salt/utils/templates.py", line 412, in render_jinja_tmpl
null_resource.monitoring_provisioner[0] (remote-exec):     tmplstr)
null_resource.monitoring_provisioner[0] (remote-exec): SaltRenderError: Jinja syntax error: unexpected char u'$' at 744; line 24

null_resource.monitoring_provisioner[0] (remote-exec): ---
null_resource.monitoring_provisioner[0] (remote-exec): [...]
null_resource.monitoring_provisioner[0] (remote-exec):   - alert: sap-hana-internal-alerts
null_resource.monitoring_provisioner[0] (remote-exec):     expr: hanadb_alerts_current_rating > 3
null_resource.monitoring_provisioner[0] (remote-exec):     labels:
null_resource.monitoring_provisioner[0] (remote-exec):       severity: page
null_resource.monitoring_provisioner[0] (remote-exec):     annotations:
null_resource.monitoring_provisioner[0] (remote-exec):       summary: "HANA Internal alert raised for SID {{ $labels.sid }} InsNr {{ $labels.insnr }} DBName {{ $labels.database_name }}"    <======================
null_resource.monitoring_provisioner[0] (remote-exec):       description: "Alert Details: {{ $labels.alert_details }} User Action: {{ $labels.alert_useraction }}"
```