### PR TITLE
Fix iscsi initiator cannot automatic login after disconnected.

### DIFF
--- a/salt/cluster_node/iscsi_initiator.sls
+++ b/salt/cluster_node/iscsi_initiator.sls
@@ -38,6 +38,5 @@ iscsi_discovery:
 
 iscsid:
   service.running:
-    - enable: True
     - watch:
       - cmd: iscsi_discovery


### PR DESCRIPTION
Somehow, enable iscsid service may cause iscsi don't
automatical login after disconnecting for any reason,
which need to restart iscsid to fix.

Error log:
iscsid: Kernel reported iSCSI connection 1:0 error
 (1020 - ISCSI_ERR_TCP_CONN_CLOSE: TCP connection closed)

This issue can not reproduce on libvirt, only in AWS/Azure.