### PR TITLE
Make Azure VM sizes configurable for all terraform modules

### DIFF
--- a/azure/README.md
+++ b/azure/README.md
@@ -133,7 +133,7 @@ In the file [terraform.tfvars.example](terraform.tfvars.example) there are a num
 * **storage_account_key**: Azure storage account secret key (key1 or key2).
 * **hana_inst_master**: path to the storage account where SAP HANA installation files are stored.
 * **hana_fstype**: filesystem type used for HANA installation (xfs by default).
-* **instancetype**: SKU to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the VM.
+* **hana_vm_size**: SKU to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the VM.
 * **hana_data_disk_type**: disk type to use for HANA (Standard_LRS by default).
 * **hana_data_disk_caching**: caching mode for HANA disk, could be None, ReadOnly or ReadWrite (ReadWrite by default).
 * **hana_count**: number of cluster nodes to deploy. 2 by default.

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -2,7 +2,7 @@ module "drbd_node" {
   source                 = "./modules/drbd_node"
   az_region              = var.az_region
   drbd_count             = var.drbd_enabled == true ? 2 : 0
-  instancetype           = "Standard_D2s_v3"
+  vm_size                = var.drbd_vm_size
   drbd_image_uri         = var.drbd_image_uri
   drbd_public_publisher  = var.drbd_public_publisher
   drbd_public_offer      = var.drbd_public_offer
@@ -74,7 +74,7 @@ module "hana_node" {
   az_region                     = var.az_region
   hana_count                    = var.hana_count
   hana_instance_number          = var.hana_instance_number
-  instancetype                  = var.instancetype
+  vm_size                       = var.hana_vm_size
   host_ips                      = var.host_ips
   scenario_type                 = var.scenario_type
   resource_group_name           = azurerm_resource_group.myrg.name
@@ -118,7 +118,7 @@ module "hana_node" {
 module "monitoring" {
   source                 = "./modules/monitoring"
   az_region              = var.az_region
-  instancetype           = "Standard_D2s_v3"
+  vm_size                = var.monitoring_vm_size
   resource_group_name    = azurerm_resource_group.myrg.name
   network_subnet_id      = azurerm_subnet.mysubnet.id
   sec_group_id           = azurerm_network_security_group.mysecgroup.id
@@ -141,6 +141,7 @@ module "monitoring" {
 module "iscsi_server" {
   source                 = "./modules/iscsi_server"
   az_region              = var.az_region
+  vm_size                = var.iscsi_vm_size
   resource_group_name    = azurerm_resource_group.myrg.name
   network_subnet_id      = azurerm_subnet.mysubnet.id
   sec_group_id           = azurerm_network_security_group.mysecgroup.id

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -170,7 +170,7 @@ resource "azurerm_virtual_machine" "drbd" {
   resource_group_name   = var.resource_group_name
   network_interface_ids = [element(azurerm_network_interface.drbd.*.id, count.index)]
   availability_set_id   = azurerm_availability_set.drbd-availability-set[0].id
-  vm_size               = var.instancetype
+  vm_size               = var.vm_size
 
   storage_os_disk {
     name              = "disk-${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}-Os"

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -61,7 +61,7 @@ variable "drbd_public_version" {
   default = "latest"
 }
 
-variable "instancetype" {
+variable "vm_size" {
   type    = string
   default = "Standard_D2s_v3"
 }

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -220,7 +220,7 @@ resource "azurerm_virtual_machine" "hana" {
   resource_group_name   = var.resource_group_name
   network_interface_ids = [element(azurerm_network_interface.hana.*.id, count.index)]
   availability_set_id   = azurerm_availability_set.hana-availability-set.id
-  vm_size               = var.instancetype
+  vm_size               = var.vm_size
 
   storage_os_disk {
     name              = "disk-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}-Os"

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -82,6 +82,7 @@ variable "hana_public_version" {
 
 variable "vm_size" {
   type    = string
+  default = "Standard_M128s"
 }
 
 variable "admin_user" {

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -80,7 +80,7 @@ variable "hana_public_version" {
   type    = string
 }
 
-variable "instancetype" {
+variable "vm_size" {
   type    = string
 }
 

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -58,7 +58,7 @@ resource "azurerm_virtual_machine" "iscsisrv" {
   location              = var.az_region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [azurerm_network_interface.iscsisrv.id]
-  vm_size               = "Standard_D2s_v3"
+  vm_size               = var.vm_size
 
   storage_os_disk {
     name              = "disk-iscsisrv-Os"

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -44,6 +44,11 @@ variable "iscsi_srv_uri" {
   default = ""
 }
 
+variable "vm_size" {
+  type    = string
+  default = "Standard_D2s_v3"
+}
+
 variable "admin_user" {
   type    = string
   default = "azadmin"

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -61,7 +61,7 @@ resource "azurerm_virtual_machine" "monitoring" {
   location              = var.az_region
   resource_group_name   = var.resource_group_name
   network_interface_ids = [azurerm_network_interface.monitoring.0.id]
-  vm_size               = var.instancetype
+  vm_size               = var.vm_size
 
   storage_os_disk {
     name              = "disk-monitoring-Os"

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -11,8 +11,9 @@ variable "sec_group_id" {
   type = string
 }
 
-variable "instancetype" {
+variable "vm_size" {
   type    = string
+  default = "Standard_D2s_v3"
 }
 
 variable "network_subnet_id" {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -1,5 +1,5 @@
-# Instance type to use for the cluster nodes
-instancetype = "Standard_M128s"
+# VM size to use for the cluster nodes
+hana_vm_size = "Standard_M128s"
 
 # Disk type for HANA
 hana_data_disk_type = "StandardSSD_LRS"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -1,9 +1,9 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
 # Variables for type of instances to use and number of cluster nodes
-# Use with: terraform apply -var instancetype=Small -var hana_count=2
+# Use with: terraform apply -var hana_vm_size=Standard_M128s -var hana_count=2
 
-variable "instancetype" {
+variable "hana_vm_size" {
   type    = string
   default = "Standard_M128s"
 }
@@ -91,6 +91,12 @@ variable "iscsi_srv_ip" {
   default     = "10.74.1.10"
 }
 
+variable "iscsi_vm_size" {
+  description = "VM size for the iscsi server machine. Default to Standard_D2s_v3"
+  type        = string
+  default     = "Standard_D2s_v3"
+}
+
 variable "iscsidev" {
   description = "device iscsi for iscsi server"
   type        = string
@@ -153,6 +159,18 @@ variable "drbd_ips" {
   default     = []
 }
 
+variable "drbd_vm_size" {
+  description = "VM size for the DRBD machine. Default to Standard_D2s_v3"
+  type        = string
+  default     = "Standard_D2s_v3"
+}
+
+variable "monitoring_vm_size" {
+  description = "VM size for the monitoring machine. Default to Standard_D2s_v3"
+  type        = string
+  default     = "Standard_D2s_v3"
+}
+
 # Repository url used to install HA/SAP deployment packages"
 # The latest RPM packages can be found at:
 # https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
@@ -190,7 +208,7 @@ variable "netweaver_enabled" {
 }
 
 variable "netweaver_vm_size" {
-  description = "VM size for the Netweaver machines. Default to Standard_D2s_v3"
+  description = "VM size for the Netweaver machines. Default to Standard_D4s_v3"
   type        = string
   default     = "Standard_D4s_v3"
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -4,8 +4,9 @@
 # Use with: terraform apply -var hana_vm_size=Standard_M128s -var hana_count=2
 
 variable "hana_vm_size" {
-  type    = string
-  default = "Standard_M128s"
+  description = "VM size for the hana machine"
+  type        = string
+  default     = "Standard_M128s"
 }
 
 # For reference:
@@ -92,7 +93,7 @@ variable "iscsi_srv_ip" {
 }
 
 variable "iscsi_vm_size" {
-  description = "VM size for the iscsi server machine. Default to Standard_D2s_v3"
+  description = "VM size for the iscsi server machine"
   type        = string
   default     = "Standard_D2s_v3"
 }
@@ -160,13 +161,13 @@ variable "drbd_ips" {
 }
 
 variable "drbd_vm_size" {
-  description = "VM size for the DRBD machine. Default to Standard_D2s_v3"
+  description = "VM size for the DRBD machine"
   type        = string
   default     = "Standard_D2s_v3"
 }
 
 variable "monitoring_vm_size" {
-  description = "VM size for the monitoring machine. Default to Standard_D2s_v3"
+  description = "VM size for the monitoring machine"
   type        = string
   default     = "Standard_D2s_v3"
 }
@@ -208,7 +209,7 @@ variable "netweaver_enabled" {
 }
 
 variable "netweaver_vm_size" {
-  description = "VM size for the Netweaver machines. Default to Standard_D4s_v3"
+  description = "VM size for the Netweaver machines"
   type        = string
   default     = "Standard_D4s_v3"
 }


### PR DESCRIPTION
As most of the VM sizes `(vm_size)` in Azure were hardcoded, this PR makes them configurable, for terraform modules (drbd, hana, scsi server, netweaver, monitoring)

Also updating the different variable names (instance_type, instancetype, vm_size) to use one name ie `vm_size`