### PR TITLE
Update readme to change example workspace name

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -49,8 +49,8 @@ If you use terraform azure in CI see [terraform azure ci](terraform-azure-ci)
 
 ```
 terraform init
-terraform workspace new my-execution # optional
-terraform workspace select my-execution # optional
+terraform workspace new myexecution # optional
+terraform workspace select myexecution # optional
 terraform plan
 terraform apply
 ```


### PR DESCRIPTION
Update readme to change example workspace name to avoid such errors. Azure resource name can only consist of lowercase letters and numbers

```
Error: name can only consist of lowercase letters and numbers, and must be between 3 and 24 characters long

  on resources.tf line 6, in resource "azurerm_storage_account" "mytfstorageacc":
   6: resource "azurerm_storage_account" "mytfstorageacc" {
```