### PR TITLE
Improvements/remove hostname indexes

### DIFF
--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -64,9 +64,9 @@ resource "aws_instance" "clusternodes" {
   }
 
   tags = {
-    Name      = "${terraform.workspace} - ${var.name}0${count.index + 1}"
-    Workspace = terraform.workspace
-    Cluster   = "${terraform.workspace}-${var.name}0${count.index + 1}"
+    Name                             = "${terraform.workspace} - ${var.name}0${count.index + 1}"
+    Workspace                        = terraform.workspace
+    "${terraform.workspace}-cluster" = "${var.name}0${count.index + 1}"
   }
 }
 

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -60,13 +60,13 @@ resource "aws_instance" "clusternodes" {
   }
 
   volume_tags = {
-    Name = "${terraform.workspace}-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+    Name = "${terraform.workspace}-${var.name}0${count.index + 1}"
   }
 
   tags = {
-    Name      = "${terraform.workspace} - ${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+    Name      = "${terraform.workspace} - ${var.name}0${count.index + 1}"
     Workspace = terraform.workspace
-    Cluster   = "${terraform.workspace}-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+    Cluster   = "${terraform.workspace}-${var.name}0${count.index + 1}"
   }
 }
 

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -31,8 +31,8 @@ hana_cluster_vip: ${var.hana_cluster_vip}
 route_table: ${var.route_table_id}
 scenario_type: ${var.scenario_type}
 name_prefix: ${terraform.workspace}-${var.name}
+hostname: ${terraform.workspace}-${var.name}0${count.index + 1}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-hostname: ${terraform.workspace}-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}
 network_domain: "tf.local"
 shared_storage_type: iscsi
 sbd_disk_device: /dev/sda

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -23,15 +23,15 @@ provider: aws
 region: ${var.aws_region}
 role: hana_node
 aws_cluster_profile: Cluster
-aws_instance_tag: Cluster
+aws_instance_tag: ${terraform.workspace}-cluster
 aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}
 hana_cluster_vip: ${var.hana_cluster_vip}
 route_table: ${var.route_table_id}
 scenario_type: ${var.scenario_type}
-name_prefix: ${terraform.workspace}-${var.name}
-hostname: ${terraform.workspace}-${var.name}0${count.index + 1}
+name_prefix: ${var.name}
+hostname: ${var.name}0${count.index + 1}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 network_domain: "tf.local"
 shared_storage_type: iscsi

