### PR TITLE
Improve software_path usage to only download HANA folder if desired

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -37,14 +37,13 @@ aws_credentials = "~/.aws/credentials"
 name = "hana"
 
 # S3 bucket where HANA installation master is located
-hana_inst_master = "s3://path/to/your/hana/installation/master"
+hana_inst_master = "s3://path/to/your/hana/installation/master/51053381"
+# Or you can combine the `hana_inst_master` with `hana_platform_folder` variable.
+#hana_inst_master = "s3://path/to/your/hana/installation/master"
+# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point.
+# This will have preference over hdbserver sar archive installation media
+#hana_platform_folder = "51053381"
 
-# Local folder where HANA installation master will be downloaded from S3
-hana_inst_folder = "/sapmedia/HANA"
-
-# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point. 
-#This will have preference over hdbserver sar archive installation media
-hana_platform_folder = "51053381"
 # Or specify the path to the sapcar executable & HANA database server installation sar archive, relative to the 'hana_inst_master' mounting point
 # The sar archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
 # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -76,14 +76,13 @@ storage_account_name = "YOUR_STORAGE_ACCOUNT_NAME"
 storage_account_key = "YOUR_STORAGE_ACCOUNT_KEY"
 
 # Azure storage account path where HANA installation master is located
-hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/hana/installation/master"
+hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/hana/installation/master/51053381"
+# Or you can combine the `hana_inst_master with` `hana_platform_folder` variable.
+#hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/path/to/your/hana/installation/master
+# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point.
+# This will have preference over hdbserver sar archive installation media
+#hana_platform_folder = "51053381"
 
-# Local folder where HANA installation master will be mounted
-hana_inst_folder = "/sapmedia/HANA"
-
-# Specify the path to already extracted HANA platform installation media, relative to hana_inst_master mounting point. 
-#This will have preference over hdbserver sar archive installation media
-hana_platform_folder = "51053381"
 # Or specify the path to the sapcar executable & HANA database server installation sar archive, relative to the 'hana_inst_master' mounting point
 # The sar archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
 # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -38,11 +38,13 @@ public_key_location = "/path/to/your/public/ssh/key"
 region = "europe-west1"
 
 # The name of the GCP storage bucket in your project that contains the SAP HANA installation files
-sap_hana_deployment_bucket = "MyHanaBucket"
+sap_hana_deployment_bucket = "MyHanaBucket/51053381"
+# Or you can combine the `sap_hana_deployment_bucket` with `hana_platform_folder` variable.
+#sap_hana_deployment_bucket = "MyHanaBucket"
+# Specify the path to already extracted HANA platform installation media, relative to sap_hana_deployment_bucket.
+# This will have preference over hdbserver sar archive installation media
+#hana_platform_folder = "51053381"
 
-# Specify the path to already extracted HANA platform installation media, relative to sap_hana_deployment_bucket. 
-#This will have preference over hdbserver sar archive installation media
-hana_platform_folder = "51053381"
 # Or specify the path to the sapcar executable & HANA database server installation sar archive, relative to the sap_hana_deployment_bucket
 # The sar archive will be extracted to path specified at hana_extract_dir (optional, by default /sapmedia/HANA)
 # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -1,8 +1,12 @@
 qemu_uri = "qemu:///system"
-hana_inst_media = "url-to-your-nfs-share"
-# Specify the path to already extracted HANA platform installation media, relative to hana_inst_media mounting point. 
-#This will have preference over hdbserver sar archive installation media
-hana_platform_folder = "51053381"
+
+hana_inst_media = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
+# Or you can combine the `hana_inst_media` with `hana_platform_folder` variable.
+#hana_inst_media = "url-to-your-nfs-share:/sapdata/sap_inst_media"
+# Specify the path to already extracted HANA platform installation media, relative to hana_inst_media mounting point.
+# This will have preference over hdbserver sar archive installation media
+#hana_platform_folder = "51053381"
+
 # Or specify the path to the sapcar executable & HANA database server installation sar archive, relative to the 'hana_inst_media' mounting point
 # The sar archive will be extracted to path specified at hdbserver_extract_dir (optional, by default /sapmedia/HANA)
 # Make sure to use the latest/compatible version of sapcar executable, otherwise file may be extracted incorrectly

--- a/pillar_examples/automatic/hana/hana.sls
+++ b/pillar_examples/automatic/hana/hana.sls
@@ -3,11 +3,12 @@ hana:
   install_packages: false
   {% endif %}
   {%- if grains.get('hana_platform_folder', False) %}
-  software_path:  /sapmedia/HANA/{{ grains['hana_platform_folder'] }}
-  {% endif %}
-  {%- if grains.get('hana_sapcar_exe', False) and grains.get('hdbserver_sar', False) %}
+  software_path: /sapmedia/HANA/{{ grains['hana_platform_folder'] }}
+  {%- elif grains.get('hana_sapcar_exe', False) and grains.get('hdbserver_sar', False) %}
   sapcar_exe_file: /sapmedia/HANA/{{ grains['hana_sapcar_exe'] }}
   hdbserver_sar_file: /sapmedia/HANA/{{ grains['hdbserver_sar'] }}
+  {%- else %}
+  software_path: /sapmedia/HANA/
   {%- endif %}
   {%- if grains.get('hana_extract_dir', False) %}
   hdbserver_extract_dir: {{ grains['hana_extract_dir'] }}


### PR DESCRIPTION
I have done a change to update the usage of the `software_path` entry in HANA pillar file.

Before this, the code war forcing to download the whole folder where HANA folder was stored. This might not be optimal, as many HANA versions might be stored there, and they are really heavy. We don't most probably want to download them all.

Now we can have the next 2 options:
```
hana_inst_media = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
```
Where you only get the HANA folder.
Or, where you can get the whole folder and choose the platform directory
```
#hana_inst_media = "url-to-your-nfs-share:/sapdata/sap_inst_media"
# Specify the path to already extracted HANA platform installation media, relative to hana_inst_media mounting point.
# This will have preference over hdbserver sar archive installation media
#hana_platform_folder = "51053381"
```