### PR TITLE
Remove duplicated variables from aws variables

### DIFF
--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -4,19 +4,6 @@ variable "aws_region" {
   type = string
 }
 
-variable "name" {
-  description = "hostname, without the domain part"
-  type        = string
-}
-
-variable "public_key_location" {
-  type = string
-}
-
-variable "private_key_location" {
-  type = string
-}
-
 variable "aws_credentials" {
   description = "AWS credentials file path in local machine"
   type        = string


### PR DESCRIPTION
When I brought change from Master to develop in https://github.com/SUSE/ha-sap-terraform-deployments/commit/5d91553b44ae9d5ecaf707622c633d447e70fc9a
I failed editing the conflicts..
In fact, as I did the merge manually to avoid more PRs, the CI was not executed.

Maybe in the future, we should do proper merge requests to sync develop with master