### PR TITLE
adapt pillars of deployment to apply saptune solutions

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,7 @@ ___
 - [Netweaver](doc/netweaver.md)
 - [DRBD](doc/drbd.md)
 - [QA](doc/qa.md)
-
-___
+- [Saptune](doc/saptune.md)
 ## Rationale
 
 This project is organized in folders containing the Terraform configuration files per Public or Private Cloud providers, each also containing documentation relevant to the use of the configuration files and to the cloud provider itself.

--- a/doc/saptune.md
+++ b/doc/saptune.md
@@ -1,0 +1,21 @@
+# Saptune deployment configuration
+
+You can tune your hana or netweaver nodes with saptune during the deployment phase.
+
+Currently we support following features:
+
+- 1) apply a saptune solution during deployement
+
+
+1) Apply a saptune solution during deployement:
+
+In order to apply a saptune solution, you need to adapt the pillars:
+
+```
+saptune_solution: 'HANA'
+```
+
+By default the pillars are configured to apply HANA for hana nodes and NETWEAVER solution for netweavers.
+
+For further information refer to the saphanaboostrap-formula or netweaver.
+The code for the module is implemented in https://github.com/SUSE/salt-shaptools

--- a/pillar_examples/automatic/hana/hana.sls
+++ b/pillar_examples/automatic/hana/hana.sls
@@ -2,6 +2,7 @@ hana:
   {% if grains.get('qa_mode') %}
   install_packages: false
   {% endif %}
+  saptune_solution: 'HANA'
   nodes:
     - host: {{ grains['name_prefix'] }}01
       sid: prd

--- a/pillar_examples/aws/hana.sls
+++ b/pillar_examples/aws/hana.sls
@@ -1,5 +1,6 @@
 hana:
   # install_packages: false # disable pre defined pacakge installation
+  saptune_solution: 'HANA'
   nodes:
     - host: 'hana01'
       sid: 'prd'

--- a/pillar_examples/azure/hana.sls
+++ b/pillar_examples/azure/hana.sls
@@ -1,4 +1,5 @@
 hana:
+  saptune_solution: 'HANA'
   nodes:
     - host: 'hana01'
       sid: 'prd'

--- a/pillar_examples/libvirt/cost_optimized/hana.sls
+++ b/pillar_examples/libvirt/cost_optimized/hana.sls
@@ -1,4 +1,5 @@
 hana:
+  saptune_solution: 'HANA'
   nodes:
     - host: 'hana01'
       sid: 'prd'

--- a/pillar_examples/libvirt/performance_optimized/hana.sls
+++ b/pillar_examples/libvirt/performance_optimized/hana.sls
@@ -1,4 +1,5 @@
 hana:
+  saptune_solution: 'HANA'
   nodes:
     - host: 'hana01'
       sid: 'prd'

--- a/salt/netweaver_node/files/pillar/netweaver.sls
+++ b/salt/netweaver_node/files/pillar/netweaver.sls
@@ -30,6 +30,9 @@ netweaver:
     - /netweaver_inst_media/51050829_3 # NW Export folder
     - /netweaver_inst_media/51053381 # HANA HDB Client folder
 
+  # apply by default the netweaver solution
+  saptune_solution: 'NETWEAVER'
+
   hana:
 {%- if grains['provider'] == 'gcp' %}
     host: {{ grains['hana_cluster_vip'] }}


### PR DESCRIPTION
## Description:

This PR is a follow-up for the previous work on the saptune module in salt. It enables the mechanism to apply to all node a saptune solution.

For reference look at prs:

- saptune module implementation https://github.com/SUSE/salt-shaptools/pull/45 ( shaptools)
- https://github.com/SUSE/sapnwbootstrap-formula/pull/27 (netweaver formula enablement)
- https://github.com/SUSE/saphanabootstrap-formula/pull/65 (hana formula enablement )

# behaviour changes/features:

This pr , with the new tfvars

`saptune_solution = "HANA"` will allow to apply to all node the saptune solution (in this case) HANA.
So that the user can choose which saptune solution can apply to all (netweaver and ha) cluster nodes .



