### PR TITLE
Add the option to use ssh keys to create the cluster in libvirt

### DIFF
--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -77,6 +77,8 @@ module "hana_node" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
+  cluster_ssh_pub        = var.cluster_ssh_pub
+  cluster_ssh_key        = var.cluster_ssh_key
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   qa_mode                = var.qa_mode
   hwcct                  = var.hwcct
@@ -111,6 +113,8 @@ module "drbd_node" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
+  cluster_ssh_pub        = var.cluster_ssh_pub
+  cluster_ssh_key        = var.cluster_ssh_key
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   devel_mode             = var.devel_mode
   provisioner            = var.provisioner
@@ -170,6 +174,8 @@ module "netweaver_node" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   reg_additional_modules = var.reg_additional_modules
+  cluster_ssh_pub        = var.cluster_ssh_pub
+  cluster_ssh_key        = var.cluster_ssh_key
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   provisioner            = var.provisioner
   background             = var.background

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -45,6 +45,8 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
+cluster_ssh_pub:  ${var.cluster_ssh_pub}
+cluster_ssh_key: ${var.cluster_ssh_key}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 provider: libvirt

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -25,6 +25,18 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
+variable "cluster_ssh_pub" {
+  description = "path for the public key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_ssh_key" {
+  description = "path for the private key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
 // hana/drbd
 variable "ha_sap_deployment_repo" {
   description = "Repository url used to install HA/SAP deployment packages"

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -45,6 +45,8 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
+cluster_ssh_pub:  ${var.cluster_ssh_pub}
+cluster_ssh_key: ${var.cluster_ssh_key}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 provider: libvirt

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -25,6 +25,18 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
+variable "cluster_ssh_pub" {
+  description = "path for the public key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_ssh_key" {
+  description = "path for the private key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
 // hana
 variable "ha_sap_deployment_repo" {
   description = "Repository url used to install HA/SAP deployment packages"

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -44,6 +44,8 @@ reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
+cluster_ssh_pub:  ${var.cluster_ssh_pub}
+cluster_ssh_key: ${var.cluster_ssh_key}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -25,6 +25,18 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
+variable "cluster_ssh_pub" {
+  description = "path for the public key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_ssh_key" {
+  description = "path for the private key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
 variable "ha_sap_deployment_repo" {
   description = "Repository url used to install HA/SAP deployment packages"
   type        = string

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -137,6 +137,18 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
+variable "cluster_ssh_pub" {
+  description = "path for the public key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
+variable "cluster_ssh_key" {
+  description = "path for the private key needed by the cluster"
+  type        = string
+  default     = ""
+}
+
 # Repository url used to install HA/SAP deployment packages"
 # The latest RPM packages can be found at:
 # https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}

--- a/salt/cluster_node/init.sls
+++ b/salt/cluster_node/init.sls
@@ -4,7 +4,7 @@ include:
   {% endif %}
   - cluster_node.hosts
   - cluster_node.cluster_packages
-  {% if grains['cluster_ssh_pub'] is defined and grains['cluster_ssh_key'] is defined %}
+  {% if grains.get('cluster_ssh_pub', None) and grains.get('cluster_ssh_key', None) %}
   - cluster_node.ssh
   {% endif %}
   {% if grains['shared_storage_type'] == 'iscsi' %}


### PR DESCRIPTION
Add the usage of ssh keys to create the cluster in libvirt as we do in the cloud providers