### PR TITLE
remove server:monitoring repository configuration

### DIFF
--- a/salt/cluster_node/monitoring.sls
+++ b/salt/cluster_node/monitoring.sls
@@ -1,18 +1,6 @@
-{% set repository = 'SLE_'~grains['osrelease_info'][0] %}
-{% set repository = repository~'_SP'~grains['osrelease_info'][1] if grains['osrelease_info']|length > 1 else repository %}
-
-server_monitoring_repo:
- pkgrepo.managed:
-    - humanname: Server:Monitoring
-    - baseurl: https://download.opensuse.org/repositories/server:/monitoring/{{ repository }}/
-    - refresh: True
-    - gpgautoimport: True
-
 prometheus_node_exporter:
   pkg.installed:
     - name: golang-github-prometheus-node_exporter
-    - require:
-      - pkgrepo: server_monitoring_repo
 
 node_exporter_service:
   service.running:
@@ -21,7 +9,6 @@ node_exporter_service:
     - restart: True
     - require:
       - pkg: prometheus_node_exporter
-      - pkgrepo: server_monitoring_repo
       - file: activate_node_exporter_systemd_collector
     - watch:
       - file: activate_node_exporter_systemd_collector


### PR DESCRIPTION
I have branched everything in [network:ha-clustering:sap-deployments:devel](https://build.opensuse.org/project/show/network:ha-clustering:sap-deployments:devel) so we don't need `server:monitoring` anymore.