### PR TITLE
Set type bool entry to boolean type variables

### DIFF
--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -210,11 +210,13 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -225,10 +227,12 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/aws/modules/sap_cluster_policies/variables.tf
+++ b/aws/modules/sap_cluster_policies/variables.tf
@@ -1,6 +1,6 @@
 variable "enabled" {
-  type        = bool
   description = "Enable the sap cluster policies creation"
+  type        = bool
 }
 
 variable "name" {

--- a/aws/monitoring.tf
+++ b/aws/monitoring.tf
@@ -1,20 +1,11 @@
-variable "timezone" {
-  description = "Timezone setting for all VMs"
-  default     = "Europe/Berlin"
-}
-
 variable "monitoring_srv_ip" {
   description = "monitoring server address. Must be in 10.0.0.0/24 subnet"
   type        = string
   default     = ""
 }
 
-variable "devel_mode" {
-  description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
-  default     = false
-}
-
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -45,6 +45,11 @@ variable "init_type" {
   default = "all"
 }
 
+variable "timezone" {
+  description = "Timezone setting for all VMs"
+  default     = "Europe/Berlin"
+}
+
 variable "cluster_ssh_pub" {
   description = "path for the public key needed by the cluster"
   type        = string
@@ -100,6 +105,12 @@ variable "scenario_type" {
   default     = "performance-optimized"
 }
 
+variable "devel_mode" {
+  description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
+  type        = bool
+  default     = false
+}
+
 variable "provisioner" {
   description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
   default     = "salt"
@@ -107,6 +118,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -227,6 +239,7 @@ variable "monitor_instancetype" {
 
 variable "netweaver_enabled" {
   description = "enable SAP Netweaver cluster deployment"
+  type        = bool
   default     = false
 }
 

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -122,11 +122,13 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -137,10 +139,12 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -125,6 +125,7 @@ variable "reg_email" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
@@ -146,6 +147,7 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -157,6 +159,7 @@ variable "hwcct" {
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -167,6 +170,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -105,6 +105,7 @@ variable "additional_packages" {
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -115,5 +116,6 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -111,11 +111,13 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
 variable "drbd_enabled" {
   description = "enable the DRBD cluster for nfs"
+  type        = bool
   default     = false
 }
 
@@ -127,6 +129,7 @@ variable "drbd_ips" {
 
 variable "netweaver_enabled" {
   description = "enable SAP Netweaver cluster deployment"
+  type        = bool
   default     = false
 }
 
@@ -138,5 +141,6 @@ variable "netweaver_ips" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -115,7 +115,7 @@ variable "storage_account_path" {
 
 variable "enable_accelerated_networking" {
   description = "Enable accelerated networking for netweaver. This function is mandatory for certified Netweaver environments and are not available for all kinds of instances. Check https://docs.microsoft.com/en-us/azure/virtual-network/create-vm-accelerated-networking-cli for more details"
-  type = bool
+  type        = bool
   default     = true
 }
 
@@ -212,11 +212,13 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -227,10 +229,12 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -100,6 +100,7 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
+  type        = bool
   default     = false
 }
 
@@ -115,6 +116,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -264,6 +266,7 @@ variable "iscsi_disks" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
@@ -308,6 +311,7 @@ variable "monitoring_srv_ip" {
 
 variable "drbd_enabled" {
   description = "enable the DRBD cluster for nfs"
+  type        = bool
   default     = false
 }
 
@@ -352,6 +356,7 @@ variable "drbd_image_uri" {
 
 variable "netweaver_enabled" {
   description = "enable SAP Netweaver cluster deployment"
+  type        = bool
   default     = false
 }
 
@@ -466,6 +471,7 @@ variable "netweaver_additional_dvds" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
+  type        = bool
   default     = false
 }
 

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -113,11 +113,13 @@ variable "ha_sap_deployment_repo" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -128,5 +130,6 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -164,16 +164,19 @@ variable "ha_sap_deployment_repo" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
 variable "qa_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -184,5 +187,6 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }

--- a/gcp/monitoring.tf
+++ b/gcp/monitoring.tf
@@ -1,20 +1,11 @@
-variable "timezone" {
-  description = "Timezone setting for all VMs"
-  default     = "Europe/Berlin"
-}
-
 variable "monitoring_srv_ip" {
   description = "monitoring server address"
   type        = string
   default     = ""
 }
 
-variable "devel_mode" {
-  description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
-  default     = false
-}
-
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -42,6 +42,11 @@ variable "init_type" {
   default = "all"
 }
 
+variable "timezone" {
+  description = "Timezone setting for all VMs"
+  default     = "Europe/Berlin"
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   type        = string
@@ -102,8 +107,15 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "devel_mode" {
+  description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
+  type        = bool
+  default     = false
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -219,6 +231,7 @@ variable "iscsi_disks" {
 
 variable "drbd_enabled" {
   description = "enable the DRBD cluster for nfs"
+  type        = bool
   default     = false
 }
 
@@ -262,6 +275,7 @@ variable "drbd_cluster_vip" {
 
 variable "netweaver_enabled" {
   description = "enable netweaver cluster creation"
+  type        = bool
   default     = false
 }
 
@@ -323,6 +337,7 @@ variable "netweaver_additional_dvds" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
+  type        = bool
   default     = false
 }
 

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -33,6 +33,7 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -86,6 +87,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -130,6 +132,7 @@ variable "bridge" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -33,6 +33,7 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  type        = bool
   default     = false
 }
 
@@ -112,6 +113,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -161,6 +163,7 @@ variable "pool" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
@@ -168,6 +171,7 @@ variable "monitoring_enabled" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
+  type        = bool
   default     = false
 }
 

--- a/libvirt/modules/iscsi_server/variables.tf
+++ b/libvirt/modules/iscsi_server/variables.tf
@@ -61,6 +61,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -105,5 +106,6 @@ variable "bridge" {
 # Specific QA variables
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
+  type        = bool
   default     = false
 }

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -78,6 +78,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -125,6 +125,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -132,6 +133,7 @@ variable "background" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -58,6 +58,7 @@ variable "ha_sap_deployment_repo" {
 
 variable "devel_mode" {
   description = "whether or not to install HA/SAP packages from ha_sap_deployment_repo"
+  type        = bool
   default     = false
 }
 
@@ -73,6 +74,7 @@ variable "provisioner" {
 
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
+  type        = bool
   default     = false
 }
 
@@ -135,6 +137,7 @@ variable "iscsi_disks" {
 
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
+  type        = bool
   default     = false
 }
 
@@ -154,6 +157,7 @@ variable "monitoring_srv_ip" {
 
 variable "netweaver_enabled" {
   description = "enable SAP Netweaver deployment"
+  type        = bool
   default     = false
 }
 
@@ -209,6 +213,7 @@ variable "netweaver_additional_dvds" {
 
 variable "drbd_enabled" {
   description = "enable the DRBD cluster for nfs"
+  type        = bool
   default     = false
 }
 
@@ -233,6 +238,7 @@ variable "drbd_shared_storage_type" {
 
 variable "qa_mode" {
   description = "define qa mode (Disable extra packages outside images)"
+  type        = bool
   default     = false
 }
 


### PR DESCRIPTION
Hello,
I have noticed that when the variables are passed through the command line to terraform, the boolean types are not properly managed.

I was running `terraform plan -var "drbd_enabled=false" -var "netweaver_enabled=true" -var "monitoring_enabled=false"` command, and the new entries are not set as boolean, or something strange happens. It looks kind a bug.

Anyway, setting the type to the variables fixes the issue

PD: I have moved some variables from `monitoring.tf` to the main `variables.tf` file where they should belong to