### PR TITLE
Set correct ip to monitor for hana in non HA scenario

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -240,7 +240,7 @@ module "monitoring" {
   provisioner            = var.provisioner
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
-  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : []) # we use the vip to target the active hana instance
+  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets           = var.drbd_enabled ? local.drbd_ips : []
   netweaver_targets      = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   on_destroy_dependencies = [

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -214,7 +214,7 @@ module "monitoring" {
   provisioner                 = var.provisioner
   background                  = var.background
   monitoring_enabled          = var.monitoring_enabled
-  hana_targets                = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : []) # we use the vip to target the active hana instance
+  hana_targets                = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets                = var.drbd_enabled ? local.drbd_ips : []
   netweaver_targets           = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -174,7 +174,7 @@ module "monitoring" {
   additional_packages    = var.additional_packages
   monitoring_srv_ip      = local.monitoring_srv_ip
   monitoring_enabled     = var.monitoring_enabled
-  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : []) # we use the vip to target the active hana instance
+  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets           = var.drbd_enabled ? local.drbd_ips : []
   netweaver_targets      = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   provisioner            = var.provisioner

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -146,7 +146,7 @@ module "monitoring" {
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
   provisioner            = var.provisioner
   background             = var.background
-  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : []) # we use the vip to target the active hana instance
+  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets           = var.drbd_enabled ? local.drbd_ips : []
   netweaver_targets      = local.netweaver_virtual_ips
 }


### PR DESCRIPTION
The HANA monitored address was incorrect for non HA scenarios.
We need to adapt the used IP as the monitored address is the last one in the list.

https://github.com/SUSE/ha-sap-terraform-deployments/blob/develop/salt/monitoring/prometheus/prometheus.yml.j2#L31