### PR TITLE
Improve template usage in aws policies

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -4,10 +4,6 @@ provider "aws" {
   region  = var.aws_region
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 # AWS key pair
 resource "aws_key_pair" "hana-key-pair" {
   key_name   = "${terraform.workspace} - terraform"

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -53,7 +53,7 @@ module "sap_cluster_policies" {
   source            = "../../modules/sap_cluster_policies"
   name              = var.name
   aws_region        = var.aws_region
-  cluster_instances = aws_instance.netweaver.*.id
+  cluster_instances = slice(aws_instance.netweaver.*.id, 0, min(var.netweaver_count, 2))
   route_table_id    = var.route_table_id
 }
 

--- a/aws/modules/sap_cluster_policies/templates/aws_stonith_policy.tpl
+++ b/aws/modules/sap_cluster_policies/templates/aws_stonith_policy.tpl
@@ -20,10 +20,9 @@
                 "ec2:StartInstances",
                 "ec2:StopInstances"
             ],
-            "Resource": [
-                "arn:aws:ec2:${region}:${aws_account_id}:instance/${ec2_instance1}",
-                "arn:aws:ec2:${region}:${aws_account_id}:instance/${ec2_instance2}"
-            ]
+            "Resource": ${jsonencode([
+                for ec2_instance in ec2_instances : "arn:aws:ec2:${region}:${aws_account_id}:instance/${ec2_instance}"
+            ])}
         }
     ]
 }

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -3,10 +3,6 @@ provider "azurerm" {
   version = "~> 1.44"
 }
 
-provider "template" {
-  version = "~> 2.1"
-}
-
 terraform {
   required_version = ">= 0.12"
 }


### PR DESCRIPTION
Remove the `template` provider usage as we can use the new feature in terraform 12 `templatefile`.

`templatefile` has the benefit that it can pass lists to be rendered. This is important, as otherwise we were always assuming that we had 2 elements to be rendered, what if you want to deploy a single hana, was causing errors.