### PR TITLE
Update anything resource by azure-lb in drbd template

### DIFF
--- a/salt/drbd_node/files/templates/drbd_cluster.j2
+++ b/salt/drbd_node/files/templates/drbd_cluster.j2
@@ -45,8 +45,8 @@ primitive vip_{{ res.name }}_nfs IPaddr2 \
         op monitor interval=10 timeout=20
 
 {% if cloud_provider == "microsoft-azure" %}
-primitive nc_{{ res.name }}_nfs anything \
-  params binfile="/usr/bin/socat" cmdline_options="-U TCP-LISTEN:{{ data.probe }},backlog=10,fork,reuseaddr /dev/null" \
+primitive rsc_socat_{{ res.name }}_nfs azure-lb \
+  params port={{ data.probe }} \
   op monitor timeout=20s interval=10 depth=0
 {% endif %}
 
@@ -55,7 +55,7 @@ primitive exportfs_work_{{ res.name }} exportfs \
         options="rw,no_root_squash" clientspec="*" wait_for_leasetime_on_stop=true \
         op monitor interval=30s
 
-group g-nfs_{{ res.name }} fs_{{ res.name }} vip_{{ res.name }}_nfs exportfs_work_{{ res.name }} {% if cloud_provider == "microsoft-azure" %} nc_{{ res.name }}_nfs {% endif %}
+group g-nfs_{{ res.name }} fs_{{ res.name }} vip_{{ res.name }}_nfs exportfs_work_{{ res.name }} {% if cloud_provider == "microsoft-azure" %} rsc_socat_{{ res.name }}_nfs {% endif %}
 
 order o_drbd_{{ res.name }}-before-fs_{{ res.name }} \
   ms_{{ res.name }}:promote g-nfs_{{ res.name }}:start


### PR DESCRIPTION
Update load-balancer resource agent.
I have kept the `rsc_socat` nomenclature as in SUSE distros it uses socat instead `nc`, so it makes sense (replacing by `nc` as the guide suggests is confusing)
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/sap-hana-high-availability