### PR TITLE
Add outputs for openQA tests

### DIFF
--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -75,3 +75,13 @@ output "iscsisrv_name" {
 output "iscsisrv_public_name" {
   value = module.iscsi_server.iscsisrv_public_name
 }
+
+# For openQA (QA mode)
+
+output openqa_vms {
+  value = concat(module.hana_node.cluster_nodes_name, module.netweaver_node.netweaver_name)
+}
+
+output openqa_ips {
+  value = concat(module.hana_node.cluster_nodes_public_ip, module.netweaver_node.netweaver_public_ip)
+}

--- a/azure/modules/drbd_node/outputs.tf
+++ b/azure/modules/drbd_node/outputs.tf
@@ -25,3 +25,7 @@ output "drbd_name" {
 output "drbd_public_name" {
   value = data.azurerm_public_ip.drbd.*.fqdn
 }
+
+output "drbd_id" {
+  value = azurerm_virtual_machine.drbd.*.id
+}

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -31,3 +31,7 @@ output "cluster_nodes_name" {
 output "cluster_nodes_public_name" {
   value = data.azurerm_public_ip.hana.*.fqdn
 }
+
+output "cluster_nodes_id" {
+  value = azurerm_virtual_machine.hana.*.id
+}

--- a/azure/modules/netweaver_node/outputs.tf
+++ b/azure/modules/netweaver_node/outputs.tf
@@ -25,3 +25,7 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = data.azurerm_public_ip.netweaver.*.fqdn
 }
+
+output "netweaver_id" {
+  value = azurerm_virtual_machine.netweaver.*.id
+}

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -58,6 +58,10 @@ output "cluster_nodes_public_name" {
   value = module.hana_node.cluster_nodes_public_name
 }
 
+output "cluster_nodes_id" {
+  value = module.hana_node.cluster_nodes_id
+}
+
 # drbd
 
 output "drbd_ip" {
@@ -76,6 +80,10 @@ output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
 }
 
+output "drbd_id" {
+  value = module.drbd_node.drbd_id
+}
+
 # netweaver
 
 output "netweaver_ip" {
@@ -92,4 +100,18 @@ output "netweaver_name" {
 
 output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
+}
+
+output "netweaver_id" {
+  value = module.netweaver_node.netweaver_id
+}
+
+# For openQA (QA mode)
+
+output openqa_vms {
+  value = concat(module.hana_node.cluster_nodes_id, module.drbd_node.drbd_id, module.netweaver_node.netweaver_id)
+}
+
+output openqa_ips {
+  value = concat(module.hana_node.cluster_nodes_public_ip, module.drbd_node.drbd_public_ip, module.netweaver_node.netweaver_public_ip)
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -93,3 +93,13 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
+
+# For openQA (QA mode)
+
+output openqa_vms {
+  value = concat(module.hana_node.cluster_nodes_name, module.drbd_node.drbd_name, module.netweaver_node.netweaver_name)
+}
+
+output openqa_ips {
+  value = concat(module.hana_node.cluster_nodes_public_ip, module.drbd_node.drbd_public_ip, module.netweaver_node.netweaver_public_ip)
+}


### PR DESCRIPTION
For QA test, we need the ID of the Azure's VMs to be able to stop/start them during our test using the CSP API.

This commit also add `openqa_vms` and `openqa_ips` for all provider to simplify openQA code and share output with QAC team.

Manually tested on master branch.