### PR TITLE
Fix salt syntax error

### DIFF
--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -50,7 +50,7 @@ mount_swpm:
 
 {{ download_from_google_storage(
   grains['gcp_credentials_file'],
-  grains['netweaver_software_bucket']],
+  grains['netweaver_software_bucket'],
   sapcd) }}
 
 {% elif grains['provider'] == 'aws' %}


### PR DESCRIPTION
fixes the following error:
```
local:
    Data failed to compile:
----------
    Rendering SLS 'predeployment:netweaver_node.installation_files' failed: Jinja syntax error: unexpected ']', expected ')'; line 53

---
[...]

{% from 'macros/download_from_google_storage.sls' import download_from_google_storage with context %}

{{ download_from_google_storage(
  grains['gcp_credentials_file'],
  grains['netweaver_software_bucket']],    <======================
  sapcd) }}

{% elif grains['provider'] == 'aws' %}

download_files_from_s3:
[...]
---
```