### PR TITLE
Fix AWS credential file

### DIFF
--- a/salt/cluster_node/templates/aws_credentials_template.j2
+++ b/salt/cluster_node/templates/aws_credentials_template.j2
@@ -1,5 +1,5 @@
-{%- set aws_access_key_id = salt['cmd.run']('cat ~'~grains['username']~'/.aws/config | sed -En "s/aws_access_key_id = (.*)/\\\\1/p"', python_shell=true) %}
-{%- set aws_secret_access_key = salt['cmd.run']('cat ~'~grains['username']~'/.aws/config | sed -En "s/aws_secret_access_key = (.*)/\\\\1/p"', python_shell=true) %}
+{%- set aws_access_key_id = salt['cmd.run']('sed -En "s/aws_access_key_id[[:blank:]]*=[[:blank:]]*(.*)/\\\\1/p" ~'~grains['username']~'/.aws/config', python_shell=true) %}
+{%- set aws_secret_access_key = salt['cmd.run']('sed -En "s/aws_secret_access_key[[:blank:]]*=[[:blank:]]*(.*)/\\\\1/p" ~'~grains['username']~'/.aws/config', python_shell=true) %}
 [profile {{ grains['aws_cluster_profile'] }}]
 region = {{ grains['region'] }}
 output = text


### PR DESCRIPTION
The current code implies to have space around the `=` sign for `aws_access_key_id` and `aws_secret_access_key` variables in `${HOME}/.aws/config`.

This is not mandatory and could lead to issues during deployment (VIP not working for example).

Backport of this commit from `develop` to `master` to be able to create a `4.1.1` release.