### PR TITLE
Feature/fix payg images

### DIFF
--- a/salt/os_setup/registration.sls
+++ b/salt/os_setup/registration.sls
@@ -11,8 +11,6 @@ register_system:
     - retry:
         attempts: 3
         interval: 15
-{% endif %}
-
 
 {% if grains['osmajorrelease'] == 12 %}
 # hardcode the 12 version number for the 2 following modules, since they don't offer a sp version only 1.
@@ -60,6 +58,8 @@ default_sle_module_public_cloud_registration:
         attempts: 3
         interval: 15
 {% endfor %}
+{% endif %}
+
 {% endif %}
 {% endif %}
 {% endif %}

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -54,6 +54,13 @@ install_salt_minion () {
     fi
 }
 
+repeat_command () {
+  cmd=$1
+  timeout=${2:-120}
+  interval=${3:-15}
+  timeout $timeout bash -c "until $cmd;do sleep $interval;done"
+}
+
 bootstrap_salt () {
     mv /tmp/salt /root || true
 
@@ -69,6 +76,7 @@ bootstrap_salt () {
     # Check if the deployment is executed in a cloud provider
     [[ "$(get_grain provider /tmp/grains)" =~ aws|azure|gcp ]] && cloud=1
     if [[ ${qa_mode} != 1 && ${cloud} == 1 && "${reg_code}" == "" ]]; then
+        repeat_command "systemctl is-active guestregister.service | grep inactive" 300
         zypper lr || sudo /usr/sbin/registercloudguest --force-new
     fi
 


### PR DESCRIPTION
Bugfixing implementation for **master** branch focused on PAYG images.

Fixes:
- `arch` variable usage in registartion.sls. The `if` conditions were not correct. We only need to run `SUSEConnect` operations if we have the `reg_code`.

- Wait until `guestregister` daemon execution is done before running an `zypper` operation. Otherwise, we had the possibility to fail with the next error where our zypper usage is conflicting with this service:
```
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): System management is locked by the application with pid 2808 (zypper).
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): Close this application before trying again.
```

After merging this PR we will create a new bugfix release `5.0.1`.

FYI: @weikiat8
