### PR TITLE
remove libvirt network hostname fields

### DIFF
--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -58,7 +58,6 @@ resource "libvirt_domain" "drbd_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 
@@ -92,7 +91,7 @@ resource "libvirt_domain" "drbd_domain" {
 output "output_data" {
   value = {
     id                = libvirt_domain.drbd_domain.*.id
-    hostname          = libvirt_domain.drbd_domain.*.name
+    name              = libvirt_domain.drbd_domain.*.name
     private_addresses = var.host_ips
     addresses         = libvirt_domain.drbd_domain.*.network_interface.0.addresses.0
   }

--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -59,7 +59,6 @@ resource "libvirt_domain" "hana_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 
@@ -93,7 +92,7 @@ resource "libvirt_domain" "hana_domain" {
 output "output_data" {
   value = {
     id                = libvirt_domain.hana_domain.*.id
-    hostname          = libvirt_domain.hana_domain.*.name
+    name              = libvirt_domain.hana_domain.*.name
     private_addresses = var.host_ips
     addresses         = libvirt_domain.hana_domain.*.network_interface.0.addresses.0
   }

--- a/libvirt/modules/iscsi_server/main.tf
+++ b/libvirt/modules/iscsi_server/main.tf
@@ -77,7 +77,7 @@ resource "libvirt_domain" "iscsisrv" {
 output "output_data" {
   value = {
     id                = libvirt_domain.iscsisrv.*.id
-    hostname          = libvirt_domain.iscsisrv.*.name
+    name              = libvirt_domain.iscsisrv.*.name
     private_addresses = [var.iscsi_srv_ip]
     addresses         = libvirt_domain.iscsisrv.*.network_interface.0.addresses.0
   }

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -32,7 +32,6 @@ resource "libvirt_domain" "monitoring_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${terraform.workspace}-${var.name}"
     addresses      = [var.monitoring_srv_ip]
   }
 
@@ -62,7 +61,7 @@ resource "libvirt_domain" "monitoring_domain" {
 output "output_data" {
   value = {
     id              = join("", libvirt_domain.monitoring_domain.*.id)
-    hostname        = join("", libvirt_domain.monitoring_domain.*.name)
+    name            = join("", libvirt_domain.monitoring_domain.*.name)
     private_address = var.monitoring_srv_ip
     address         = join("", libvirt_domain.monitoring_domain.*.network_interface.0.addresses.0)
   }

--- a/libvirt/modules/netweaver_node/main.tf
+++ b/libvirt/modules/netweaver_node/main.tf
@@ -38,7 +38,6 @@ resource "libvirt_domain" "netweaver_domain" {
     wait_for_lease = false
     network_name   = var.isolated_network_name
     network_id     = var.isolated_network_id
-    hostname       = "${var.name}0${count.index + 1}"
     addresses      = [element(var.host_ips, count.index)]
   }
 
@@ -72,7 +71,7 @@ resource "libvirt_domain" "netweaver_domain" {
 output "output_data" {
   value = {
     id                = libvirt_domain.netweaver_domain.*.id
-    hostname          = libvirt_domain.netweaver_domain.*.name
+    name              = libvirt_domain.netweaver_domain.*.name
     private_addresses = var.host_ips
     addresses         = libvirt_domain.netweaver_domain.*.network_interface.0.addresses.0
   }

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -9,7 +9,7 @@ output "cluster_nodes_public_ip" {
 }
 
 output "cluster_nodes_name" {
-  value = module.hana_node.output_data.hostname
+  value = module.hana_node.output_data.name
 }
 
 output "cluster_nodes_public_name" {
@@ -25,7 +25,7 @@ output "drbd_public_ip" {
 }
 
 output "drbd_name" {
-  value = module.drbd_node.output_data.hostname
+  value = module.drbd_node.output_data.name
 }
 
 output "drbd_public_name" {
@@ -41,7 +41,7 @@ output "iscsisrv_public_ip" {
 }
 
 output "iscsisrv_name" {
-  value = module.iscsi_server.output_data.hostname
+  value = module.iscsi_server.output_data.name
 }
 
 output "iscsisrv_public_name" {
@@ -57,7 +57,7 @@ output "monitoring_public_ip" {
 }
 
 output "monitoring_name" {
-  value = module.monitoring.output_data.hostname
+  value = module.monitoring.output_data.name
 }
 
 output "monitoring_public_name" {
@@ -73,7 +73,7 @@ output "netweaver_nodes_public_ip" {
 }
 
 output "netweaver_nodes_name" {
-  value = module.netweaver_node.output_data.hostname
+  value = module.netweaver_node.output_data.name
 }
 
 output "netweaver_nodes_public_name" {


### PR DESCRIPTION
We set the hostnames via salt states so there is no need to use the libvirt field, which in some cases it's even wrong and wouldn't match the actual hostname set by salt.

I manually tested this and it has no effect whatsoever.

supersedes #291 