### PR TITLE
Update cluster pillar file for azure for better tuning

### DIFF
--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -16,6 +16,15 @@ cluster:
   {% if grains['sbd_enabled'] %}
   sbd:
     device: {{ grains['sbd_disk_device'] }}
+    {% if grains['provider'] == 'azure' %}
+    configure_resource:
+      params:
+        pcmk_delay_max: 15
+      op:
+        monitor:
+          timeout: 15
+          interval: 15
+    {% endif %}
   watchdog:
     module: softdog
     device: /dev/watchdog
@@ -40,7 +49,11 @@ cluster:
   monitoring_enabled: {{ grains['monitoring_enabled']|default(False) }}
   {% if grains['init_type']|default('all') != 'skip-hana' %}
   configure:
-    method: update
+    {% if grains['provider'] == 'azure' %}
+    properties:
+      stonith-timeout: 144s
+      stonith-enabled: true
+    {% endif %}
     template:
       source: /usr/share/salt-formulas/states/hana/templates/scale_up_resources.j2
       parameters:


### PR DESCRIPTION
Update cluster tuning for Azure to follow the configuration provided in:
https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-pacemaker#default-pacemaker-configuration-for-sbd

Now, sbd resource parameters,  cluster properties, rsc_defaults and op_defaults can be updated.

@diegoakechi Eventually we would want to drop the defaults configuration done in the formulas templates, as it is really inflexible. Having the option to make changes from the pillar file it's better in my opinon.

Depends on:
https://github.com/SUSE/salt-shaptools/pull/63
https://github.com/SUSE/habootstrap-formula/pull/49

bsc#1170702