--- a/aws/modules/monitoring/salt_provisioner.tf
+++ b/aws/modules/monitoring/salt_provisioner.tf
@@ -17,9 +17,9 @@ resource "null_resource" "monitoring_provisioner" {
 provider: aws
 region: ${var.aws_region}
 role: monitoring
-name_prefix: ${terraform.workspace}-monitoring
+name_prefix: monitoring
+hostname: monitoring
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-hostname: ${terraform.workspace}-monitoring
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -76,13 +76,13 @@ resource "aws_instance" "netweaver" {
   }
 
   volume_tags = {
-    Name = "${terraform.workspace}-${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
+    Name = "${terraform.workspace}-${var.name}0${count.index + 1}"
   }
 
   tags = {
-    Name      = "${terraform.workspace} - ${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
+    Name      = "${terraform.workspace} - ${var.name}0${count.index + 1}"
     Workspace = terraform.workspace
-    Cluster   = "${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
+    Cluster   = "${terraform.workspace}-${var.name}0${count.index + 1}"
   }
 }
 

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -80,9 +80,9 @@ resource "aws_instance" "netweaver" {
   }
 
   tags = {
-    Name      = "${terraform.workspace} - ${var.name}0${count.index + 1}"
-    Workspace = terraform.workspace
-    Cluster   = "${terraform.workspace}-${var.name}0${count.index + 1}"
+    Name                             = "${terraform.workspace} - ${var.name}0${count.index + 1}"
+    Workspace                        = terraform.workspace
+    "${terraform.workspace}-cluster" = "${var.name}0${count.index + 1}"
   }
 }
 

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -22,10 +22,10 @@ resource "null_resource" "netweaver_provisioner" {
 provider: aws
 region: ${var.aws_region}
 role: netweaver_node
-name_prefix: ${terraform.workspace}-${var.name}
-hostname: ${terraform.workspace}-${var.name}0${count.index + 1}
+name_prefix: ${var.name}
+hostname: ${var.name}0${count.index + 1}
 aws_cluster_profile: Cluster
-aws_instance_tag: Cluster
+aws_instance_tag: ${terraform.workspace}-cluster
 aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -22,14 +22,14 @@ resource "null_resource" "netweaver_provisioner" {
 provider: aws
 region: ${var.aws_region}
 role: netweaver_node
-name_prefix: ${var.name}
+name_prefix: ${terraform.workspace}-${var.name}
+hostname: ${terraform.workspace}-${var.name}0${count.index + 1}
 aws_cluster_profile: Cluster
 aws_instance_tag: Cluster
 aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}
 route_table: ${var.route_table_id}
-hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 additional_packages: []
 reg_code: ${var.reg_code}

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -165,7 +165,7 @@ resource "azurerm_image" "drbd-image" {
 
 resource "azurerm_virtual_machine" "drbd" {
   count                            = var.drbd_count
-  name                             = "vm${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}"
+  name                             = "vm${var.name}0${count.index + 1}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.drbd.*.id, count.index)]
@@ -175,7 +175,7 @@ resource "azurerm_virtual_machine" "drbd" {
   delete_data_disks_on_termination = true
 
   storage_os_disk {
-    name              = "disk-${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}-Os"
+    name              = "disk-${var.name}0${count.index + 1}-Os"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
@@ -190,7 +190,7 @@ resource "azurerm_virtual_machine" "drbd" {
   }
 
   storage_data_disk {
-    name              = "disk-${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}-Data01"
+    name              = "disk-${var.name}0${count.index + 1}-Data01"
     caching           = "ReadWrite"
     create_option     = "Empty"
     disk_size_gb      = "10"
@@ -199,7 +199,7 @@ resource "azurerm_virtual_machine" "drbd" {
   }
 
   os_profile {
-    computer_name  = "drbd0${count.index + 1}"
+    computer_name  = "vmdrbd0${count.index + 1}"
     admin_username = var.admin_user
   }
 

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -17,7 +17,7 @@ resource "null_resource" "drbd_provisioner" {
 provider: azure
 role: drbd_node
 name_prefix: vm${var.name}
-hostname: vm${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}
+hostname: vm${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 additional_packages: []
 reg_code: ${var.reg_code}

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -161,7 +161,7 @@ resource "azurerm_lb_rule" "lb_3xx17" {
 
 resource "azurerm_network_interface" "hana" {
   count                         = var.hana_count
-  name                          = "nic-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+  name                          = "nic-${var.name}0${count.index + 1}"
   location                      = var.az_region
   resource_group_name           = var.resource_group_name
   network_security_group_id     = var.sec_group_id
@@ -182,7 +182,7 @@ resource "azurerm_network_interface" "hana" {
 
 resource "azurerm_public_ip" "hana" {
   count                   = var.hana_count
-  name                    = "pip-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+  name                    = "pip-${var.name}0${count.index + 1}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name
   allocation_method       = "Dynamic"
@@ -215,7 +215,7 @@ resource "azurerm_image" "sles4sap" {
 
 resource "azurerm_virtual_machine" "hana" {
   count                            = var.hana_count
-  name                             = "vm${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+  name                             = "vm${var.name}0${count.index + 1}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.hana.*.id, count.index)]
@@ -225,7 +225,7 @@ resource "azurerm_virtual_machine" "hana" {
   delete_data_disks_on_termination = true
 
   storage_os_disk {
-    name              = "disk-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}-Os"
+    name              = "disk-${var.name}0${count.index + 1}-Os"
     caching           = "ReadWrite"
     create_option     = "FromImage"
     managed_disk_type = "Premium_LRS"
@@ -240,7 +240,7 @@ resource "azurerm_virtual_machine" "hana" {
   }
 
   storage_data_disk {
-    name              = "disk-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}-Data01"
+    name              = "disk-${var.name}0${count.index + 1}-Data01"
     managed_disk_type = var.hana_data_disk_type
     create_option     = "Empty"
     lun               = 0
@@ -249,7 +249,7 @@ resource "azurerm_virtual_machine" "hana" {
   }
 
   storage_data_disk {
-    name              = "disk-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}-Data02"
+    name              = "disk-${var.name}0${count.index + 1}-Data02"
     managed_disk_type = var.hana_data_disk_type
     create_option     = "Empty"
     lun               = 1
@@ -258,7 +258,7 @@ resource "azurerm_virtual_machine" "hana" {
   }
 
   storage_data_disk {
-    name              = "disk-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}-Data03"
+    name              = "disk-${var.name}0${count.index + 1}-Data03"
     managed_disk_type = var.hana_data_disk_type
     create_option     = "Empty"
     lun               = 2
@@ -267,7 +267,7 @@ resource "azurerm_virtual_machine" "hana" {
   }
 
   os_profile {
-    computer_name  = "${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+    computer_name  = "vm${var.name}0${count.index + 1}"
     admin_username = var.admin_user
   }
 

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -22,8 +22,8 @@ role: hana_node
 devel_mode: ${var.devel_mode}
 scenario_type: ${var.scenario_type}
 name_prefix: vm${var.name}
+hostname: vm${var.name}0${count.index + 1}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-hostname: vm${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}
 network_domain: "tf.local"
 shared_storage_type: iscsi
 sbd_disk_device: /dev/sdf

--- a/azure/modules/monitoring/salt_provisioner.tf
+++ b/azure/modules/monitoring/salt_provisioner.tf
@@ -17,7 +17,7 @@ resource "null_resource" "monitoring_provisioner" {
 provider: azure
 role: monitoring
 name_prefix: vmmonitoring
-hostname: "vmmonitoring"
+hostname: vmmonitoring
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -22,7 +22,7 @@ resource "google_compute_route" "drbd-route" {
 
 resource "google_compute_instance" "drbd" {
   machine_type = var.machine_type
-  name         = "${terraform.workspace}-drbd${var.drbd_count > 1 ? "0${count.index + 1}" : ""}"
+  name         = "${terraform.workspace}-drbd0${count.index + 1}"
   count        = var.drbd_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -20,7 +20,7 @@ resource "null_resource" "drbd_provisioner" {
 provider: gcp
 role: drbd_node
 name_prefix: ${terraform.workspace}-drbd
-hostname: ${terraform.workspace}-drbd${var.drbd_count > 1 ? "0${count.index + 1}" : ""}
+hostname: ${terraform.workspace}-drbd$0${count.index + 1}"
 network_domain: ${var.network_domain}
 additional_packages: []
 reg_code: ${var.reg_code}

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -38,7 +38,7 @@ resource "google_compute_route" "hana-route" {
 
 resource "google_compute_instance" "clusternodes" {
   machine_type = var.machine_type
-  name         = "${terraform.workspace}-hana${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+  name         = "${terraform.workspace}-hana0${count.index + 1}"
   count        = var.hana_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/hana_node/salt_provisioner.tf
+++ b/gcp/modules/hana_node/salt_provisioner.tf
@@ -27,8 +27,8 @@ role: hana_node
 devel_mode: ${var.devel_mode}
 scenario_type: ${var.scenario_type}
 name_prefix: ${terraform.workspace}-hana
+hostname: ${terraform.workspace}-hana0${count.index + 1}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-hostname: ${terraform.workspace}-hana${var.hana_count > 1 ? "0${count.index + 1}" : ""}
 network_domain: "tf.local"
 shared_storage_type: iscsi
 sbd_disk_device: /dev/sde

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -22,7 +22,7 @@ resource "google_compute_route" "nw-route" {
 
 resource "google_compute_instance" "netweaver" {
   machine_type = var.machine_type
-  name         = "${terraform.workspace}-netweaver${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
+  name         = "${terraform.workspace}-netweaver0${count.index + 1}"
   count        = var.netweaver_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -25,7 +25,7 @@ resource "null_resource" "netweaver_provisioner" {
 provider: gcp
 role: netweaver_node
 name_prefix: ${terraform.workspace}-netweaver
-hostname: ${terraform.workspace}-netweaver${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}
+hostname: ${terraform.workspace}-netweaver0${count.index + 1}
 network_domain: ${var.network_domain}
 additional_packages: []
 reg_code: ${var.reg_code}

--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -1,20 +1,20 @@
 resource "libvirt_volume" "drbd_image_disk" {
   count            = var.drbd_count
-  name             = "${terraform.workspace}-${var.name}${var.drbd_count > 1 ? "-${count.index + 1}" : ""}-main-disk"
+  name             = "${terraform.workspace}-${var.name}-${count.index + 1}-main-disk"
   source           = var.source_image
   base_volume_name = var.volume_name
   pool             = var.storage_pool
 }
 
 resource "libvirt_volume" "drbd_data_disk" {
-  name  = "${terraform.workspace}-${var.name}${var.drbd_count > 1 ? "-${count.index + 1}" : ""}-drbd-disk"
+  name  = "${terraform.workspace}-${var.name}-${count.index + 1}-drbd-disk"
   pool  = var.storage_pool
   count = var.drbd_count
   size  = var.drbd_disk_size
 }
 
 resource "libvirt_domain" "drbd_domain" {
-  name       = "${terraform.workspace}-${var.name}${var.drbd_count > 1 ? "-${count.index + 1}" : ""}"
+  name       = "${terraform.workspace}-${var.name}-${count.index + 1}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.drbd_count
@@ -58,7 +58,7 @@ resource "libvirt_domain" "drbd_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}"
+    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -16,8 +16,8 @@ resource "null_resource" "drbd_node_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
-name_prefix: ${terraform.workspace}-${var.name}
-hostname: ${terraform.workspace}-${var.name}${var.drbd_count > 1 ? "0${count.index + 1}" : ""}
+name_prefix: ${var.name}
+hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}

--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -1,20 +1,20 @@
 resource "libvirt_volume" "hana_image_disk" {
   count            = var.hana_count
-  name             = "${terraform.workspace}-${var.name}${var.hana_count > 1 ? "-${count.index + 1}" : ""}-main-disk"
+  name             = "${terraform.workspace}-${var.name}-${count.index + 1}-main-disk"
   source           = var.source_image
   base_volume_name = var.volume_name
   pool             = var.storage_pool
 }
 
 resource "libvirt_volume" "hana_data_disk" {
-  name  = "${terraform.workspace}-${var.name}${var.hana_count > 1 ? "-${count.index + 1}" : ""}-hana-disk"
+  name  = "${terraform.workspace}-${var.name}-${count.index + 1}-hana-disk"
   pool  = var.storage_pool
   count = var.hana_count
   size  = var.hana_disk_size
 }
 
 resource "libvirt_domain" "hana_domain" {
-  name       = "${terraform.workspace}-${var.name}${var.hana_count > 1 ? "-${count.index + 1}" : ""}"
+  name       = "${terraform.workspace}-${var.name}-${count.index + 1}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.hana_count
@@ -59,7 +59,7 @@ resource "libvirt_domain" "hana_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}"
+    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -16,8 +16,8 @@ resource "null_resource" "hana_node_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
-name_prefix: ${terraform.workspace}-${var.name}
-hostname: ${terraform.workspace}-${var.name}${var.hana_count > 1 ? "0${count.index + 1}" : ""}
+name_prefix: ${var.name}
+hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}

--- a/libvirt/modules/netweaver_node/main.tf
+++ b/libvirt/modules/netweaver_node/main.tf
@@ -1,13 +1,13 @@
 resource "libvirt_volume" "netweaver_image_disk" {
   count            = var.netweaver_count
-  name             = "${terraform.workspace}-${var.name}${var.netweaver_count > 1 ? "-${count.index + 1}" : ""}-main-disk"
+  name             = "${terraform.workspace}-${var.name}-${count.index + 1}-main-disk"
   source           = var.source_image
   base_volume_name = var.volume_name
   pool             = var.storage_pool
 }
 
 resource "libvirt_domain" "netweaver_domain" {
-  name       = "${terraform.workspace}-${var.name}${var.netweaver_count > 1 ? "-${count.index + 1}" : ""}"
+  name       = "${terraform.workspace}-${var.name}-${count.index + 1}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.netweaver_count
@@ -38,7 +38,7 @@ resource "libvirt_domain" "netweaver_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}"
+    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -17,7 +17,7 @@ resource "null_resource" "netweaver_node_provisioner" {
   provisioner "file" {
     content     = <<EOF
 name_prefix: ${var.name}
-hostname: ${var.name}${var.netweaver_count > 1 ? "0${count.index + 1}" : ""}
+hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 reg_code: ${var.reg_code}


### PR DESCRIPTION
Changes:
- Remove the logic to add a subix or not to the hostname. It doesn't have much sense and any usage. Actually, it makes things worst when you want to create a single hana environment
- Remove terraform workspace from hostname to make it more simple. GCP is an exception, as the hostname and machine name must be the same (unless you use some external dns service)
- Improve AWS cluster tag usage. Otherwise, the `ec2` fence agent could report machines in other clusters as all of them where using the same tag.