### PR TITLE
Replace rclone by gcloud tools

### DIFF
--- a/gcp/modules/hana_node/salt_provisioner.tf
+++ b/gcp/modules/hana_node/salt_provisioner.tf
@@ -1,3 +1,7 @@
+locals {
+  gcp_credentials_dest = "/root/google_credentials.json"
+}
+
 resource "null_resource" "hana_node_provisioner" {
   count = var.provisioner == "salt" ? var.hana_count : 0
 
@@ -17,7 +21,7 @@ resource "null_resource" "hana_node_provisioner" {
 
   provisioner "file" {
     source      = var.gcp_credentials_file
-    destination = "/root/google_credentials.json"
+    destination = local.gcp_credentials_dest
   }
 
   provisioner "file" {
@@ -44,7 +48,7 @@ hana_backup_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_co
 hana_inst_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.2.device_name, count.index))}
 hana_fstype: ${var.hana_fstype}
 hana_cluster_vip: ${var.hana_cluster_vip}
-gcp_credentials_file: ${var.gcp_credentials_file}
+gcp_credentials_file: ${local.gcp_credentials_dest}
 vpc_network_name: ${var.network_name}
 route_table: ${google_compute_route.hana-route[0].name}
 sap_hana_deployment_bucket: ${var.sap_hana_deployment_bucket}

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -1,3 +1,7 @@
+locals {
+  gcp_credentials_dest = "/root/google_credentials.json"
+}
+
 resource "null_resource" "netweaver_provisioner" {
   count = var.provisioner == "salt" ? var.netweaver_count : 0
 
@@ -17,7 +21,7 @@ resource "null_resource" "netweaver_provisioner" {
 
   provisioner "file" {
     source      = var.gcp_credentials_file
-    destination = "/root/google_credentials.json"
+    destination = local.gcp_credentials_dest
   }
 
   provisioner "file" {
@@ -37,6 +41,7 @@ virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
+gcp_credentials_file: ${local.gcp_credentials_dest}
 ha_enabled: ${var.ha_enabled}
 sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}

--- a/salt/hana_node/download_hana_inst.sls
+++ b/salt/hana_node/download_hana_inst.sls
@@ -36,19 +36,14 @@ hana_inst_directory:
     - require:
       - cmd: hana_inst_partition
 
-install_rclone:
-  cmd.run:
-    - name: "curl https://rclone.org/install.sh | sudo bash"
 
-configure_rclone:
-  file.append:
-    - name: /root/.rclone.conf
-    - source: /root/salt/hana_node/files/rclone/gcp.conf
+{% from 'macros/download_from_google_storage.sls' import download_from_google_storage with context %}
 
-download_files_from_gcp:
-  cmd.run:
-    - name: "rclone copy remote:{{ grains['sap_hana_deployment_bucket'] }}
-      {{ grains['hana_inst_folder'] }}"
+{{ download_from_google_storage(
+  grains['gcp_credentials_file'],
+  grains['sap_hana_deployment_bucket'],
+  grains['hana_inst_folder']) }}
+
 {% endif %}
 
 {{ grains['hana_inst_folder'] }}:

--- a/salt/hana_node/files/rclone/gcp.conf
+++ b/salt/hana_node/files/rclone/gcp.conf
@@ -1,7 +1,0 @@
-[remote]
-type = google cloud storage
-object_acl = private
-bucket_acl = private
-location = eu
-storage_class = MULTI_REGIONAL
-service_account_file = /root/google_credentials.json

--- a/salt/macros/download_from_google_storage.sls
+++ b/salt/macros/download_from_google_storage.sls
@@ -1,0 +1,50 @@
+# Install and configure gcloud to download files from google storage accounts
+# https://cloud.google.com/sdk/install
+{% macro download_from_google_storage(credentials_file, bucket_path, dest_folder) -%}
+{% set gcloud_dir = '/root' %}
+{% set gcloud_bin_dir = gcloud_dir~'/google-cloud-sdk/bin' %}
+
+install_gcloud:
+  cmd.run:
+    - name: curl https://sdk.cloud.google.com | bash -s -- '--disable-prompts' '--install-dir={{ gcloud_dir }}'
+    - unless: ls {{ gcloud_dir }}/google-cloud-sdk
+
+# The next 2 states are not really needed, but it's good to have gcloud configured in any case
+add_gcloud_path:
+  file.append:
+    - name: /root/.bashrc
+    - text: |
+
+        # The next line updates PATH for the Google Cloud SDK.
+        if [ -f '{{ gcloud_dir }}/google-cloud-sdk/path.bash.inc' ]; then . '{{ gcloud_dir }}/google-cloud-sdk/path.bash.inc'; fi
+
+        # The next line enables shell command completion for gcloud.
+        if [ -f '{{ gcloud_dir }}/google-cloud-sdk/completion.bash.inc' ]; then . '{{ gcloud_dir }}/google-cloud-sdk/completion.bash.inc'; fi
+    - require:
+      - install_gcloud
+
+restart_shell:
+  cmd.run:
+    - name: exec $SHELL &
+    - require:
+      - install_gcloud
+
+configure_gcloud_credentials:
+  cmd.run:
+    - name: {{ gcloud_bin_dir }}/gcloud auth activate-service-account --key-file {{ credentials_file }}
+    - require:
+      - install_gcloud
+
+# We cannot just use path_join as converts '//' to '/'
+{% set bucket_path = bucket_path.replace('gs://', '') %}
+{% set gs_url = 'gs://'~(bucket_path | path_join('*')) %}
+
+download_files_from_gcp:
+  cmd.run:
+    - name: {{ gcloud_bin_dir }}/gsutil -m cp -r {{ gs_url }} {{ dest_folder }}
+    - output_loglevel: quiet
+    - hide_output: True
+    - require:
+      - install_gcloud
+
+{%- endmacro %}

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -45,18 +45,13 @@ mount_swpm:
       - cmd: nw_inst_partition
 
 {% if grains['provider'] == 'gcp' %}
-install_rclone:
-  cmd.run:
-    - name: "curl https://rclone.org/install.sh | sudo bash"
 
-configure_rclone:
-  file.append:
-    - name: /root/.rclone.conf
-    - source: /root/salt/hana_node/files/rclone/gcp.conf
+{% from 'macros/download_from_google_storage.sls' import download_from_google_storage with context %}
 
-download_files_from_gcp:
-  cmd.run:
-    - name: rclone copy remote:{{ grains['netweaver_software_bucket'] }} {{ sapcd }}
+{{ download_from_google_storage(
+  grains['gcp_credentials_file'],
+  grains['netweaver_software_bucket']],
+  sapcd) }}
 
 {% elif grains['provider'] == 'aws' %}
 


### PR DESCRIPTION
Implementation to replace `rclone` by the official GCP tools (gcloud and gsutil). We cannot use non official 3 party tools like `rclone`, so using the GCP provided tools make sense.
The usage for the user will be exactly the same (it must provide the bucket path and the credentials file). 

I have created the implementation in a macro in order to avoid duplicated code, but if it's too confusing I can just copy/paste the states in HANA and NW.

PD: Even though it's not strictly needed, I have added 2 states to configure the `gcloud` usage so the user can use it later. It's a quite standard tool, so it makes sense. I can remove them anyway (I'm talking about `add_gcloud_path` and `restart_shell` states)

Some info about the official docs:
https://cloud.google.com/sdk/docs/downloads-interactive
https://www.ecosia.org/search?q=gsutil+cp&addon=firefox&addonversion=4.0.4

Adding @petersatsuse