### PR TITLE
Install lsscsi and use nw grains properly

### DIFF
--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -46,8 +46,7 @@ pas_instance_number: ${var.pas_instance_number}
 aas_instance_number: ${var.aas_instance_number}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 shared_storage_type: shared-disk
-sbd_disk_device: "${var.shared_storage_type == "shared-disk" ? "/dev/vdb1" : ""}"
-sbd_disk_index: 2
+sbd_disk_device: /dev/vdb1
 monitoring_enabled: ${var.monitoring_enabled}
 devel_mode: ${var.devel_mode}
 EOF

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -1,5 +1,4 @@
 {%- import_yaml "/root/salt/netweaver_node/files/pillar/netweaver.sls" as netweaver %}
-{%- set iprange = ".".join(grains['host_ips'][0].split('.')[0:-1]) %}
 {%- if not grains.get('sbd_disk_device') %}
 {%- set sbd_disk_device = salt['cmd.run']('lsscsi | grep "LIO-ORG" | awk "{ if (NR=='~grains['sbd_disk_index']~') print \$NF }"', python_shell=true) %}
 {%- else %}

--- a/salt/cluster_node/iscsi_initiator.sls
+++ b/salt/cluster_node/iscsi_initiator.sls
@@ -4,6 +4,13 @@ open-iscsi:
       attempts: 3
       interval: 15
 
+# lsscsi is used to retrieve the sbd disk in the automatic pillar files
+lsscsi:
+  pkg.installed:
+  - retry:
+      attempts: 3
+      interval: 15
+
 /etc/iscsi/initiatorname.iscsi:
   file.replace:
     - pattern: "^InitiatorName=.*"


### PR DESCRIPTION
Fixes:
- `lsscsi` package is not always available, so we need to install it (I have put it in the iscsi initiator, as it's only used together with iscsi, and the call is just in this scenario)
- In libvirt, netweaver doesn't use iscsi by now, so `shared_storage_type` variable doesn't exist. In the future, if we include the iscsi usage in netweaver to use sbd and netweaver shared folder, we might implement this. By now, a shared disk created by libvirt is always used.