### PR TITLE
Change default instance for azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,12 @@ This project is organized in folders containing the Terraform configuration file
 This project uses Terraform for the deployment and Saltstack for the provisioning.
 
 **Be carreful what instance type you will use because default choice is systems certified by SAP, so cost could be expensive if you let default value.**
+
+These are links to find certified systems for each provider:
+
+- [SAP Certified IaaS Platforms for AWS](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Amazon%20Web%20Services)
+
+- [SAP Certified IaaS Platforms for GCP](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Google%20Cloud%20Platform)
+
+- [SAP Certified IaaS Platforms for Azure](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Microsoft%20Azure) (Be carreful with Azure, **clustering** means scale-out scenario)
+

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # Instance type to use for the cluster nodes
-instancetype = "Standard_M128s"
+instancetype = "Standard_M32ls"
 
 # Disk type for HANA
 hana_data_disk_type = "StandardSSD_LRS"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -5,15 +5,12 @@
 
 variable "instancetype" {
   type    = string
-  default = "Standard_M128s"
+  default = "Standard_M32ls"
 }
 
 # For reference:
-# Standard_B1ms has 1 VCPU, 2GiB RAM, 1 NIC, 2 data disks and 4GiB SSD
-# Standard_D2s_v3 has 2 VCPU, 8GiB RAM, 2 NICs, 4 data disks and 16GiB SSD disk
-# Standard_D8s_v3 has 8 VCPU, 32GiB RAM, 2 NICs, 16 data disks and 64GiB SSD disk
-# Standard_E4s_v3 has 4 VCPU, 32GiB RAM, 2 NICs, 64GiB SSD disk
-# Standard_M32ts has 32 VCPU, 192GiB RAM, 1000 GiB SSD
+# Standard_M32ls has 32 VCPU, 256GiB RAM, 1000 GiB SSD
+# You could find other supported instances in Azure documentation
 
 variable "ninstances" {
   type    = string


### PR DESCRIPTION
This PR changes default instance for Azure and adds links about certified systems in documentation.

Azure warned us about the default instance we are using in the project.
They told to use smaller instance which is also supported.
We chose M128S because it is a recommended instance for clustering but Azure told us that clustering means for scale-out scenario and not HA clustering.
