### PR TITLE
Fix salt scripts usage to run the proper top files

### DIFF
--- a/salt/deployment.sh
+++ b/salt/deployment.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+# Execute the states within /root/salt/pre_installation
+# This first execution is done to configure the salt minion and install the iscsi formula
 salt-call --local --file-root=/root/salt \
     --log-level=info \
     --log-file=/tmp/salt-pre-installation.log \
@@ -7,11 +9,12 @@ salt-call --local --file-root=/root/salt \
     --retcode-passthrough \
     --force-color state.apply pre_installation || exit 1
 
+# Execute the states defined in /root/salt/top.sls
+# This execution is done to pre configure the cluster nodes, the support machines and install the formulas
 salt-call --local \
     --pillar-root=/root/salt/pillar/ \
-    --file-root=/root/salt \
     --log-level=info \
     --log-file=/tmp/salt-deployment.log \
     --log-file-level=debug \
     --retcode-passthrough \
-    --force-color state.highstate || exit 1
+    --force-color state.highstate saltenv=predeployment || exit 1

--- a/salt/formula.sh
+++ b/salt/formula.sh
@@ -5,4 +5,4 @@ salt-call --local \
     --log-file=/tmp/salt-formula.log \
     --log-file-level=debug \
     --retcode-passthrough \
-    --force-color state.highstate || exit 1
+    --force-color state.highstate saltenv=base || exit 1

--- a/salt/netweaver_node/nfs.sls
+++ b/salt/netweaver_node/nfs.sls
@@ -9,7 +9,7 @@ install_nfs_client:
        attempts: 3
        interval: 15
 
-mount_sapmnt:
+mount_sapmnt_temporary:
   mount.mounted:
     - name: /tmp/sapmnt
     - device: {{ grains['netweaver_nfs_share'] }}
@@ -32,7 +32,7 @@ mount_sapmnt:
     - makedirs: True
     - clean: True
     - require:
-      - mount_sapmnt
+      - mount_sapmnt_temporary
 
 /tmp/sapmnt/usrsapsys:
   file.directory:
@@ -41,7 +41,7 @@ mount_sapmnt:
     - makedirs: True
     - clean: True
     - require:
-      - mount_sapmnt
+      - mount_sapmnt_temporary
 
 # This next folders are created to use as shared folder in Azure
 /tmp/sapmnt/ASCS:
@@ -51,7 +51,7 @@ mount_sapmnt:
     - makedirs: True
     - clean: True
     - require:
-      - mount_sapmnt
+      - mount_sapmnt_temporary
 
 /tmp/sapmnt/ERS:
   file.directory:
@@ -60,7 +60,7 @@ mount_sapmnt:
     - makedirs: True
     - clean: True
     - require:
-      - mount_sapmnt
+      - mount_sapmnt_temporary
 
 {% endif %}
 
@@ -69,7 +69,7 @@ unmount_sapmnt:
     - name: /tmp/sapmnt
     - device: {{ grains['netweaver_nfs_share'] }}
     - require:
-      - mount_sapmnt
+      - mount_sapmnt_temporary
 
 remove_tmp_folder:
   file.absent:

--- a/salt/pre_installation/minion_configuration.sls
+++ b/salt/pre_installation/minion_configuration.sls
@@ -11,7 +11,9 @@ configure_file_roots:
           base:
             - /srv/salt
             - /usr/share/salt-formulas/states
+          predeployment:
             - /root/salt
+            - /usr/share/salt-formulas/states
 
 # Old module.run style will be deprecated after sodium release
 upgrade_module_run:

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -1,4 +1,4 @@
-base:
+predeployment:
   'role:hana_node':
     - match: grain
     - default


### PR DESCRIPTION
This PR fixes 2 issues:

- `mount_sapmnt` is used in the `sapnwbootstrap-formula`, so we need to change the name to avoid duplicated states
- In order to keep idempotency properly, we need to split the execution of the formulas and the pre deployment. This is done having different salt envs that are executed in the highstate.

Before that, the `iscsi_srv` execution was failing because the `file_root` variable was not getting the folder where iscsi formula states are stored.

I have tested with AWS and works fine now.