### PR TITLE
Correct the iscsi target package in SLE12SPx.

### DIFF
--- a/salt/cluster_node/ha/iscsi_initiator.sls
+++ b/salt/cluster_node/ha/iscsi_initiator.sls
@@ -13,7 +13,7 @@ lsscsi:
 /etc/iscsi/initiatorname.iscsi:
   file.replace:
     - pattern: "^InitiatorName=.*"
-    - repl: "InitiatorName=iqn.{{ grains['server_id'] }}.suse.qa"
+    - repl: "InitiatorName=iqn.{{ grains['hostname'] }}.{{ grains['server_id'] }}.suse"
 
 /etc/iscsi/iscsid.conf:
   file.replace:

--- a/salt/pillar/iscsi_srv.sls
+++ b/salt/pillar/iscsi_srv.sls
@@ -6,8 +6,13 @@ iscsi:
   target:
     pkgs:
       wanted:
+      {%- if grains['osmajorrelease'] == 12 %}
+        - targetcli-fb
+        - python-dbus-python
+      {%- else %}
         - targetcli-fb-common
         - python3-targetcli-fb
+      {%- endif %}
         - yast2-iscsi-lio-server
   config:
     data:


### PR DESCRIPTION
Package `targetcli-fb-common` and `python3-targetcli-fb` not exist in SLE12SP4.