### PR TITLE
Hotfix/use relative path

### DIFF
--- a/generic_modules/on_destroy/main.tf
+++ b/generic_modules/on_destroy/main.tf
@@ -9,6 +9,7 @@ resource "null_resource" "on_destroy" {
     public_ips          = join(",", var.public_ips)
     bastion_host        = var.bastion_host
     bastion_private_key = var.bastion_private_key
+    source              = "${path.module}/on_destroy.sh"
   }
 
   connection {
@@ -26,7 +27,7 @@ resource "null_resource" "on_destroy" {
 
   provisioner "file" {
     when        = destroy
-    source      = "${path.module}/on_destroy.sh"
+    source      = self.triggers.source
     destination = "/tmp/on_destroy.sh"
     on_failure  = continue
   }

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "provision_background" {
   }
 
   provisioner "file" {
-    source      = "../salt"
+    source      = "${path.module}/../../salt"
     destination = "/tmp"
   }
 
@@ -48,7 +48,7 @@ resource "null_resource" "provision" {
   }
 
   provisioner "file" {
-    source      = "../salt"
+    source      = "${path.module}/../../salt"
     destination = "/tmp"
   }
 


### PR DESCRIPTION
To use the modules externally, we need to set the salt folder path starting from the module itself, otherwise it will fail. Terraform uses the path where it's executed to elaborate all of the other things, so if terraform is executed in other folder (we are importing the module source), the path will be different.

Example:
```
module "bluehorizon" {
  source  = "git::https://github.com/SUSE/ha-sap-terraform-deployments.git///azure?ref=develop"
  ...
}
```

Besides that, I have correct a warning that was showing up in the `on_destroy` module in the latest terraform versions