### PR TITLE
Add qa_mode support for nw and drbd for all providers

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -71,6 +71,7 @@ module "netweaver_node" {
   reg_additional_modules     = var.reg_additional_modules
   ha_sap_deployment_repo     = var.ha_sap_deployment_repo
   devel_mode                 = var.devel_mode
+  qa_mode                    = var.qa_mode
   provisioner                = var.provisioner
   background                 = var.background
   monitoring_enabled         = var.monitoring_enabled

--- a/aws/modules/hana_node/variables.tf
+++ b/aws/modules/hana_node/variables.tf
@@ -211,7 +211,7 @@ variable "hwcct" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/aws/modules/iscsi_server/variables.tf
+++ b/aws/modules/iscsi_server/variables.tf
@@ -107,7 +107,7 @@ variable "background" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -228,7 +228,7 @@ variable "devel_mode" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -51,6 +51,7 @@ module "drbd_node" {
   reg_additional_modules = var.reg_additional_modules
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   devel_mode             = var.devel_mode
+  qa_mode                = var.qa_mode
   provisioner            = var.provisioner
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
@@ -100,6 +101,7 @@ module "netweaver_node" {
   reg_additional_modules        = var.reg_additional_modules
   ha_sap_deployment_repo        = var.ha_sap_deployment_repo
   devel_mode                    = var.devel_mode
+  qa_mode                       = var.qa_mode
   provisioner                   = var.provisioner
   background                    = var.background
   monitoring_enabled            = var.monitoring_enabled

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -127,7 +127,7 @@ variable "devel_mode" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -158,7 +158,7 @@ variable "hwcct" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -104,7 +104,7 @@ variable "additional_packages" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -240,7 +240,7 @@ variable "devel_mode" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -28,6 +28,7 @@ module "drbd_node" {
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   monitoring_enabled     = var.monitoring_enabled
   devel_mode             = var.devel_mode
+  qa_mode                = var.qa_mode
   provisioner            = var.provisioner
   background             = var.background
   on_destroy_dependencies = [
@@ -67,6 +68,7 @@ module "netweaver_node" {
   reg_additional_modules     = var.reg_additional_modules
   ha_sap_deployment_repo     = var.ha_sap_deployment_repo
   devel_mode                 = var.devel_mode
+  qa_mode                    = var.qa_mode
   provisioner                = var.provisioner
   background                 = var.background
   monitoring_enabled         = var.monitoring_enabled

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -41,6 +41,7 @@ vpc_network_name: ${var.network_name}
 route_table: ${google_compute_route.drbd-route[0].name}
 monitoring_enabled: ${var.monitoring_enabled}
 devel_mode: ${var.devel_mode}
+qa_mode: ${var.qa_mode}
 partitions:
   1:
     start: 0%

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -123,6 +123,12 @@ variable "devel_mode" {
   default     = false
 }
 
+variable "qa_mode" {
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
+  type        = bool
+  default     = false
+}
+
 variable "provisioner" {
   description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
   default     = "salt"

--- a/gcp/modules/hana_node/variables.tf
+++ b/gcp/modules/hana_node/variables.tf
@@ -200,7 +200,7 @@ variable "hwcct" {
 }
 
 variable "qa_mode" {
-  description = "Enable test/qa mode (disable extra packages usage not coming in the image)`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/gcp/modules/iscsi_server/variables.tf
+++ b/gcp/modules/iscsi_server/variables.tf
@@ -70,7 +70,7 @@ variable "additional_packages" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -193,7 +193,7 @@ variable "devel_mode" {
 }
 
 variable "qa_mode" {
-  description = "Whether or not to install the HA/SAP packages from the `ha_sap_deployment_repo`"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -126,6 +126,7 @@ module "drbd_node" {
   reg_additional_modules = var.reg_additional_modules
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   devel_mode             = var.devel_mode
+  qa_mode                = var.qa_mode
   provisioner            = var.provisioner
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
@@ -195,4 +196,5 @@ module "netweaver_node" {
   background                 = var.background
   monitoring_enabled         = var.monitoring_enabled
   devel_mode                 = var.devel_mode
+  qa_mode                    = var.qa_mode
 }

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -22,6 +22,7 @@ network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}
 devel_mode: ${var.devel_mode}
+qa_mode: ${var.qa_mode}
 reg_email: ${var.reg_email}
 reg_additional_modules: {${join(", ",formatlist("'%s': '%s'",keys(var.reg_additional_modules),values(var.reg_additional_modules),),)}}
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -37,6 +37,12 @@ variable "devel_mode" {
   default     = false
 }
 
+variable "qa_mode" {
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
+  type        = bool
+  default     = false
+}
+
 variable "additional_packages" {
   description = "extra packages which should be installed"
   default     = []

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -194,7 +194,7 @@ variable "monitoring_enabled" {
 // QA mode variables
 
 variable "qa_mode" {
-  description = "define qa mode (Disable extra packages outside images)"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/libvirt/modules/iscsi_server/variables.tf
+++ b/libvirt/modules/iscsi_server/variables.tf
@@ -105,7 +105,7 @@ variable "bridge" {
 
 # Specific QA variables
 variable "qa_mode" {
-  description = "define qa mode (Disable extra packages outside images)"
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
   type        = bool
   default     = false
 }

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -48,6 +48,7 @@ shared_storage_type: shared-disk
 sbd_disk_device: /dev/vdb1
 monitoring_enabled: ${var.monitoring_enabled}
 devel_mode: ${var.devel_mode}
+qa_mode: ${var.qa_mode}
 EOF
     destination = "/tmp/grains"
   }

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -207,3 +207,9 @@ variable "devel_mode" {
   type        = bool
   default     = false
 }
+
+variable "qa_mode" {
+  description = "Enable test/qa mode (disable extra packages usage not coming in the image)"
+  type        = bool
+  default     = false
+}

--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -1,5 +1,7 @@
 cluster:
-  install_packages: true
+  {%- if grains.get('qa_mode') %}
+  install_packages: false
+  {%- endif %}
   name: 'drbd_cluster'
   init: {{ grains['name_prefix'] }}01
   {% if grains['provider'] == 'libvirt' %}

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -1,4 +1,7 @@
 drbd:
+  {%- if grains.get('qa_mode') %}
+  install_packages: false
+  {%- endif %}
   promotion: {{ grains['name_prefix'] }}01
 
   ## Resource template for /etc/drbd.d/xxx.res

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -2,7 +2,9 @@
 {%- set iprange = ".".join(grains['host_ips'][0].split('.')[0:-1]) %}
 
 cluster:
-  install_packages: true
+  {%- if grains.get('qa_mode') %}
+  install_packages: false
+  {%- endif %}
   name: netweaver_cluster
   init: {{ grains['name_prefix'] }}01
   {%- if grains['provider'] == 'libvirt' %}

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -12,6 +12,9 @@
 {%- endif %}
 
 netweaver:
+  {%- if grains.get('qa_mode') %}
+  install_packages: false
+  {%- endif %}
   virtual_addresses:
     {{ grains['virtual_host_ips'][0] }}: sapha1as
     {{ grains['virtual_host_ips'][1] }}: sapha1er

--- a/pillar_examples/aws/hana.sls
+++ b/pillar_examples/aws/hana.sls
@@ -1,5 +1,5 @@
 hana:
-  # install_packages: false # disable pre defined pacakge installation
+  # install_packages: false # disable pre defined package installation
   saptune_solution: 'HANA'
   nodes:
     - host: 'hana01'


### PR DESCRIPTION
Adding/updating the `qa_mode` support for all providers in DRBD and Netweaver modules.
I have updated the variable description for the modules variables.
For aws, it not have drbd module implemented yet, I added qa_mode for netweaver. 