### PR TITLE
Register the cloud extension in libvirt to get python3-pip

### DIFF
--- a/salt/os_setup/registration.sls
+++ b/salt/os_setup/registration.sls
@@ -23,7 +23,6 @@ default_sle_module_adv_systems_management_registration:
         attempts: 3
         interval: 15
 
-{%- if grains['provider'] in ['gcp', 'aws', 'azure'] %}
 default_sle_module_public_cloud_registration:
   cmd.run:
     - name: /usr/bin/SUSEConnect -p sle-module-public-cloud/12/{{ arch }} -r $reg_code
@@ -32,8 +31,6 @@ default_sle_module_public_cloud_registration:
     - retry:
         attempts: 3
         interval: 15
-
-{% endif %}
 
 {% elif grains['osmajorrelease'] == 15 and grains['provider'] in ['gcp', 'aws', 'azure'] %}
 default_sle_module_public_cloud_registration:


### PR DESCRIPTION
We need `python3-pip` to install the SAP `dbapi` python library. `python3-pip` is only available in the cloud extension in SLE12. Until now, we were adding the cloud extension only for the cloud providers, but now we need to add it in libvirt too.

**This only affects to SLE12 and libvirt**

Related: https://github.com/SUSE/saphanabootstrap-formula/pull/89