### PR TITLE
Update hana_inst_folder default value

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -42,7 +42,7 @@ name = "hana"
 hana_inst_master = "s3://path/to/your/hana/installation/master"
 
 # Local folder where HANA installation master will be downloaded from S3
-hana_inst_folder = "/root/hana_inst_media/"
+hana_inst_folder = "/sapmedia/HANA"
 
 # Device used by node where HANA will be installed
 hana_disk_device = "/dev/xvdd"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -173,7 +173,7 @@ variable "hana_inst_master" {
 
 variable "hana_inst_folder" {
   type    = string
-  default = "/root/hana_inst_media"
+  default = "/sapmedia/HANA"
 }
 
 variable "hana_disk_device" {

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -185,7 +185,7 @@ variable "hana_inst_master" {
 
 variable "hana_inst_folder" {
   type    = string
-  default = "/root/hana_inst_media"
+  default = "/sapmedia/HANA"
 }
 
 variable "hana_disk_device" {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -79,7 +79,7 @@ storage_account_key = "YOUR_STORAGE_ACCOUNT_KEY"
 hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/hana/installation/master"
 
 # Local folder where HANA installation master will be mounted
-hana_inst_folder = "/root/hana_inst_media/"
+hana_inst_folder = "/sapmedia/HANA"
 
 # Device used by node where HANA will be installed
 hana_disk_device = "/dev/sdc"

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -193,7 +193,7 @@ variable "hana_inst_master" {
 
 variable "hana_inst_folder" {
   type    = string
-  default = "/root/hana_inst_media"
+  default = "/sapmedia/HANA"
 }
 
 variable "hana_disk_device" {

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -62,7 +62,7 @@ cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
 host_ips = ["10.0.0.2", "10.0.0.3"]
 
 # Local folder where HANA installation master will be mounted
-hana_inst_folder = "/root/hana_inst_media"
+hana_inst_folder = "/sapmedia/HANA"
 
 # Device used by node where HANA will be installed
 hana_disk_device = "/dev/sdb"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -148,7 +148,7 @@ variable "sap_hana_deployment_bucket" {
 
 variable "hana_inst_folder" {
   type    = string
-  default = "/root/hana_inst_media"
+  default = "/sapmedia/HANA"
 }
 
 variable "hana_data_disk_type" {

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -67,7 +67,7 @@ variable "netweaver_product_id" {
 }
 
 variable "netweaver_inst_media" {
-  description = "URL of the NFS share where the SAP Netweaver software installer is stored. This media shall be mounted in `/root/netweaver_inst_media`"
+  description = "URL of the NFS share where the SAP Netweaver software installer is stored. This media shall be mounted in `/sapmedia/NW`"
   type        = string
 }
 

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -93,7 +93,7 @@ variable "hana_inst_media" {
 variable "hana_inst_folder" {
   description = "Folder where SAP HANA installation files are stored"
   type        = string
-  default     = "/root/hana_inst_media"
+  default     = "/sapmedia/HANA"
 }
 
 variable "hana_fstype" {

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -186,7 +186,7 @@ variable "netweaver_product_id" {
 }
 
 variable "netweaver_inst_media" {
-  description = "URL of the NFS share where the SAP Netweaver software installer is stored. This media shall be mounted in `/root/netweaver_inst_media`"
+  description = "URL of the NFS share where the SAP Netweaver software installer is stored. This media shall be mounted in `/sapmedia/NW`"
   type        = string
   default     = ""
 }

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -24,12 +24,12 @@ netweaver:
   sap_adm_password: SuSE1234
   master_password: SuSE1234
   sapmnt_inst_media: "{{ grains['netweaver_nfs_share'] }}"
-  swpm_folder: /netweaver_inst_media/{{ grains['netweaver_swpm_folder'] }}
-  sapexe_folder: /netweaver_inst_media/{{ grains['netweaver_sapexe_folder'] }}
+  swpm_folder: /sapmedia/NW/{{ grains['netweaver_swpm_folder'] }}
+  sapexe_folder: /sapmedia/NW/{{ grains['netweaver_sapexe_folder'] }}
   additional_dvds: {%- if not grains['netweaver_additional_dvds'] %} []
   {%- else %}
     {%- for dvd in grains['netweaver_additional_dvds'] %}
-    - /netweaver_inst_media/{{ dvd }}
+    - /sapmedia/NW/{{ dvd }}
     {%- endfor %}
   {%- endif %}
 

--- a/pillar_examples/aws/hana.sls
+++ b/pillar_examples/aws/hana.sls
@@ -7,7 +7,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media/'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: ''
         system_user_password: 'SET YOUR PASSWORD'
@@ -30,7 +30,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media/'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: ''
         system_user_password: 'SET YOUR PASSWORD'

--- a/pillar_examples/azure/hana.sls
+++ b/pillar_examples/azure/hana.sls
@@ -6,7 +6,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: ''
         system_user_password: 'SET YOUR PASSWORD'
@@ -29,7 +29,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: ''
         system_user_password: 'SET YOUR PASSWORD'

--- a/pillar_examples/libvirt/cost_optimized/hana.sls
+++ b/pillar_examples/libvirt/cost_optimized/hana.sls
@@ -6,7 +6,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: 'linux'
         system_user_password: 'SET YOUR PASSWORD'
@@ -33,7 +33,7 @@ hana:
         global_allocation_limit: '32100'
         preload_column_tables: False
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: 'linux'
         system_user_password: 'SET YOUR PASSWORD'
@@ -54,7 +54,7 @@ hana:
         global_allocation_limit: '28600'
         preload_column_tables: False
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: 'linux'
         system_user_password: 'SET YOUR PASSWORD'

--- a/pillar_examples/libvirt/performance_optimized/hana.sls
+++ b/pillar_examples/libvirt/performance_optimized/hana.sls
@@ -6,7 +6,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: 'linux'
         system_user_password: 'SET YOUR PASSWORD'
@@ -29,7 +29,7 @@ hana:
       instance: "00"
       password: 'SET YOUR PASSWORD'
       install:
-        software_path: '/root/hana_inst_media'
+        software_path: '/sapmedia/HANA'
         root_user: 'root'
         root_password: 'linux'
         system_user_password: 'SET YOUR PASSWORD'

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -1,4 +1,4 @@
-{% set sapcd = '/netweaver_inst_media' %}
+{% set sapcd = '/sapmedia/NW' %}
 
 {% if grains['provider'] == 'libvirt' %}
 mount_swpm:


### PR DESCRIPTION
We have found out that the usage of the `/root` folder to store HANA installation software is not really good idea.

The installer complains of having invalid permissions if the used HANA installation is obtained from a SAR file if the files are in `/root` folder.

In order to avoid that, the easy solution is just to have a different default value.
`/hana_inst_media` just works fine, but other options could be good as well.

My unique doubt is if this could have some security risk (I cannot find any).