### PR TITLE
Change default instance for azure

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,11 @@ This project is organized in folders containing the Terraform configuration file
 This project uses Terraform for the deployment and Saltstack for the provisioning.
 
 **Be careful with what instance type you will use because default choice is systems certified by SAP, so cost could be expensive if you leave the default value.**
+
+These are links to find certified systems for each provider:
+
+- [SAP Certified IaaS Platforms for AWS](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Amazon%20Web%20Services)
+
+- [SAP Certified IaaS Platforms for GCP](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Google%20Cloud%20Platform)
+
+- [SAP Certified IaaS Platforms for Azure](https://www.sap.com/dmc/exp/2014-09-02-hana-hardware/enEN/iaas.html#categories=Microsoft%20Azure) (Be carreful with Azure, **clustering** means scale-out scenario)

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -82,7 +82,7 @@ variable "hana_public_version" {
 
 variable "vm_size" {
   type    = string
-  default = "Standard_M128s"
+  default = "Standard_M32ls"
 }
 
 variable "admin_user" {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -1,5 +1,5 @@
 # VM size to use for the cluster nodes
-hana_vm_size = "Standard_M128s"
+hana_vm_size = "Standard_M32ls"
 
 # Disk type for HANA
 hana_data_disk_type = "StandardSSD_LRS"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -1,20 +1,17 @@
 # Launch SLES-HAE of SLES4SAP cluster nodes
 
 # Variables for type of instances to use and number of cluster nodes
-# Use with: terraform apply -var hana_vm_size=Standard_M128s -var hana_count=2
+# Use with: terraform apply -var hana_vm_size=Standard_M32ls -var hana_count=2
 
 variable "hana_vm_size" {
   description = "VM size for the hana machine"
   type        = string
-  default     = "Standard_M128s"
+  default     = "Standard_M32ls"
 }
 
 # For reference:
-# Standard_B1ms has 1 VCPU, 2GiB RAM, 1 NIC, 2 data disks and 4GiB SSD
-# Standard_D2s_v3 has 2 VCPU, 8GiB RAM, 2 NICs, 4 data disks and 16GiB SSD disk
-# Standard_D8s_v3 has 8 VCPU, 32GiB RAM, 2 NICs, 16 data disks and 64GiB SSD disk
-# Standard_E4s_v3 has 4 VCPU, 32GiB RAM, 2 NICs, 64GiB SSD disk
-# Standard_M32ts has 32 VCPU, 192GiB RAM, 1000 GiB SSD
+# Standard_M32ls has 32 VCPU, 256GiB RAM, 1000 GiB SSD
+# You could find other supported instances in Azure documentation
 
 variable "hana_count" {
   type    = string


### PR DESCRIPTION
This PR changes default instance for Azure and adds links about certified systems in documentation.

Azure warned us about the default instance we are using in the project.
They told to use smaller instance which is also supported.
We chose M128S because it is a recommended instance for clustering but Azure told us that clustering means for scale-out scenario and not HA clustering.