### PR TITLE
Hotfix/fix log output

### DIFF
--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -46,7 +46,7 @@ resource "null_resource" "provision" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo sh /tmp/salt/provision.sh -so > /var/log/provisioning.log",
+      "sudo sh /tmp/salt/provision.sh -sol /var/log/provisioning.log",
     ]
   }
 
@@ -59,7 +59,7 @@ resource "null_resource" "provision" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo sh /root/salt/provision.sh -pdq >> /var/log/provisioning.log",
+      "sudo sh /root/salt/provision.sh -pdql /var/log/provisioning.log",
     ]
   }
 }

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -19,7 +19,7 @@ resource "null_resource" "provision_background" {
 
   provisioner "remote-exec" {
     inline = [
-      "nohup sudo sh /tmp/salt/provision.sh > /var/log/provisioning.log &",
+      "nohup sudo sh /tmp/salt/provision.sh -l /var/log/provisioning.log > /dev/null 2>&1 &",
       "return_code=$? && sleep 1 && exit $return_code",
     ] # Workaround to let the process start in background properly
   }

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -12,6 +12,7 @@ cluster:
   interface: eth0
   unicast: True
   {% endif %}
+  join_timeout: 180
   watchdog:
     module: softdog
     device: /dev/watchdog

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -144,7 +144,7 @@ Provision the machines. The provisioning has different steps, so they can be exe
 the selected flags. The actions are always executed in the same order (if multiple are selected),
 from top to bottom in this help text.
 
-Supported Options (if no options are provided all the steps will be executed):
+Supported Options (if no options are provided (excluding -l) all the steps will be executed):
   -s               Bootstrap salt installation and configuration. It will register to SCC channels if needed
   -o               Execute OS setup operations. Register to SCC, updated the packages, etc
   -p               Execute predeployment operations (update hosts and hostnames, install support packages, etc)
@@ -186,14 +186,20 @@ while getopts ":hsopdql:" opt; do
             ;;
     esac
 done
-if [ $OPTIND -eq 1 ]; then
+
+argument_number=$OPTIND
+if [[ -n $log_to_file ]]; then
+    argument_number=$((argument_number - 2))
+    exec 1>> $log_to_file
+fi
+
+if [ $argument_number -eq 1 ]; then
     bootstrap_salt
     os_setup
     predeploy
     deploy
     run_tests
 else
-    [[ -n $log_to_file ]] && exec 1>> $log_to_file
     [[ -n $excute_bootstrap_salt ]] && bootstrap_salt
     [[ -n $excute_os_setup ]] && os_setup
     [[ -n $excute_predeploy ]] && predeploy

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -150,11 +150,12 @@ Supported Options (if no options are provided all the steps will be executed):
   -p               Execute predeployment operations (update hosts and hostnames, install support packages, etc)
   -d               Execute deployment operations (install sap, ha, drbd, etc)
   -q               Execute qa tests
+  -l [LOG_FILE]    Append the log output to the provided file
   -h               Show this help.
 EOF
 }
 
-while getopts ":hsopdq" opt; do
+while getopts ":hsopdql:" opt; do
     case $opt in
         h)
             print_help
@@ -175,6 +176,9 @@ while getopts ":hsopdq" opt; do
         q)
             excute_run_tests=1
             ;;
+        l)
+            log_to_file=$OPTARG
+            ;;
         *)
             echo "Invalid option -$OPTARG" >&2
             print_help
@@ -189,6 +193,7 @@ if [ $OPTIND -eq 1 ]; then
     deploy
     run_tests
 else
+    [[ -n $log_to_file ]] && exec 1>> $log_to_file
     [[ -n $excute_bootstrap_salt ]] && bootstrap_salt
     [[ -n $excute_os_setup ]] && os_setup
     [[ -n $excute_predeploy ]] && predeploy


### PR DESCRIPTION
The creation of the files in `/var/log` fixed. I didn't consider that `>>` are not executed as `root` user, so in `AWS` and `Azure` where we don't use `root` user by default, the scripts where failing due `permission denied`.

This change adds the option to the script to specify the output logfile natively, without redirecting. This way we can run it everything as `root`.

Besides, that I have taken advantage to increase `join_timeout` value for the HANA cluster, as I have noticed that the execution failed twice for that reason in our Jenkins builds