### PR TITLE
Add timeout for avoiding infinite looping

### DIFF
--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -14,6 +14,11 @@ resource "null_resource" "netweaver_provisioner" {
     netweaver_id = join(",", aws_instance.netweaver.*.id)
   }
 
+  # 3 hours should be enough to create netweaver cluster.
+  timeouts {
+    create = "3h"
+  }
+
   connection {
     host        = element(aws_instance.netweaver.*.public_ip, count.index)
     type        = "ssh"

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -13,6 +13,11 @@ resource "null_resource" "netweaver_provisioner" {
     netweaver_id = join(",", azurerm_virtual_machine.netweaver.*.id)
   }
 
+  # 3 hours should be enough to create netweaver cluster.
+  timeouts {
+    create = "3h"
+  }
+
   connection {
     host        = data.azurerm_public_ip.netweaver[count.index].ip_address
     type        = "ssh"

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -13,6 +13,11 @@ resource "null_resource" "netweaver_provisioner" {
     netweaver_id = join(",", google_compute_instance.netweaver.*.id)
   }
 
+  # 3 hours should be enough to create netweaver cluster.
+  timeouts {
+    create = "3h"
+  }
+
   connection {
     host = element(
       google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip,

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -17,6 +17,11 @@ resource "null_resource" "netweaver_node_provisioner" {
     netweaver_ids = libvirt_domain.netweaver_domain[count.index].id
   }
 
+  #3 hours should be enough to create netweaver cluster.
+  timeouts {
+    create = "3h"
+  }
+
   connection {
     host     = libvirt_domain.netweaver_domain[count.index].network_interface.0.addresses.0
     user     = "root"


### PR DESCRIPTION
this Pr add timeouts 3h when creating cluster.
I had currenlty problem that the cluster creation never stop.

also in future scenario of automated CI is good to have a limit to don't waste resources. I guess 3H should be enough in normal/exceptional cases imho