### PR TITLE
Feature/azure bastion

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -34,7 +34,7 @@ locals {
   subnet_address_range = var.subnet_name == "" ? (var.subnet_address_range == "" ? cidrsubnet(local.vnet_address_range, 8, 1) : var.subnet_address_range) : (var.subnet_address_range == "" ? data.azurerm_subnet.mysubnet.0.address_prefix : var.subnet_address_range)
 
   bastion_private_key = var.bastion_private_key_location != "" ? var.bastion_private_key_location : var.private_key_location
-  bastion_public_key = var.bastion_public_key_location != "" ? var.bastion_public_key_location : var.public_key_location
+  bastion_public_key  = var.bastion_public_key_location != "" ? var.bastion_public_key_location : var.public_key_location
 }
 
 # Azure resource group and storage account resources

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -242,3 +242,17 @@ resource "azurerm_network_security_group" "mysecgroup" {
     workspace = terraform.workspace
   }
 }
+
+# Bastion
+
+module "bastion" {
+  bastion_enabled     = var.bastion_enabled
+  source              = "./modules/bastion"
+  az_region           = var.az_region
+  resource_group_name = local.resource_group_name
+  vnet_name           = local.vnet_name
+  admin_user          = var.admin_user
+  public_key_location = var.public_key_location
+  storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
+  snet_address_range  = cidrsubnet(local.vnet_address_range, 8, 2)
+}

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -249,6 +249,7 @@ module "bastion" {
   bastion_enabled     = var.bastion_enabled
   source              = "./modules/bastion"
   az_region           = var.az_region
+  vm_size             = "Standard_B1s"
   resource_group_name = local.resource_group_name
   vnet_name           = local.vnet_name
   admin_user          = var.admin_user

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -32,6 +32,9 @@ locals {
   # If vnet_name is defined, and the vnet_address_range is empty, it will try to get the ip range from the real vnet using the data source. If vnet_address_range is defined it will use it
   vnet_address_range   = var.vnet_name == "" ? var.vnet_address_range : (var.vnet_address_range == "" ? data.azurerm_virtual_network.mynet.0.address_space.0 : var.vnet_address_range)
   subnet_address_range = var.subnet_name == "" ? (var.subnet_address_range == "" ? cidrsubnet(local.vnet_address_range, 8, 1) : var.subnet_address_range) : (var.subnet_address_range == "" ? data.azurerm_subnet.mysubnet.0.address_prefix : var.subnet_address_range)
+
+  bastion_private_key = var.bastion_private_key_location != "" ? var.bastion_private_key_location : var.private_key_location
+  bastion_public_key = var.bastion_public_key_location != "" ? var.bastion_public_key_location : var.public_key_location
 }
 
 # Azure resource group and storage account resources
@@ -253,7 +256,7 @@ module "bastion" {
   resource_group_name = local.resource_group_name
   vnet_name           = local.vnet_name
   admin_user          = var.admin_user
-  public_key_location = var.public_key_location
+  public_key_location = local.bastion_public_key
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   snet_address_range  = cidrsubnet(local.vnet_address_range, 8, 2)
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -202,6 +202,9 @@ module "monitoring" {
   monitoring_srv_ip           = local.monitoring_ip
   public_key_location         = var.public_key_location
   private_key_location        = var.private_key_location
+  bastion_enabled             = var.bastion_enabled
+  bastion_host                = module.bastion.public_ip
+  bastion_private_key         = local.bastion_private_key
   admin_user                  = var.admin_user
   reg_code                    = var.reg_code
   reg_email                   = var.reg_email

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -56,6 +56,7 @@ module "drbd_node" {
   private_key_location   = var.private_key_location
   bastion_enabled        = var.bastion_enabled
   bastion_host           = module.bastion.public_ip
+  bastion_private_key    = local.bastion_private_key
   cluster_ssh_pub        = var.cluster_ssh_pub
   cluster_ssh_key        = var.cluster_ssh_key
   admin_user             = var.admin_user
@@ -99,6 +100,7 @@ module "netweaver_node" {
   private_key_location        = var.private_key_location
   bastion_enabled             = var.bastion_enabled
   bastion_host                = module.bastion.public_ip
+  bastion_private_key         = local.bastion_private_key
   cluster_ssh_pub             = var.cluster_ssh_pub
   cluster_ssh_key             = var.cluster_ssh_key
   admin_user                  = var.admin_user
@@ -161,6 +163,7 @@ module "hana_node" {
   private_key_location          = var.private_key_location
   bastion_enabled               = var.bastion_enabled
   bastion_host                  = module.bastion.public_ip
+  bastion_private_key           = local.bastion_private_key
   hana_data_disks_configuration = var.hana_data_disks_configuration
   hana_public_publisher         = var.hana_public_publisher
   hana_public_offer             = var.hana_public_offer
@@ -231,6 +234,7 @@ module "iscsi_server" {
   private_key_location   = var.private_key_location
   bastion_enabled        = var.bastion_enabled
   bastion_host           = module.bastion.public_ip
+  bastion_private_key    = local.bastion_private_key
   host_ips               = [local.iscsi_ip]
   lun_count              = var.iscsi_lun_count
   iscsi_disk_size        = var.iscsi_disk_size

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -54,6 +54,8 @@ module "drbd_node" {
   storage_account        = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   public_key_location    = var.public_key_location
   private_key_location   = var.private_key_location
+  bastion_enabled        = var.bastion_enabled
+  bastion_host           = module.bastion.public_ip
   cluster_ssh_pub        = var.cluster_ssh_pub
   cluster_ssh_key        = var.cluster_ssh_key
   admin_user             = var.admin_user
@@ -95,6 +97,8 @@ module "netweaver_node" {
   storage_account             = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   public_key_location         = var.public_key_location
   private_key_location        = var.private_key_location
+  bastion_enabled             = var.bastion_enabled
+  bastion_host                = module.bastion.public_ip
   cluster_ssh_pub             = var.cluster_ssh_pub
   cluster_ssh_key             = var.cluster_ssh_key
   admin_user                  = var.admin_user
@@ -155,6 +159,8 @@ module "hana_node" {
   cluster_ssh_key               = var.cluster_ssh_key
   public_key_location           = var.public_key_location
   private_key_location          = var.private_key_location
+  bastion_enabled               = var.bastion_enabled
+  bastion_host                  = module.bastion.public_ip
   hana_data_disks_configuration = var.hana_data_disks_configuration
   hana_public_publisher         = var.hana_public_publisher
   hana_public_offer             = var.hana_public_offer
@@ -223,6 +229,8 @@ module "iscsi_server" {
   iscsi_public_version   = var.iscsi_public_version
   public_key_location    = var.public_key_location
   private_key_location   = var.private_key_location
+  bastion_enabled        = var.bastion_enabled
+  bastion_host           = module.bastion.public_ip
   host_ips               = [local.iscsi_ip]
   lun_count              = var.iscsi_lun_count
   iscsi_disk_size        = var.iscsi_disk_size

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -87,7 +87,7 @@ resource "azurerm_virtual_machine" "bastion" {
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [azurerm_network_interface.bastion[0].id]
-  vm_size                          = "Standard_D2s_v3"
+  vm_size                          = var.vm_size
   delete_os_disk_on_termination    = true
   delete_data_disks_on_termination = true
 

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -1,0 +1,130 @@
+locals {
+  bastion_enabled = var.bastion_enabled ? 1 : 0
+}
+
+
+resource "azurerm_subnet" "bastion" {
+  count                = local.bastion_enabled
+  name                 = "snet-bastion"
+  resource_group_name  = var.resource_group_name
+  virtual_network_name = var.vnet_name
+  address_prefix       = var.snet_address_range
+}
+
+resource "azurerm_network_security_group" "bastion" {
+  count               = local.bastion_enabled
+  name                = "nsg-bastion"
+  location            = var.az_region
+  resource_group_name = var.resource_group_name
+
+  security_rule {
+    name                       = "SSH"
+    priority                   = 100
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "Tcp"
+    source_port_range          = "*"
+    destination_port_range     = "22"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+  security_rule {
+    name                       = "OUTALL"
+    priority                   = 101
+    direction                  = "Outbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "*"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+}
+
+resource "azurerm_subnet_network_security_group_association" "bastion" {
+  count                     = local.bastion_enabled
+  subnet_id                 = azurerm_subnet.bastion[0].id
+  network_security_group_id = azurerm_network_security_group.bastion[0].id
+}
+
+resource "azurerm_network_interface" "bastion" {
+  count                     = local.bastion_enabled
+  name                      = "nic-bastion"
+  location                  = var.az_region
+  resource_group_name       = var.resource_group_name
+  network_security_group_id = azurerm_network_security_group.bastion[0].id
+
+  ip_configuration {
+    name                          = "ipconf-primary"
+    subnet_id                     = azurerm_subnet.bastion[0].id
+    private_ip_address_allocation = "static"
+    private_ip_address            = cidrhost(var.snet_address_range, 5)
+    public_ip_address_id          = azurerm_public_ip.bastion[0].id
+  }
+
+  tags = {
+    workspace = terraform.workspace
+  }
+}
+
+resource "azurerm_public_ip" "bastion" {
+  count                   = local.bastion_enabled
+  name                    = "pip-bastion"
+  location                = var.az_region
+  resource_group_name     = var.resource_group_name
+  allocation_method       = "Dynamic"
+  idle_timeout_in_minutes = 30
+
+  tags = {
+    workspace = terraform.workspace
+  }
+}
+
+resource "azurerm_virtual_machine" "bastion" {
+  count                            = local.bastion_enabled
+  name                             = "vmbastion"
+  location                         = var.az_region
+  resource_group_name              = var.resource_group_name
+  network_interface_ids            = [azurerm_network_interface.bastion[0].id]
+  vm_size                          = "Standard_D2s_v3"
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_os_disk {
+    name              = "disk-bastion-Os"
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = "Standard_LRS"
+  }
+
+  storage_image_reference {
+    publisher = "SUSE"
+    offer     = "sles-sap-15-sp1-byos"
+    sku       = "gen2"
+    version   = "latest"
+  }
+
+  os_profile {
+    computer_name  = "vmbastion"
+    admin_username = var.admin_user
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+
+    ssh_keys {
+      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      key_data = file(var.public_key_location)
+    }
+  }
+
+  boot_diagnostics {
+    enabled     = "true"
+    storage_uri = var.storage_account
+  }
+
+  tags = {
+    workspace = terraform.workspace
+  }
+}

--- a/azure/modules/bastion/outputs.tf
+++ b/azure/modules/bastion/outputs.tf
@@ -1,0 +1,9 @@
+data "azurerm_public_ip" "bastion" {
+  count               = var.bastion_enabled ? 1 : 0
+  name                = azurerm_public_ip.bastion[0].name
+  resource_group_name = azurerm_virtual_machine.bastion[0].resource_group_name
+}
+
+output "public_ip" {
+  value = join("", data.azurerm_public_ip.bastion.*.ip_address)
+}

--- a/azure/modules/bastion/variables.tf
+++ b/azure/modules/bastion/variables.tf
@@ -1,0 +1,41 @@
+variable "bastion_enabled" {
+  description = "Enable bastion machine creation"
+  type        = bool
+  default     = true
+}
+
+variable "az_region" {
+  description = "Azure region where the deployment machines will be created"
+  type    = string
+  default = "westeurope"
+}
+
+variable "resource_group_name" {
+  description = "Resource group name where the bastion will be created"
+  type        = string
+}
+
+variable "vnet_name" {
+  description = "Virtual network where the bastion subnet will be created"
+  type        = string
+}
+
+variable "snet_address_range" {
+  description = "Subnet address range of the bastion subnet"
+}
+
+variable "admin_user" {
+  description = "Administration user used to create the machines"
+  type        = string
+  default     = "azadmin"
+}
+
+variable "public_key_location" {
+  description = "Path to a SSH public key used to connect to the created machines"
+  type        = string
+}
+
+variable "storage_account" {
+  description = "Storage account where the boot diagnostics will be stored"
+  type = string
+}

--- a/azure/modules/bastion/variables.tf
+++ b/azure/modules/bastion/variables.tf
@@ -10,6 +10,12 @@ variable "az_region" {
   default = "westeurope"
 }
 
+variable "vm_size" {
+  description = "Bastion machine vm size"
+  type        = string
+  default     = "Standard_B1s"
+}
+
 variable "resource_group_name" {
   description = "Resource group name where the bastion will be created"
   type        = string
@@ -31,7 +37,7 @@ variable "admin_user" {
 }
 
 variable "public_key_location" {
-  description = "Path to a SSH public key used to connect to the created machines"
+  description = "Path to a SSH public key used to connect to the bastion. This key will be authorized"
   type        = string
 }
 

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -2,6 +2,10 @@
 # official documentation: https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-nfs
 # disclaimer: only supports a single NW installation
 
+locals {
+  provisioning_addresses = var.bastion_enabled ? data.azurerm_network_interface.drbd.*.private_ip_address : data.azurerm_public_ip.drbd.*.ip_address
+}
+
 resource "azurerm_availability_set" "drbd-availability-set" {
   count                       = var.drbd_count > 0 ? 1 : 0
   name                        = "avset-drbd"
@@ -109,7 +113,7 @@ resource "azurerm_lb_rule" "drbd-lb-udp-2049" {
 # drbd network configuration
 
 resource "azurerm_public_ip" "drbd" {
-  count                   = var.drbd_count
+  count                   = var.bastion_enabled ? 0 : var.drbd_count
   name                    = "pip-drbd0${count.index + 1}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name
@@ -133,7 +137,7 @@ resource "azurerm_network_interface" "drbd" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = element(var.host_ips, count.index)
-    public_ip_address_id          = element(azurerm_public_ip.drbd.*.id, count.index)
+    public_ip_address_id          = var.bastion_enabled ? null : element(azurerm_public_ip.drbd.*.id, count.index)
   }
 
   tags = {
@@ -228,6 +232,7 @@ module "drbd_on_destroy" {
   instance_ids         = azurerm_virtual_machine.drbd.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.drbd.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.drbd]
 }

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -233,6 +233,7 @@ module "drbd_on_destroy" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.drbd]
 }

--- a/azure/modules/drbd_node/outputs.tf
+++ b/azure/modules/drbd_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "drbd" {
-  count               = var.drbd_count
+  count               = var.bastion_enabled ? 0 : var.drbd_count
   name                = element(azurerm_public_ip.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
 }

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -13,7 +13,7 @@ resource "null_resource" "drbd_provisioner" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
-    bastion_private_key = file(var.private_key_location)
+    bastion_private_key = file(var.bastion_private_key)
   }
 
   provisioner "file" {
@@ -58,6 +58,7 @@ module "drbd_provision" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "drbd_provisioner" {
   }
 
   connection {
-    host        = data.azurerm_public_ip.drbd[count.index].ip_address
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.admin_user
+    bastion_private_key = file(var.private_key_location)
   }
 
   provisioner "file" {
@@ -53,6 +57,7 @@ module "drbd_provision" {
   instance_ids         = null_resource.drbd_provisioner.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.drbd.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -84,6 +84,18 @@ variable "private_key_location" {
   type = string
 }
 
+variable "bastion_enabled" {
+  description = "Use a bastion machine to create the ssh connections"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_host" {
+  description = "Bastion host address. "
+  type        = string
+  default     = ""
+}
+
 variable "sbd_enabled" {
   description = "Enable sbd usage in the HA cluster"
   type        = bool

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -91,7 +91,13 @@ variable "bastion_enabled" {
 }
 
 variable "bastion_host" {
-  description = "Bastion host address. "
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
   type        = string
   default     = ""
 }

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -1,7 +1,8 @@
 # Availability set for the hana VMs
 
 locals {
-  create_ha_infra = var.hana_count > 1 && var.ha_enabled ? 1 : 0
+  create_ha_infra        = var.hana_count > 1 && var.ha_enabled ? 1 : 0
+  provisioning_addresses = var.bastion_enabled ? data.azurerm_network_interface.hana.*.private_ip_address : data.azurerm_public_ip.hana.*.ip_address
 }
 
 resource "azurerm_availability_set" "hana-availability-set" {
@@ -202,7 +203,7 @@ resource "azurerm_network_interface" "hana" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = element(var.host_ips, count.index)
-    public_ip_address_id          = element(azurerm_public_ip.hana.*.id, count.index)
+    public_ip_address_id          = var.bastion_enabled ? null : element(azurerm_public_ip.hana.*.id, count.index)
   }
 
   tags = {
@@ -211,7 +212,7 @@ resource "azurerm_network_interface" "hana" {
 }
 
 resource "azurerm_public_ip" "hana" {
-  count                   = var.hana_count
+  count                   = var.bastion_enabled ? 0 : var.hana_count
   name                    = "pip-${var.name}0${count.index + 1}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name
@@ -320,6 +321,7 @@ module "hana_on_destroy" {
   instance_ids         = azurerm_virtual_machine.hana.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.hana.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.hana]
 }

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -174,7 +174,7 @@ resource "azurerm_lb_rule" "lb_3xx17" {
 }
 
 resource "azurerm_lb_rule" "hanadb_exporter" {
-  count                          = var.monitoring_enabled ? 1 : 0
+  count                          = var.monitoring_enabled ? local.create_ha_infra : 0
   resource_group_name            = var.resource_group_name
   loadbalancer_id                = azurerm_lb.hana-load-balancer[0].id
   name                           = "hanadb_exporter"
@@ -322,6 +322,7 @@ module "hana_on_destroy" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.hana]
 }

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -1,19 +1,13 @@
 data "azurerm_public_ip" "hana" {
-  count = var.hana_count
-  name  = element(azurerm_public_ip.hana.*.name, count.index)
-  resource_group_name = element(
-    azurerm_virtual_machine.hana.*.resource_group_name,
-    count.index,
-  )
+  count               = var.bastion_enabled ? 0 : var.hana_count
+  name                = element(azurerm_public_ip.hana.*.name, count.index)
+  resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
 }
 
 data "azurerm_network_interface" "hana" {
-  count = var.hana_count
-  name  = element(azurerm_network_interface.hana.*.name, count.index)
-  resource_group_name = element(
-    azurerm_virtual_machine.hana.*.resource_group_name,
-    count.index,
-  )
+  count               = var.hana_count
+  name                = element(azurerm_network_interface.hana.*.name, count.index)
+  resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
 }
 
 output "cluster_nodes_ip" {

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -13,7 +13,7 @@ resource "null_resource" "hana_node_provisioner" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
-    bastion_private_key = file(var.private_key_location)
+    bastion_private_key = file(var.bastion_private_key)
   }
 
   provisioner "file" {
@@ -64,6 +64,7 @@ module "hana_provision" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -6,13 +6,14 @@ resource "null_resource" "hana_node_provisioner" {
   }
 
   connection {
-    host = element(
-      data.azurerm_public_ip.hana.*.ip_address,
-      count.index,
-    )
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.admin_user
+    bastion_private_key = file(var.private_key_location)
   }
 
   provisioner "file" {
@@ -62,6 +63,7 @@ module "hana_provision" {
   instance_ids         = null_resource.hana_node_provisioner.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.hana.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -105,7 +105,13 @@ variable "bastion_enabled" {
 }
 
 variable "bastion_host" {
-  description = "Bastion host address. "
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
   type        = string
   default     = ""
 }

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -98,6 +98,18 @@ variable "private_key_location" {
   type = string
 }
 
+variable "bastion_enabled" {
+  description = "Use a bastion machine to create the ssh connections"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_host" {
+  description = "Bastion host address. "
+  type        = string
+  default     = ""
+}
+
 variable "sbd_enabled" {
   description = "Enable sbd usage in the HA cluster"
   type        = bool

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -124,6 +124,7 @@ module "iscsi_on_destroy" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.iscsisrv]
 }

--- a/azure/modules/iscsi_server/outputs.tf
+++ b/azure/modules/iscsi_server/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "iscsisrv" {
-  count               = var.iscsi_count
+  count               = var.bastion_enabled ? 0 : var.iscsi_count
   name                = element(azurerm_public_ip.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
 }

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "iscsi_provisioner" {
   }
 
   connection {
-    host        = element(data.azurerm_public_ip.iscsisrv.*.ip_address, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.admin_user
+    bastion_private_key = file(var.private_key_location)
   }
 
   provisioner "file" {
@@ -44,6 +48,7 @@ module "iscsi_provision" {
   instance_ids         = null_resource.iscsi_provisioner.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.iscsisrv.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -13,7 +13,7 @@ resource "null_resource" "iscsi_provisioner" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
-    bastion_private_key = file(var.private_key_location)
+    bastion_private_key = file(var.bastion_private_key)
   }
 
   provisioner "file" {
@@ -49,6 +49,7 @@ module "iscsi_provision" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -69,7 +69,13 @@ variable "bastion_enabled" {
 }
 
 variable "bastion_host" {
-  description = "Bastion host address. "
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
   type        = string
   default     = ""
 }

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -62,6 +62,18 @@ variable "private_key_location" {
   type = string
 }
 
+variable "bastion_enabled" {
+  description = "Use a bastion machine to create the ssh connections"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_host" {
+  description = "Bastion host address. "
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_count" {
   description = "Number of iscsi machines to deploy"
   type        = number

--- a/azure/modules/monitoring/outputs.tf
+++ b/azure/modules/monitoring/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "monitoring" {
-  count               = var.monitoring_enabled == true ? 1 : 0
+  count               = var.bastion_enabled == false && var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_public_ip.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
 }

--- a/azure/modules/monitoring/salt_provisioner.tf
+++ b/azure/modules/monitoring/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host        = data.azurerm_public_ip.monitoring.0.ip_address
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.admin_user
+    bastion_private_key = file(var.bastion_private_key)
   }
 
   provisioner "file" {
@@ -25,7 +29,7 @@ reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_addi
 additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))},${trimspace(file(var.public_key_location))}]
 host_ip: ${var.monitoring_srv_ip}
-public_ip: ${data.azurerm_public_ip.monitoring[0].ip_address}
+public_ip: ${var.bastion_enabled ? data.azurerm_network_interface.monitoring.0.private_ip_address : data.azurerm_public_ip.monitoring.0.ip_address}
 ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 hana_targets: [${join(", ", formatlist("'%s'", var.hana_targets))}]
 drbd_targets: [${join(", ", formatlist("'%s'", var.drbd_targets))}]
@@ -42,6 +46,8 @@ module "monitoring_provision" {
   instance_ids         = null_resource.monitoring_provisioner.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.monitoring.*.ip_address
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
+  public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -73,6 +73,24 @@ variable "private_key_location" {
   type = string
 }
 
+variable "bastion_enabled" {
+  description = "Use a bastion machine to create the ssh connections"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
+  type        = string
+  default     = ""
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   default     = ""

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -456,6 +456,7 @@ module "netweaver_on_destroy" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.netweaver]
 }

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -2,9 +2,10 @@
 # official documentation: https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse
 
 locals {
-  vm_count              = var.xscs_server_count + var.app_server_count
-  create_ha_infra       = var.xscs_server_count > 0 && var.ha_enabled ? 1 : 0
-  additional_lun_number = "0"
+  vm_count               = var.xscs_server_count + var.app_server_count
+  create_ha_infra        = var.xscs_server_count > 0 && var.ha_enabled ? 1 : 0
+  additional_lun_number  = "0"
+  provisioning_addresses = var.bastion_enabled ? data.azurerm_network_interface.netweaver.*.private_ip_address : data.azurerm_public_ip.netweaver.*.ip_address
 }
 
 resource "azurerm_availability_set" "netweaver-xscs-availability-set" {
@@ -323,7 +324,7 @@ resource "azurerm_lb_rule" "netweaver-lb-ers-5xx16" {
 # netweaver network configuration
 
 resource "azurerm_public_ip" "netweaver" {
-  count                   = local.vm_count
+  count                   = var.bastion_enabled ? 0 : local.vm_count
   name                    = "pip-netweaver0${count.index + 1}"
   location                = var.az_region
   resource_group_name     = var.resource_group_name
@@ -348,7 +349,7 @@ resource "azurerm_network_interface" "netweaver" {
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = element(var.host_ips, count.index)
-    public_ip_address_id          = element(azurerm_public_ip.netweaver.*.id, count.index)
+    public_ip_address_id          = var.bastion_enabled ? null : element(azurerm_public_ip.netweaver.*.id, count.index)
   }
 
   tags = {
@@ -454,6 +455,7 @@ module "netweaver_on_destroy" {
   instance_ids         = azurerm_virtual_machine.netweaver.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.netweaver.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.netweaver]
 }

--- a/azure/modules/netweaver_node/outputs.tf
+++ b/azure/modules/netweaver_node/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "netweaver" {
-  count               = local.vm_count
+  count               = var.bastion_enabled ? 0 : local.vm_count
   name                = element(azurerm_public_ip.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
 }

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "netweaver_provisioner" {
   }
 
   connection {
-    host        = data.azurerm_public_ip.netweaver[count.index].ip_address
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = var.admin_user
     private_key = file(var.private_key_location)
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.admin_user
+    bastion_private_key = file(var.private_key_location)
   }
 
   provisioner "file" {
@@ -66,6 +70,7 @@ module "netweaver_provision" {
   instance_ids         = null_resource.netweaver_provisioner.*.id
   user                 = var.admin_user
   private_key_location = var.private_key_location
-  public_ips           = data.azurerm_public_ip.netweaver.*.ip_address
+  bastion_host         = var.bastion_host
+  public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -13,7 +13,7 @@ resource "null_resource" "netweaver_provisioner" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
-    bastion_private_key = file(var.private_key_location)
+    bastion_private_key = file(var.bastion_private_key)
   }
 
   provisioner "file" {
@@ -71,6 +71,7 @@ module "netweaver_provision" {
   user                 = var.admin_user
   private_key_location = var.private_key_location
   bastion_host         = var.bastion_host
+  bastion_private_key  = var.bastion_private_key
   public_ips           = local.provisioning_addresses
   background           = var.background
 }

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -44,7 +44,13 @@ variable "bastion_enabled" {
 }
 
 variable "bastion_host" {
-  description = "Bastion host address. "
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
   type        = string
   default     = ""
 }

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -37,6 +37,18 @@ variable "private_key_location" {
   type = string
 }
 
+variable "bastion_enabled" {
+  description = "Use a bastion machine to create the ssh connections"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_host" {
+  description = "Bastion host address. "
+  type        = string
+  default     = ""
+}
+
 variable "xscs_server_count" {
   type    = number
   default = 2

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -93,3 +93,9 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
+
+# bastion
+
+output "bastion_public_ip" {
+  value = module.bastion.public_ip
+}

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -61,6 +61,12 @@ variable "private_key_location" {
   type        = string
 }
 
+variable "bastion_enabled" {
+  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
+  type        = bool
+  default     = true
+}
+
 # Deployment variables
 
 variable "name" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -67,6 +67,18 @@ variable "bastion_enabled" {
   default     = true
 }
 
+variable "bastion_public_key_location" {
+  description = "Path to a SSH public key used to connect to the bastion. If it's not set the key provided in public_key_location will be used"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key_location" {
+  description = "Path to a SSH private key used to connect to the bastion. If it's not set the key provided in private_key_location will be used"
+  type        = string
+  default     = ""
+}
+
 # Deployment variables
 
 variable "name" {

--- a/generic_modules/on_destroy/main.tf
+++ b/generic_modules/on_destroy/main.tf
@@ -7,6 +7,7 @@ resource "null_resource" "on_destroy" {
     password     = var.password
     private_key  = var.private_key_location
     public_ips   = join(",", var.public_ips)
+    bastion_host = var.bastion_host
   }
 
   connection {
@@ -15,6 +16,11 @@ resource "null_resource" "on_destroy" {
     user        = self.triggers.user
     password    = self.triggers.password
     private_key = self.triggers.private_key != "" ? file(self.triggers.private_key) : ""
+
+    bastion_host        = self.triggers.bastion_host
+    bastion_user        = self.triggers.user
+    bastion_private_key = self.triggers.private_key != "" ? file(self.triggers.private_key) : ""
+
   }
 
   provisioner "file" {

--- a/generic_modules/on_destroy/main.tf
+++ b/generic_modules/on_destroy/main.tf
@@ -2,12 +2,13 @@ resource "null_resource" "on_destroy" {
   count = var.node_count
 
   triggers = {
-    instance_ids = join(",", var.instance_ids)
-    user         = var.user
-    password     = var.password
-    private_key  = var.private_key_location
-    public_ips   = join(",", var.public_ips)
-    bastion_host = var.bastion_host
+    instance_ids        = join(",", var.instance_ids)
+    user                = var.user
+    password            = var.password
+    private_key         = var.private_key_location
+    public_ips          = join(",", var.public_ips)
+    bastion_host        = var.bastion_host
+    bastion_private_key = var.bastion_private_key
   }
 
   connection {
@@ -19,7 +20,7 @@ resource "null_resource" "on_destroy" {
 
     bastion_host        = self.triggers.bastion_host
     bastion_user        = self.triggers.user
-    bastion_private_key = self.triggers.private_key != "" ? file(self.triggers.private_key) : ""
+    bastion_private_key = self.triggers.bastion_private_key != "" ? file(self.triggers.bastion_private_key) : ""
 
   }
 

--- a/generic_modules/on_destroy/variables.tf
+++ b/generic_modules/on_destroy/variables.tf
@@ -27,7 +27,13 @@ variable "private_key_location" {
 }
 
 variable "bastion_host" {
-  description = "Address of a bastion host to use in the SSH connections. It uses the same user/private key combo of the normal connection. Let empty to use the normal connection"
+  description = "Address of a bastion host to use in the SSH connections. Let empty to use the normal connection"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion"
   type        = string
   default     = ""
 }

--- a/generic_modules/on_destroy/variables.tf
+++ b/generic_modules/on_destroy/variables.tf
@@ -26,6 +26,12 @@ variable "private_key_location" {
   default     = ""
 }
 
+variable "bastion_host" {
+  description = "Address of a bastion host to use in the SSH connections. It uses the same user/private key combo of the normal connection. Let empty to use the normal connection"
+  type        = string
+  default     = ""
+}
+
 variable "public_ips" {
   description = "List of ips used to connect through SSH"
   type        = list(string)

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -13,7 +13,7 @@ resource "null_resource" "provision_background" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.user
-    bastion_private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
+    bastion_private_key = var.bastion_private_key != "" ? file(var.bastion_private_key) : ""
   }
 
   provisioner "file" {
@@ -44,7 +44,7 @@ resource "null_resource" "provision" {
 
     bastion_host        = var.bastion_host
     bastion_user        = var.user
-    bastion_private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
+    bastion_private_key = var.bastion_private_key != "" ? file(var.bastion_private_key) : ""
   }
 
   provisioner "file" {

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -10,6 +10,10 @@ resource "null_resource" "provision_background" {
     user        = var.user
     password    = var.password
     private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.user
+    bastion_private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
   }
 
   provisioner "file" {
@@ -37,6 +41,10 @@ resource "null_resource" "provision" {
     user        = var.user
     password    = var.password
     private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.user
+    bastion_private_key = var.private_key_location != "" ? file(var.private_key_location) : ""
   }
 
   provisioner "file" {

--- a/generic_modules/salt_provisioner/variables.tf
+++ b/generic_modules/salt_provisioner/variables.tf
@@ -27,7 +27,13 @@ variable "private_key_location" {
 }
 
 variable "bastion_host" {
-  description = "Address of a bastion host to use in the SSH connections. It uses the same user/private key combo of the normal connection. Let empty to use the normal connection"
+  description = "Address of a bastion host to use in the SSH connections. Let empty to use the normal connection"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Path to a SSH private key used to connect to the bastion. It must be provided if bastion is enabled"
   type        = string
   default     = ""
 }

--- a/generic_modules/salt_provisioner/variables.tf
+++ b/generic_modules/salt_provisioner/variables.tf
@@ -26,6 +26,12 @@ variable "private_key_location" {
   default     = ""
 }
 
+variable "bastion_host" {
+  description = "Address of a bastion host to use in the SSH connections. It uses the same user/private key combo of the normal connection. Let empty to use the normal connection"
+  type        = string
+  default     = ""
+}
+
 variable "public_ips" {
   description = "List of ips used to connect through SSH"
   type        = list(string)


### PR DESCRIPTION
Implementation of the bastion host. This machine is used as a jumpbox to avoid the creation of public addresses for the rest of machines.
To use it, set bastion_enabled = true (enabled by default). If set to false the bastion machine is not created and all of the machines will have a public address, as we do before this implementation.

The bastion is just a basic Standard_D2s_v3 machine using sle15sp1. This data is hardcoded. It only enables the coming SSH connections.

The machine is created in a new subnet with a custom security group, so now, we will have 2 subnets:
- One for the bastion
- One for the rest of the machines

@petersatsuse Have a look if you want?