### PR TITLE
Hotfix/iscsi registration qamode

### DIFF
--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -43,6 +43,7 @@ module "iscsi_server" {
   reg_code               = var.reg_code
   reg_email              = var.reg_email
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
+  qa_mode                = var.qa_mode
   provisioner            = var.provisioner
   background             = var.background
 }

--- a/salt/pre_installation/registration.sls
+++ b/salt/pre_installation/registration.sls
@@ -1,5 +1,5 @@
 {% if grains['os_family'] == 'Suse' %}
-{% if not grains.get('qa_mode') %}
+{% if not grains.get('qa_mode') or '.*_node' not in grains.get('role') %}
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:

--- a/salt/pre_installation/repos.sls
+++ b/salt/pre_installation/repos.sls
@@ -27,5 +27,6 @@ refresh_repos_after_registration:
     - retry:
         attempts: 3
         interval: 15
+    - onlyif: 'zypper lr'
 
 {% endif %}


### PR DESCRIPTION
Hotfix to master branch to fix the `qa_mode` usage.
1. Register SCC in the nodes that are not HA (support nodes) in qa_mode
2. Avoid repositories refresh if there is not any repository