### PR TITLE
Remove hardcoded storage devices on GCE

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -127,9 +127,6 @@ module "hana_node" {
   hana_data_disk_size        = var.hana_data_disk_size
   hana_backup_disk_type      = var.hana_backup_disk_type
   hana_backup_disk_size      = var.hana_backup_disk_size
-  hana_disk_device           = var.hana_disk_device
-  hana_backup_device         = var.hana_backup_device
-  hana_inst_disk_device      = var.hana_inst_disk_device
   hana_fstype                = var.hana_fstype
   hana_cluster_vip           = local.hana_cluster_vip
   scenario_type              = var.scenario_type
@@ -186,7 +183,6 @@ module "iscsi_server" {
   network_subnet_name       = local.subnet_name
   iscsi_server_boot_image   = var.iscsi_server_boot_image
   iscsi_srv_ip              = local.iscsi_srv_ip
-  iscsidev                  = var.iscsidev
   iscsi_disks               = var.iscsi_disks
   public_key_location       = var.public_key_location
   private_key_location      = var.private_key_location

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -31,7 +31,7 @@ host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
-drbd_disk_device: /dev/sdb
+drbd_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.drbd.*.attached_disk.0.device_name, count.index))}
 drbd_cluster_vip: ${var.drbd_cluster_vip}
 shared_storage_type: iscsi
 sbd_disk_device: /dev/sdd

--- a/gcp/modules/hana_node/salt_provisioner.tf
+++ b/gcp/modules/hana_node/salt_provisioner.tf
@@ -37,9 +37,9 @@ hana_platform_folder: ${var.hana_platform_folder}
 hana_sapcar_exe: ${var.hana_sapcar_exe}
 hdbserver_sar: ${var.hdbserver_sar}
 hana_extract_dir: ${var.hana_extract_dir}
-hana_disk_device: ${var.hana_disk_device}
-hana_backup_device: ${var.hana_backup_device}
-hana_inst_disk_device: ${var.hana_inst_disk_device}
+hana_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.0.device_name, count.index))}
+hana_backup_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.1.device_name, count.index))}
+hana_inst_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.2.device_name, count.index))}
 hana_fstype: ${var.hana_fstype}
 hana_cluster_vip: ${var.hana_cluster_vip}
 gcp_credentials_file: ${var.gcp_credentials_file}

--- a/gcp/modules/iscsi_server/salt_provisioner.tf
+++ b/gcp/modules/iscsi_server/salt_provisioner.tf
@@ -17,7 +17,7 @@ resource "null_resource" "iscsi_provisioner" {
 provider: gcp
 role: iscsi_srv
 iscsi_srv_ip: ${var.iscsi_srv_ip}
-iscsidev: ${var.iscsidev}
+iscsidev: ${format("%s%s","/dev/disk/by-id/google-", google_compute_instance.iscsisrv.attached_disk.0.device_name)}
 iscsi_disks: ${var.iscsi_disks}
 qa_mode: ${var.qa_mode}
 reg_code: ${var.reg_code}

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -57,7 +57,7 @@ netweaver_swpm_extract_dir: ${var.netweaver_swpm_extract_dir}
 netweaver_sapexe_folder: ${var.netweaver_sapexe_folder}
 netweaver_additional_dvds: [${join(", ", formatlist("'%s'", var.netweaver_additional_dvds))}]
 netweaver_nfs_share: ${var.netweaver_nfs_share}
-nw_inst_disk_device : /dev/sdb
+nw_inst_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.netweaver.*.attached_disk.0.device_name, count.index))}
 hana_ip: ${var.hana_ip}
 vpc_network_name: ${var.network_name}
 route_table: ${google_compute_route.nw-route[0].name}

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -70,9 +70,6 @@ sles4sap_boot_image = "MySles4SapImage"
 # Variable to control what is deployed in the nodes. Can be all, skip-hana or skip-cluster
 init_type = "all"
 
-# Device used by the iSCSI server to provide LUNs
-iscsidev = "/dev/sdb"
-
 # Path to a custom ssh public key to upload to the nodes
 # Used for cluster communication for example
 cluster_ssh_pub = "salt://hana_node/files/sshkeys/cluster.id_rsa.pub"
@@ -87,15 +84,6 @@ cluster_ssh_key = "salt://hana_node/files/sshkeys/cluster.id_rsa"
 
 # Local folder where HANA installation master will be mounted
 hana_inst_folder = "/sapmedia/HANA"
-
-# Device used by node where HANA will be installed
-hana_disk_device = "/dev/sdb"
-
-# Device used by node where HANA backup will be stored
-hana_backup_device = "/dev/sdc"
-
-# Device used by node where HANA will be downloaded
-hana_inst_disk_device = "/dev/sdd"
 
 # Repository url used to install HA/SAP deployment packages"
 # The latest RPM packages can be found at:

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -214,24 +214,6 @@ variable "hana_backup_disk_size" {
   default     = "416"
 }
 
