### PR TITLE
Fix registration check (remove .*)

### DIFF
--- a/salt/pre_installation/registration.sls
+++ b/salt/pre_installation/registration.sls
@@ -1,5 +1,5 @@
 {% if grains['os_family'] == 'Suse' %}
-{% if not grains.get('qa_mode') or '.*_node' not in grains.get('role') %}
+{% if not grains.get('qa_mode') or '_node' not in grains.get('role') %}
 {% if grains['reg_code'] %}
 register_system:
   cmd.run:


### PR DESCRIPTION
The `if` statement is wrong. With this fix if `qa_mode` is set to `True` the the iscsi server will continue being registered but any node related to HA or SAP won't (hana, drbd and netweaver nodes).