### PR TITLE
Hotfix/gcp hana route name

### DIFF
--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -11,7 +11,7 @@ resource "google_compute_disk" "data" {
 
 # temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
 resource "google_compute_route" "drbd-route" {
-  name                   = "drbd-route"
+  name                   = "${terraform.workspace}-drbd-route"
   count                  = var.drbd_count > 0 ? 1 : 0
   dest_range             = "${var.drbd_cluster_vip}/32"
   network                = var.network_name

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -27,7 +27,7 @@ resource "google_compute_disk" "hana-software" {
 
 # temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
 resource "google_compute_route" "hana-route" {
-  name                   = "hana-route"
+  name                   = "${terraform.workspace}-hana-route"
   count                  = var.hana_count > 0 ? 1 : 0
   dest_range             = "${var.hana_cluster_vip}/32"
   network                = var.network_name

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -11,7 +11,7 @@ resource "google_compute_disk" "netweaver-software" {
 
 # temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
 resource "google_compute_route" "nw-route" {
-  name                   = "nw-route"
+  name                   = "${terraform.workspace}-nw-route"
   count                  = var.netweaver_count > 0 ? 1 : 0
   dest_range             = "${element(var.virtual_host_ips, 0)}/32"
   network                = var.network_name


### PR DESCRIPTION
In `gcp` all the names must be unique, as we don't have the option to group them like in `azure`. For that, we need to add the workspace to the created resources name, so we can run multiple deployments. Otherwise my deployments will conflict with yours if we are using the the same subscription