### PR TITLE
Fix iscsi queue_depth configuration error and hard code of instance type of iscsi/monitoring nodes on aws

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -130,7 +130,11 @@ These are the relevant files and what each provides:
 
 In [terraform.tfvars](terraform.tfvars.example) there are a number of variables that control what is deployed. Some of these variables are:
 
-* **instancetype**: instance type to use for the cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
+* **instancetype**: instance type to use for the hana cluster nodes; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `r3.8xlarge`.
+* **netweaver_instancetype**: instance type of netweaver node; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `r3.8xlarge`.
+* **min_instancetype**: instance type of minimun capacity; basically the "size" (number of vCPUS and memory) of the instance. Defaults to `t2.micro`.
+* **iscsi_instancetype**: instance type of iscsi server; an empty string will follow the **min_instancetype**. Defaults to `""`.
+* **monitor_instancetype**: instance type of monitor server; an empty string will follow the **min_instancetype**. Defaults to `""`.
 * **hana_data_disk_type**: disk type to use for HANA (gp2 by default).
 * **ninstances**: number of cluster nodes to deploy. Defaults to 2.
 * **aws_region**: AWS region where to deploy the configuration.

--- a/aws/instances.tf
+++ b/aws/instances.tf
@@ -8,7 +8,7 @@ data "aws_availability_zones" "available" {
 
 resource "aws_instance" "iscsisrv" {
   ami                         = var.iscsi_srv[var.aws_region]
-  instance_type               = "t2.micro"
+  instance_type               = var.iscsi_instancetype == "" ? var.min_instancetype : var.iscsi_instancetype
   key_name                    = aws_key_pair.hana-key-pair.key_name
   associate_public_ip_address = true
   subnet_id                   = element(aws_subnet.hana-subnet.*.id, 0)
@@ -86,7 +86,7 @@ resource "aws_instance" "clusternodes" {
 resource "aws_instance" "monitoring" {
   count                       = var.monitoring_enabled == true ? 1 : 0
   ami                         = var.sles4sap[var.aws_region]
-  instance_type               = "t2.micro"
+  instance_type               = var.monitor_instancetype == "" ? var.min_instancetype : var.monitor_instancetype
   key_name                    = aws_key_pair.hana-key-pair.key_name
   associate_public_ip_address = true
   subnet_id                   = element(aws_subnet.hana-subnet.*.id, 0)

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -1,7 +1,10 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
-# Instance type to use for the cluster nodes
+# Instance type to use for the hana cluster nodes
 instancetype = "r3.8xlarge"
+
+# The minimum instance type of a region, not suitable to hana nodes
+min_instancetype = "t2.micro"
 
 # Disk type for HANA
 hana_data_disk_type = "gp2"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -44,8 +44,26 @@ variable "iscsi_srv" {
 # Use with: terraform apply -var instancetype=t2.micro -var ninstances=2
 
 variable "instancetype" {
-  type    = string
-  default = "r3.8xlarge"
+  description = "The instance type of hana node."
+  type        = string
+  default     = "r3.8xlarge"
+}
+variable "min_instancetype" {
+  description = "The minimum cost/capacity instance type, different per region."
+  type        = string
+  default     = "t2.micro"
+}
+
+variable "iscsi_instancetype" {
+  description = "The instance type of iscsi server node."
+  type        = string
+  default     = ""
+}
+
+variable "monitor_instancetype" {
+  description = "The instance type of monitoring node."
+  type        = string
+  default     = ""
 }
 
 variable "hana_data_disk_type" {

--- a/salt/cluster_node/iscsi_initiator.sls
+++ b/salt/cluster_node/iscsi_initiator.sls
@@ -14,6 +14,12 @@ open-iscsi:
     - pattern: "^node.startup = manual"
     - repl: "node.startup = automatic"
 
+iscsi-queue-depth:
+  file.replace:
+    - name: "/etc/iscsi/iscsid.conf"
+    - pattern: "^node.session.queue_depth = [0-9]*"
+    - repl: "node.session.queue_depth = 64"
+
 iscsi:
   service.running:
     - enable: True
@@ -32,5 +38,6 @@ iscsi_discovery:
 
 iscsid:
   service.running:
+    - enable: True
     - watch:
       - cmd: iscsi_discovery

--- a/salt/pillar/iscsi_srv.sls
+++ b/salt/pillar/iscsi_srv.sls
@@ -27,7 +27,6 @@ iscsi:
             attributes:
               block_size: 512
               emulate_write_cache: 0
-              queue_depth: 64
               unmap_granularity: 0
             dev: {{ grains['iscsidev'] }}{{ loop.index }}
             name: sd{{ devicenum[loop.index0] }}


### PR DESCRIPTION
Fix issue#357 and issue#258

Remove the hard code of instance type of iscsi/monitoring nodes, since it is different per region.
Correct the queue_depth configuration of iscsi pillar file.