### PR TITLE
Hotfix/fix pre v500 issues

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -242,3 +242,14 @@ resource "aws_security_group_rule" "prometheus_server" {
 
   security_group_id = local.security_group_id
 }
+
+resource "aws_security_group_rule" "grafana_server" {
+  count       = local.create_security_group_monitoring
+  type        = "ingress"
+  from_port   = 3000
+  to_port     = 3000
+  protocol    = "tcp"
+  cidr_blocks = ["0.0.0.0/0"]
+
+  security_group_id = local.security_group_id
+}

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -134,7 +134,7 @@ module "netweaver_node" {
   netweaver_swpm_extract_dir = var.netweaver_swpm_extract_dir
   netweaver_sapexe_folder    = var.netweaver_sapexe_folder
   netweaver_additional_dvds  = var.netweaver_additional_dvds
-  netweaver_nfs_share        = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : "${aws_efs_file_system.netweaver-efs.0.dns_name}:"
+  netweaver_nfs_share        = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : "${join("", aws_efs_file_system.netweaver-efs.*.dns_name)}:"
   hana_ip                    = local.hana_cluster_vip
   host_ips                   = local.netweaver_ips
   virtual_host_ips           = local.netweaver_virtual_ips

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -72,13 +72,13 @@ hana_extract_dir = "/sapmedia/HDBSERVER"
 hana_disk_device = "/dev/xvdd"
 
 # IP address used to configure the hana cluster floating IP. It must be in other subnet than the machines!
-hana_cluster_vip = "192.168.1.10"
+#hana_cluster_vip = "192.168.1.10"
 
 # Variable to control what is deployed in the nodes. Can be all, skip-hana or skip-cluster
 init_type = "all"
 
 # iSCSI server address. It should be in same iprange as hana_ips
-iscsi_srv_ip = "10.0.0.254"
+#iscsi_srv_ip = "10.0.0.254"
 
 # iSCSI OS image
 #iscsi_os_image = "ami-xxxxxxxxxxxxxxxxx"
@@ -137,7 +137,7 @@ ha_sap_deployment_repo = ""
 #monitoring_os_owner = "self"
 
 # IP address of the machine where Prometheus and Grafana are running. Must be in 10.0.0.0/24 subnet
-monitoring_srv_ip = "10.0.0.253"
+#monitoring_srv_ip = "10.0.0.253"
 
 # QA variables
 

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -226,6 +226,18 @@ resource "azurerm_network_security_group" "mysecgroup" {
     destination_address_prefix = "*"
   }
 
+  security_rule {
+    name                       = "grafana"
+    priority                   = 1009
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "3000"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
   tags = {
     workspace = terraform.workspace
   }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -158,13 +158,13 @@ variable "hana_public_publisher" {
 variable "hana_public_offer" {
   description = "Public image offer name used to create the hana machines"
   type        = string
-  default     = "SLES-SAP-BYOS"
+  default     = "sles-sap-15-sp1-byos"
 }
 
 variable "hana_public_sku" {
   description = "Public image sku used to create the hana machines"
   type        = string
-  default     = "15-sp1"
+  default     = "gen2"
 }
 
 variable "hana_public_version" {
@@ -298,13 +298,13 @@ variable "iscsi_public_publisher" {
 variable "iscsi_public_offer" {
   description = "Public image offer name used to create the iscsi machines"
   type        = string
-  default     = "SLES-SAP-BYOS"
+  default     = "sles-sap-15-sp1-byos"
 }
 
 variable "iscsi_public_sku" {
   description = "Public image sku used to create the iscsi machines"
   type        = string
-  default     = "15-sp1"
+  default     = "gen2"
 }
 
 variable "iscsi_public_version" {
@@ -364,13 +364,13 @@ variable "monitoring_public_publisher" {
 variable "monitoring_public_offer" {
   description = "Public image offer name used to create the monitoring machines"
   type        = string
-  default     = "SLES-SAP-BYOS"
+  default     = "sles-sap-15-sp1-byos"
 }
 
 variable "monitoring_public_sku" {
   description = "Public image sku used to create the monitoring machines"
   type        = string
-  default     = "15-sp1"
+  default     = "gen2"
 }
 
 variable "monitoring_public_version" {
@@ -420,13 +420,13 @@ variable "drbd_public_publisher" {
 variable "drbd_public_offer" {
   description = "Public image offer name used to create the drbd machines"
   type        = string
-  default     = "SLES-SAP-BYOS"
+  default     = "sles-sap-15-sp1-byos"
 }
 
 variable "drbd_public_sku" {
   description = "Public image sku used to create the drbd machines"
   type        = string
-  default     = "15-sp1"
+  default     = "gen2"
 }
 
 variable "drbd_public_version" {
@@ -464,13 +464,13 @@ variable "netweaver_public_publisher" {
 variable "netweaver_public_offer" {
   description = "Public image offer name used to create the netweaver machines"
   type        = string
-  default     = "SLES-SAP-BYOS"
+  default     = "sles-sap-15-sp1-byos"
 }
 
 variable "netweaver_public_sku" {
   description = "Public image sku used to create the netweaver machines"
   type        = string
-  default     = "15-sp1"
+  default     = "gen2"
 }
 
 variable "netweaver_public_version" {

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -81,6 +81,6 @@ resource "google_compute_firewall" "ha_firewall_allow_tcp" {
 
   allow {
     protocol = "tcp"
-    ports    = ["22", "80", "443", "7630", "9668", "9100", "9664", "9090"]
+    ports    = ["22", "80", "443", "3000", "7630", "9668", "9100", "9664", "9090"]
   }
 }

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -9,7 +9,7 @@ resource "google_compute_disk" "data" {
   zone  = element(var.compute_zones, count.index)
 }
 
-# temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
+# Don't remove the routes! Even though the RA gcp-vpc-move-route creates them, if they are not created here, the terraform destroy cannot work as it will find new route names
 resource "google_compute_route" "drbd-route" {
   name                   = "${terraform.workspace}-drbd-route"
   count                  = var.drbd_count > 0 ? 1 : 0

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -20,7 +20,7 @@ resource "null_resource" "drbd_provisioner" {
 provider: gcp
 role: drbd_node
 name_prefix: ${terraform.workspace}-drbd
-hostname: ${terraform.workspace}-drbd$0${count.index + 1}"
+hostname: ${terraform.workspace}-drbd0${count.index + 1}
 network_domain: ${var.network_domain}
 additional_packages: []
 reg_code: ${var.reg_code}

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -25,7 +25,7 @@ resource "google_compute_disk" "hana-software" {
   zone  = element(var.compute_zones, count.index)
 }
 
-# temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
+# Don't remove the routes! Even though the RA gcp-vpc-move-route creates them, if they are not created here, the terraform destroy cannot work as it will find new route names
 resource "google_compute_route" "hana-route" {
   name                   = "${terraform.workspace}-hana-route"
   count                  = var.hana_count > 0 ? 1 : 0

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -9,14 +9,24 @@ resource "google_compute_disk" "netweaver-software" {
   zone  = element(var.compute_zones, count.index)
 }
 
-# temporary HA solution to create the static routes, eventually this routes must be created by the RA gcp-vpc-move-route
-resource "google_compute_route" "nw-route" {
-  name                   = "${terraform.workspace}-nw-route"
+# Don't remove the routes! Even though the RA gcp-vpc-move-route creates them, if they are not created here, the terraform destroy cannot work as it will find new route names
+resource "google_compute_route" "nw-ascs-route" {
+  name                   = "${terraform.workspace}-nw-ascs-route"
   count                  = var.netweaver_count > 0 ? 1 : 0
   dest_range             = "${element(var.virtual_host_ips, 0)}/32"
   network                = var.network_name
   next_hop_instance      = google_compute_instance.netweaver.0.name
   next_hop_instance_zone = element(var.compute_zones, 0)
+  priority               = 1000
+}
+
+resource "google_compute_route" "nw-ers-route" {
+  name                   = "${terraform.workspace}-nw-ers-route"
+  count                  = var.netweaver_count > 0 ? 1 : 0
+  dest_range             = "${element(var.virtual_host_ips, 1)}/32"
+  network                = var.network_name
+  next_hop_instance      = google_compute_instance.netweaver.1.name
+  next_hop_instance_zone = element(var.compute_zones, 1)
   priority               = 1000
 }
 

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -60,7 +60,8 @@ netweaver_nfs_share: ${var.netweaver_nfs_share}
 netweaver_inst_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.netweaver.*.attached_disk.0.device_name, count.index))}
 hana_ip: ${var.hana_ip}
 vpc_network_name: ${var.network_name}
-route_table: ${google_compute_route.nw-route[0].name}
+ascs_route_name: ${google_compute_route.nw-ascs-route[0].name}
+ers_route_name: ${google_compute_route.nw-ers-route[0].name}
 
 EOF
     destination = "/tmp/grains"

--- a/generic_modules/on_destroy/main.tf
+++ b/generic_modules/on_destroy/main.tf
@@ -26,7 +26,7 @@ resource "null_resource" "on_destroy" {
 
   provisioner "remote-exec" {
     when       = destroy
-    inline     = ["sudo sh /tmp/on_destroy.sh"]
+    inline     = ["sudo timeout 300 sh /tmp/on_destroy.sh"]
     on_failure = continue
   }
 

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -66,6 +66,7 @@ cluster:
         cluster_profile: {{ grains['aws_cluster_profile'] }}
         instance_tag: {{ grains['aws_instance_tag'] }}
         {%- elif grains['provider'] == 'gcp' %}
-        route_table: {{ grains['route_table'] }}
+        ascs_route_name: {{ grains['ascs_route_name'] }}
+        ers_route_name: {{ grains['ers_route_name'] }}
         vpc_network_name: {{ grains['vpc_network_name'] }}
         {%- endif %}


### PR DESCRIPTION
Hotfixing branch to solve all the issues before creating release v5.0.0.

Fixes:
- EFS usage in AWS if Netweaver is not enabled
- DRBD creation in GCP
- Netweaver routing for GCP.
   - Depends on: https://github.com/SUSE/sapnwbootstrap-formula/pull/50
- Open port 3000 to make grafana available in the cloud providers
- Use netcat to find available NFS share. Showmount has several issues (it needs more ports, 111 and 20048, so Azure load balancer and AWS EFS doesn't serve them)
- Workaround error using SUSEConnect to deregister in AWS (doesn't fix the issue!): https://github.com/SUSE/ha-sap-terraform-deployments/issues/474