### PR TITLE
Get aws_account data automatically from terraform

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -172,7 +172,6 @@ In [terraform.tfvars](terraform.tfvars.example) there are a number of variables 
 * **aws_region**: AWS region where to deploy the configuration.
 * **public_key_location**: local path to the public SSH key associated with the private key file. This public key is configured in the file $HOME/.ssh/authorized_keys of the administration user in the remote virtual machines.
 * **private_key_location**: local path to the private SSH key associated to the public key from the previous line.
-* **aws_account_id**: AWS account id (12 digit id available to the right of the user in the AWS portal).
 * **aws_access_key_id**: AWS access key id.
 * **aws_secret_access_key**: AWS secret access key.
 * **aws_credentials**: path to the `aws-cli` credentials file. This is required to configure `aws-cli` in the instances so that they can access the S3 bucket containing the HANA installation master.

--- a/aws/instances.tf
+++ b/aws/instances.tf
@@ -42,7 +42,6 @@ module "sap_cluster_policies" {
   source            = "./modules/sap_cluster_policies"
   name              = var.name
   aws_region        = var.aws_region
-  aws_account_id    = var.aws_account_id
   cluster_instances = aws_instance.clusternodes.*.id
   route_table_id    = aws_route_table.route-table.id
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -3,7 +3,6 @@ module "netweaver_node" {
   netweaver_count        = var.netweaver_enabled == true ? 4 : 0
   instancetype           = var.netweaver_instancetype
   name                   = "netweaver"
-  aws_account_id         = var.aws_account_id
   aws_region             = var.aws_region
   availability_zones     = data.aws_availability_zones.available.names
   sles4sap_images        = var.sles4sap

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -53,7 +53,6 @@ module "sap_cluster_policies" {
   source             = "../../modules/sap_cluster_policies"
   name               = var.name
   aws_region         = var.aws_region
-  aws_account_id     = var.aws_account_id
   cluster_instances  = aws_instance.netweaver.*.id
   route_table_id     = var.route_table_id
 }

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -17,11 +17,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "aws_account_id" {
-  type        = string
-  description = "AWS account id (12 digit id available to the right of the user in the AWS portal)"
-}
-
 variable "availability_zones" {
   type        = list(string)
   description = "Used availability zones"

--- a/aws/modules/sap_cluster_policies/main.tf
+++ b/aws/modules/sap_cluster_policies/main.tf
@@ -1,4 +1,7 @@
 # Create roles and policies fos SAP clusters
+
+data "aws_caller_identity" "current" {}
+
 resource "aws_iam_role" "cluster-role" {
   count              = var.enabled ? 1 : 0
   name               = "${terraform.workspace}-${var.name}-cluster"
@@ -27,7 +30,7 @@ data "template_file" "stonith-policy-template" {
   template = file("${path.module}/templates/aws_stonith_policy.tpl")
   vars = {
     region         = var.aws_region
-    aws_account_id = var.aws_account_id
+    aws_account_id = data.aws_caller_identity.current.account_id
     ec2_instance1  = var.cluster_instances.0
     ec2_instance2  = var.cluster_instances.1
   }
@@ -45,7 +48,7 @@ data "template_file" "ip-agent-policy-template" {
   template = file("${path.module}/templates/aws_ip_agent_policy.tpl")
   vars = {
     region         = var.aws_region
-    aws_account_id = var.aws_account_id
+    aws_account_id = data.aws_caller_identity.current.account_id
     route_table    = var.route_table_id
   }
 }

--- a/aws/modules/sap_cluster_policies/variables.tf
+++ b/aws/modules/sap_cluster_policies/variables.tf
@@ -12,11 +12,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "aws_account_id" {
-  type        = string
-  description = "AWS account id (12 digit id available to the right of the user in the AWS portal)"
-}
-
 variable "cluster_instances" {
   type        = list(string)
   description = "Instances that will be attached to the role"

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -11,8 +11,6 @@ ninstances = "2"
 
 # Region where to deploy the configuration
 aws_region = "eu-central-1"
-# AWS account id (12 digit id available to the right of the user in the AWS portal)
-aws_account_id = "123412341234"
 
 # SSH Public key location to configure access to the remote instances
 public_key_location = "/path/to/your/public/ssh/key"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -68,11 +68,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "aws_account_id" {
-  type        = string
-  description = "AWS account id (12 digit id available to the right of the user in the AWS portal)"
-}
-
 variable "name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
Remove `aws_account` explicit usage. It was created to use in the policies creation, but terraform already has a native way to obtain that information.

**Merging directly to master, as it would help to run some tests in openQA. I will create `4.1.0` version only with this change.**