### PR TITLE
update prometheus nw targets

### DIFF
--- a/aws/salt_provisioner.tf
+++ b/aws/salt_provisioner.tf
@@ -106,7 +106,7 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 host_ip: ${var.monitoring_srv_ip}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 monitored_hosts: [${join(", ", formatlist("'%s'", var.host_ips))}]
-nw_monitored_hosts: [${join(", ", formatlist("'%s'", var.netweaver_enabled ? var.netweaver_ips : []))}]
+nw_monitored_hosts: [${join(", ", formatlist("'%s'", var.netweaver_enabled ? var.netweaver_virtual_ips : []))}]
 network_domain: "tf.local"
 EOF
     destination = "/tmp/grains"

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -158,7 +158,7 @@ module "monitoring" {
   drbd_enabled                = var.drbd_enabled
   drbd_ips                    = var.drbd_ips
   netweaver_enabled           = var.netweaver_enabled
-  netweaver_ips               = var.netweaver_ips
+  netweaver_ips               = var.netweaver_virtual_ips
 }
 
 module "iscsi_server" {

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -154,7 +154,7 @@ module "monitoring" {
   background             = var.background
   monitored_hosts        = var.host_ips
   drbd_monitored_hosts   = var.drbd_enabled ? var.drbd_ips : []
-  nw_monitored_hosts     = var.netweaver_enabled ? var.nw_ips : []
+  nw_monitored_hosts     = var.netweaver_enabled ? var.nw_virtual_ips : []
 }
 
 module "nw_shared_disk" {

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -69,3 +69,4 @@ cluster:
         cluster_profile: {{ grains['aws_cluster_profile'] }}
         instance_tag: {{ grains['aws_instance_tag'] }}
         {%- endif %}
+        monitoring_enabled: {{ grains.get('monitoring_enabled', False) }}

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -69,4 +69,4 @@ cluster:
         cluster_profile: {{ grains['aws_cluster_profile'] }}
         instance_tag: {{ grains['aws_instance_tag'] }}
         {%- endif %}
-        monitoring_enabled: {{ grains.get('monitoring_enabled', False) }}
+        monitoring_enabled: {{ grains['monitoring_enabled']|default(False) }}


### PR DESCRIPTION
This PR changes Prometheus configuration to use floating ips as target of the netweaver exporters.
It also introduces the `monitoring_enabled` variable in the netweaver pillar, which was missing and is leveraged by SUSE/sapnwbootstrap-formula#43