-variable "hana_disk_device" {
-  description = "Device where hana is installed"
-  type        = string
-  default     = "/dev/sdb"
-}
-
-variable "hana_backup_device" {
-  description = "Device where hana backup is stored"
-  type        = string
-  default     = "/dev/sdc"
-}
-
-variable "hana_inst_disk_device" {
-  description = "Device where hana installation software CIFS share is mounted"
-  type        = string
-  default     = "/dev/sdd"
-}
-
 variable "hana_fstype" {
   description = "Filesystem type used by the disk where hana is installed"
   type        = string
@@ -279,12 +261,6 @@ variable "iscsi_srv_ip" {
   description = "IP for iSCSI server. It must be in the same network addresses range defined in `ip_cidr_range`"
   type        = string
   default     = ""
-}
-
-variable "iscsidev" {
-  description = "Disk device where iscsi partitions are created"
-  type        = string
-  default     = "/dev/sdb"
 }
 
 variable "iscsi_disks" {

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -1,3 +1,5 @@
+{% set drbd_disk_device = salt['cmd.run']('realpath '~grains['drbd_disk_device']) %}
+
 drbd:
   promotion: {{ grains['name_prefix'] }}01
 
@@ -62,7 +64,7 @@ drbd:
   resource:
     - name: "sapdata"
       device: "/dev/drbd1"
-      disk: {{ grains['drbd_disk_device'] }}1
+      disk: {{ drbd_disk_device }}1
 
       file_system: "xfs"
       mount_point: "/mnt/sapdata/HA1"

--- a/salt/hana_node/download_hana_inst.sls
+++ b/salt/hana_node/download_hana_inst.sls
@@ -8,13 +8,14 @@ download_files_from_s3:
 
 {% elif grains['provider'] == 'gcp' %}
 
+{% set hana_inst_disk_device = salt['cmd.run']('realpath '~grains['hana_inst_disk_device']) %}
 hana_inst_partition:
   cmd.run:
     - name: |
-        /usr/sbin/parted -s {{ grains['hana_inst_disk_device'] }} mklabel msdos && \
-        /usr/sbin/parted -s {{ grains['hana_inst_disk_device'] }} mkpart primary ext2 1M 100% && sleep 1 && \
-        /sbin/mkfs -t xfs {{ grains['hana_inst_disk_device'] }}1
-    - unless: ls {{ grains['hana_inst_disk_device'] }}1
+        /usr/sbin/parted -s {{ hana_inst_disk_device }} mklabel msdos && \
+        /usr/sbin/parted -s {{ hana_inst_disk_device }} mkpart primary ext2 1M 100% && sleep 1 && \
+        /sbin/mkfs -t xfs {{ hana_inst_disk_device }}1
+    - unless: ls {{ hana_inst_disk_device }}1
     - require:
       - pkg: parted
 
@@ -26,7 +27,7 @@ hana_inst_directory:
     - makedirs: True
   mount.mounted:
     - name: {{ grains['hana_inst_folder'] }}
-    - device: {{ grains['hana_inst_disk_device'] }}1
+    - device: {{ hana_inst_disk_device }}1
     - fstype: xfs
     - mkmnt: True
     - persist: True

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -72,18 +72,19 @@ sapcd_folder:
       - wait_until_sw_downloaded
 
 {% elif grains['provider'] == 'gcp' %}
+{% set nw_inst_disk_device = salt['cmd.run']('realpath '~grains['nw_inst_disk_device']) %}
 nw_inst_partition:
   cmd.run:
     - name: |
-        /usr/sbin/parted -s {{ grains['nw_inst_disk_device'] }} mklabel msdos && \
-        /usr/sbin/parted -s {{ grains['nw_inst_disk_device'] }} mkpart primary ext2 1M 100% && sleep 1 && \
-        /sbin/mkfs -t xfs {{ grains['nw_inst_disk_device'] }}1
-    - unless: ls {{ grains['nw_inst_disk_device'] }}1
+        /usr/sbin/parted -s {{ nw_inst_disk_device }} mklabel msdos && \
+        /usr/sbin/parted -s {{ nw_inst_disk_device }} mkpart primary ext2 1M 100% && sleep 1 && \
+        /sbin/mkfs -t xfs {{ nw_inst_disk_device }}1
+    - unless: ls {{ nw_inst_disk_device }}1
 
 mount_swpm:
   mount.mounted:
     - name: {{ sapcd }}
-    - device: {{ grains['nw_inst_disk_device'] }}1
+    - device: {{ nw_inst_disk_device }}1
     - fstype: xfs
     - mkmnt: True
     - persist: True


### PR DESCRIPTION
Storage devices in GCE are currently set either in the tfvars file or hardcoded in TF/sls files. This is bad because device name in Linux are handled by udev and the naming is dynamic (`/dev/sdb` could be `/dev/sda` sometimes).

This commit removes all of these by using GCE functionalities to get the correct device name.

Manual tests done successfully and through [openQA tests](http://1b210.qa.suse.de/tests/6633) also.