### PR TITLE
Create common_variables module

### DIFF
--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -38,30 +38,39 @@ locals {
   iscsi_enabled = var.sbd_storage_type == "iscsi" && (var.hana_count > 1 && var.hana_cluster_sbd_enabled == true || (var.drbd_enabled && var.drbd_cluster_sbd_enabled == true) || (local.netweaver_count > 1 && var.netweaver_cluster_sbd_enabled == true)) ? true : false
 }
 
-module "iscsi_server" {
-  source                 = "./modules/iscsi_server"
-  iscsi_count            = local.iscsi_enabled == true ? 1 : 0
-  source_image           = var.iscsi_source_image
-  volume_name            = var.iscsi_source_image != "" ? "" : (var.iscsi_volume_name != "" ? var.iscsi_volume_name : local.generic_volume_name)
-  vcpu                   = var.iscsi_vcpu
-  memory                 = var.iscsi_memory
-  bridge                 = "br0"
-  storage_pool           = var.storage_pool
-  isolated_network_id    = local.internal_network_id
-  isolated_network_name  = local.internal_network_name
-  host_ips               = [local.iscsi_ip]
-  lun_count              = var.iscsi_lun_count
-  iscsi_disk_size        = var.sbd_disk_size
+module "common_variables" {
+  source                 = "../generic_modules/common_variables"
   reg_code               = var.reg_code
   reg_email              = var.reg_email
+  reg_additional_modules = var.reg_additional_modules
   ha_sap_deployment_repo = var.ha_sap_deployment_repo
-  qa_mode                = var.qa_mode
+  additional_packages    = var.additional_packages
   provisioner            = var.provisioner
   background             = var.background
+  monitoring_enabled     = var.monitoring_enabled
+  qa_mode                = var.qa_mode
+}
+
+module "iscsi_server" {
+  source                = "./modules/iscsi_server"
+  common_variables      = module.common_variables.configuration
+  iscsi_count           = local.iscsi_enabled == true ? 1 : 0
+  source_image          = var.iscsi_source_image
+  volume_name           = var.iscsi_source_image != "" ? "" : (var.iscsi_volume_name != "" ? var.iscsi_volume_name : local.generic_volume_name)
+  vcpu                  = var.iscsi_vcpu
+  memory                = var.iscsi_memory
+  bridge                = "br0"
+  storage_pool          = var.storage_pool
+  isolated_network_id   = local.internal_network_id
+  isolated_network_name = local.internal_network_name
+  host_ips              = [local.iscsi_ip]
+  lun_count             = var.iscsi_lun_count
+  iscsi_disk_size       = var.sbd_disk_size
 }
 
 module "hana_node" {
   source                     = "./modules/hana_node"
+  common_variables           = module.common_variables.configuration
   name                       = "hana"
   source_image               = var.hana_source_image
   volume_name                = var.hana_source_image != "" ? "" : (var.hana_volume_name != "" ? var.hana_volume_name : local.generic_volume_name)
@@ -88,72 +97,54 @@ module "hana_node" {
   sbd_storage_type           = var.sbd_storage_type
   sbd_disk_id                = module.hana_sbd_disk.id
   iscsi_srv_ip               = module.iscsi_server.output_data.private_addresses.0
-  reg_code                   = var.reg_code
-  reg_email                  = var.reg_email
-  reg_additional_modules     = var.reg_additional_modules
-  ha_sap_deployment_repo     = var.ha_sap_deployment_repo
-  qa_mode                    = var.qa_mode
   hwcct                      = var.hwcct
   scenario_type              = var.scenario_type
-  provisioner                = var.provisioner
-  background                 = var.background
-  monitoring_enabled         = var.monitoring_enabled
 }
 
 module "drbd_node" {
-  source                 = "./modules/drbd_node"
-  name                   = "drbd"
-  source_image           = var.drbd_source_image
-  volume_name            = var.drbd_source_image != "" ? "" : (var.drbd_volume_name != "" ? var.drbd_volume_name : local.generic_volume_name)
-  drbd_count             = var.drbd_enabled == true ? 2 : 0
-  vcpu                   = var.drbd_node_vcpu
-  memory                 = var.drbd_node_memory
-  bridge                 = "br0"
-  host_ips               = local.drbd_ips
-  drbd_cluster_vip       = local.drbd_cluster_vip
-  drbd_disk_size         = var.drbd_disk_size
-  sbd_enabled            = var.drbd_cluster_sbd_enabled
-  sbd_storage_type       = var.sbd_storage_type
-  sbd_disk_id            = module.drbd_sbd_disk.id
-  iscsi_srv_ip           = module.iscsi_server.output_data.private_addresses.0
-  reg_code               = var.reg_code
-  reg_email              = var.reg_email
-  reg_additional_modules = var.reg_additional_modules
-  ha_sap_deployment_repo = var.ha_sap_deployment_repo
-  provisioner            = var.provisioner
-  background             = var.background
-  monitoring_enabled     = var.monitoring_enabled
-  isolated_network_id    = local.internal_network_id
-  isolated_network_name  = local.internal_network_name
-  storage_pool           = var.storage_pool
+  source                = "./modules/drbd_node"
+  common_variables      = module.common_variables.configuration
+  name                  = "drbd"
+  source_image          = var.drbd_source_image
+  volume_name           = var.drbd_source_image != "" ? "" : (var.drbd_volume_name != "" ? var.drbd_volume_name : local.generic_volume_name)
+  drbd_count            = var.drbd_enabled == true ? 2 : 0
+  vcpu                  = var.drbd_node_vcpu
+  memory                = var.drbd_node_memory
+  bridge                = "br0"
+  host_ips              = local.drbd_ips
+  drbd_cluster_vip      = local.drbd_cluster_vip
+  drbd_disk_size        = var.drbd_disk_size
+  sbd_enabled           = var.drbd_cluster_sbd_enabled
+  sbd_storage_type      = var.sbd_storage_type
+  sbd_disk_id           = module.drbd_sbd_disk.id
+  iscsi_srv_ip          = module.iscsi_server.output_data.private_addresses.0
+  isolated_network_id   = local.internal_network_id
+  isolated_network_name = local.internal_network_name
+  storage_pool          = var.storage_pool
 }
 
 module "monitoring" {
-  source                 = "./modules/monitoring"
-  name                   = "monitoring"
-  monitoring_enabled     = var.monitoring_enabled
-  source_image           = var.monitoring_source_image
-  volume_name            = var.monitoring_source_image != "" ? "" : (var.monitoring_volume_name != "" ? var.monitoring_volume_name : local.generic_volume_name)
-  vcpu                   = var.monitoring_vcpu
-  memory                 = var.monitoring_memory
-  bridge                 = "br0"
-  storage_pool           = var.storage_pool
-  isolated_network_id    = local.internal_network_id
-  isolated_network_name  = local.internal_network_name
-  monitoring_srv_ip      = local.monitoring_srv_ip
-  reg_code               = var.reg_code
-  reg_email              = var.reg_email
-  reg_additional_modules = var.reg_additional_modules
-  ha_sap_deployment_repo = var.ha_sap_deployment_repo
-  provisioner            = var.provisioner
-  background             = var.background
-  hana_targets           = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
-  drbd_targets           = var.drbd_enabled ? local.drbd_ips : []
-  netweaver_targets      = local.netweaver_virtual_ips
+  source                = "./modules/monitoring"
+  common_variables      = module.common_variables.configuration
+  name                  = "monitoring"
+  monitoring_enabled    = var.monitoring_enabled
+  source_image          = var.monitoring_source_image
+  volume_name           = var.monitoring_source_image != "" ? "" : (var.monitoring_volume_name != "" ? var.monitoring_volume_name : local.generic_volume_name)
+  vcpu                  = var.monitoring_vcpu
+  memory                = var.monitoring_memory
+  bridge                = "br0"
+  storage_pool          = var.storage_pool
+  isolated_network_id   = local.internal_network_id
+  isolated_network_name = local.internal_network_name
+  monitoring_srv_ip     = local.monitoring_srv_ip
+  hana_targets          = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
+  drbd_targets          = var.drbd_enabled ? local.drbd_ips : []
+  netweaver_targets     = local.netweaver_virtual_ips
 }
 
 module "netweaver_node" {
   source                    = "./modules/netweaver_node"
+  common_variables          = module.common_variables.configuration
   netweaver_count           = local.netweaver_count
   name                      = "netweaver"
   source_image              = var.netweaver_source_image
@@ -182,11 +173,4 @@ module "netweaver_node" {
   netweaver_additional_dvds = var.netweaver_additional_dvds
   netweaver_nfs_share       = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : var.netweaver_nfs_share
   ha_enabled                = var.netweaver_ha_enabled
-  reg_code                  = var.reg_code
-  reg_email                 = var.reg_email
-  reg_additional_modules    = var.reg_additional_modules
-  ha_sap_deployment_repo    = var.ha_sap_deployment_repo
-  provisioner               = var.provisioner
-  background                = var.background
-  monitoring_enabled        = var.monitoring_enabled
 }

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -3,7 +3,7 @@
 # libvirt_domain.domain (drbd_node) resources are created (check triggers option).
 
 resource "null_resource" "drbd_node_provisioner" {
-  count = var.provisioner == "salt" ? var.drbd_count : 0
+  count = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
   triggers = {
     drbd_ids = libvirt_domain.drbd_domain[count.index].id
   }
@@ -16,28 +16,23 @@ resource "null_resource" "drbd_node_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
+provider: libvirt
+role: drbd_node
+${var.common_variables["grains_output"]}
 name_prefix: ${var.name}
 hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
-reg_code: ${var.reg_code}
-reg_email: ${var.reg_email}
-reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
-additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 drbd_cluster_vip: ${var.drbd_cluster_vip}
-provider: libvirt
-role: drbd_node
 drbd_disk_device: /dev/vdb
 sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/vdc" : ""}"
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
-ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
-monitoring_enabled: ${var.monitoring_enabled}
 partitions:
   1:
     start: 0%
@@ -49,10 +44,10 @@ EOF
 
 module "drbd_provision" {
   source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.provisioner == "salt" ? var.drbd_count : 0
+  node_count   = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
   instance_ids = null_resource.drbd_node_provisioner.*.id
   user         = "root"
   password     = "linux"
   public_ips   = libvirt_domain.drbd_domain.*.network_interface.0.addresses.0
-  background   = var.background
+  background   = var.common_variables["background"]
 }

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -1,3 +1,7 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string
@@ -7,35 +11,6 @@ variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
 }
-
-// repo and pkgs
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-// hana/drbd
-variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install HA/SAP deployment packages"
-  type        = string
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default     = []
-}
-
 
 variable "network_domain" {
   description = "hostname's network domain"
@@ -90,17 +65,6 @@ variable "iscsi_srv_ip" {
   default     = ""
 }
 
-variable "provisioner" {
-  description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
-  default     = "salt"
-}
-
-variable "background" {
-  description = "Run the provisioner execution in background if set to true finishing terraform execution"
-  type        = bool
-  default     = false
-}
-
 // Provider-specific variables
 
 variable "source_image" {
@@ -148,14 +112,6 @@ variable "network_name" {
 variable "bridge" {
   description = "a bridge device name available on the libvirt host, leave default for NAT"
   default     = ""
-}
-
-// monitoring
-
-variable "monitoring_enabled" {
-  description = "enable the host to be monitored by exporters, e.g node_exporter"
-  type        = bool
-  default     = false
 }
 
 variable "storage_pool" {

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -3,7 +3,7 @@
 # libvirt_domain.domain (hana_node) resources are created (check triggers option).
 
 resource "null_resource" "hana_node_provisioner" {
-  count = var.provisioner == "salt" ? var.hana_count : 0
+  count = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
   triggers = {
     hana_ids = libvirt_domain.hana_domain[count.index].id
   }
@@ -16,19 +16,16 @@ resource "null_resource" "hana_node_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
+provider: libvirt
+role: hana_node
+${var.common_variables["grains_output"]}
 name_prefix: ${var.name}
 hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
-reg_code: ${var.reg_code}
-reg_email: ${var.reg_email}
-reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
-additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-provider: libvirt
-role: hana_node
 scenario_type: ${var.scenario_type}
 hana_disk_device: /dev/vdb
 ha_enabled: ${var.ha_enabled}
@@ -37,7 +34,6 @@ sbd_storage_type: ${var.sbd_storage_type}
 sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/vdc" : ""}"
 sbd_lun_index: 0
 iscsi_srv_ip: ${var.iscsi_srv_ip}
-qa_mode: ${var.qa_mode}
 hwcct: ${var.hwcct}
 hana_cluster_vip: ${var.hana_cluster_vip}
 hana_cluster_vip_secondary: ${var.hana_cluster_vip_secondary}
@@ -48,8 +44,6 @@ hana_sapcar_exe: ${var.hana_sapcar_exe}
 hana_archive_file: ${var.hana_archive_file}
 hana_extract_dir: ${var.hana_extract_dir}
 hana_inst_media: ${var.hana_inst_media}
-ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
-monitoring_enabled: ${var.monitoring_enabled}
 EOF
     destination = "/tmp/grains"
   }
@@ -57,10 +51,10 @@ EOF
 
 module "hana_provision" {
   source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.provisioner == "salt" ? var.hana_count : 0
+  node_count   = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
   instance_ids = null_resource.hana_node_provisioner.*.id
   user         = "root"
   password     = "linux"
   public_ips   = libvirt_domain.hana_domain.*.network_interface.0.addresses.0
-  background   = var.background
+  background   = var.common_variables["background"]
 }

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -1,3 +1,7 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string
@@ -7,35 +11,6 @@ variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
 }
-
-// repo and pkgs
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-// hana
-variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install HA/SAP deployment packages"
-  type        = string
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default     = []
-}
-
 
 variable "network_domain" {
   description = "hostname's network domain"
@@ -147,17 +122,6 @@ variable "scenario_type" {
   default     = "performance-optimized"
 }
 
-variable "provisioner" {
-  description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
-  default     = "salt"
-}
-
-variable "background" {
-  description = "Run the provisioner execution in background if set to true finishing terraform execution"
-  type        = bool
-  default     = false
-}
-
 // Provider-specific variables
 
 variable "source_image" {
@@ -212,21 +176,7 @@ variable "bridge" {
   default     = ""
 }
 
-// monitoring
-
-variable "monitoring_enabled" {
-  description = "enable the host to be monitored by exporters, e.g node_exporter"
-  type        = bool
-  default     = false
-}
-
 // QA mode variables
-
-variable "qa_mode" {
-  description = "define qa mode (Disable extra packages outside images)"
-  type        = bool
-  default     = false
-}
 
 variable "hwcct" {
   description = "Execute HANA Hardware Configuration Check Tool to bench filesystems"

--- a/libvirt/modules/iscsi_server/variables.tf
+++ b/libvirt/modules/iscsi_server/variables.tf
@@ -1,3 +1,7 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
 variable "host_ips" {
   description = "List of ip addresses to set to the machines"
   type        = list(string)
@@ -14,51 +18,9 @@ variable "iscsi_disk_size" {
   default     = 10000000000
 }
 
-variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install HA/SAP deployment packages"
-  type        = string
-}
-
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map
-  default     = {}
-}
-
-variable "additional_packages" {
-  description = "extra packages to install"
-  default     = []
-}
-
 variable "iscsi_count" {
   description = "number of hosts like this one"
   default     = 1
-}
-
-variable "grains" {
-  description = "custom grain string to be added to this host's configuration"
-  default     = ""
-}
-
-variable "provisioner" {
-  description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
-  default     = "salt"
-}
-
-variable "background" {
-  description = "Run the provisioner execution in background if set to true finishing terraform execution"
-  type        = bool
-  default     = false
 }
 
 // Provider-specific variables
@@ -113,11 +75,4 @@ variable "bridge" {
 variable "storage_pool" {
   description = "libvirt storage pool name for VM disks"
   default     = "default"
-}
-
-# Specific QA variables
-variable "qa_mode" {
-  description = "define qa mode (Disable extra packages outside images)"
-  type        = bool
-  default     = false
 }

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -1,5 +1,5 @@
 resource "null_resource" "monitoring_provisioner" {
-  count = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
+  count = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
   triggers = {
     monitoring_id = libvirt_domain.monitoring_domain.0.id
   }
@@ -12,20 +12,16 @@ resource "null_resource" "monitoring_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
+provider: libvirt
+role: monitoring
+${var.common_variables["grains_output"]}
 name_prefix: ${terraform.workspace}-${var.name}
 hostname: ${terraform.workspace}-${var.name}
 timezone: ${var.timezone}
 network_domain: ${var.network_domain}
-reg_code: ${var.reg_code}
-reg_email: ${var.reg_email}
-reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
-additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
 host_ip: ${var.monitoring_srv_ip}
 public_ip: ${libvirt_domain.monitoring_domain[0].network_interface[0].addresses[0]}
-role: monitoring
-provider: libvirt
-ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 hana_targets: [${join(", ", formatlist("'%s'", var.hana_targets))}]
 drbd_targets: [${join(", ", formatlist("'%s'", var.drbd_targets))}]
 netweaver_targets: [${join(", ", formatlist("'%s'", var.netweaver_targets))}]
@@ -36,10 +32,10 @@ EOF
 
 module "monitoring_provision" {
   source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.provisioner == "salt" && var.monitoring_enabled ? 1 : 0
+  node_count   = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
   instance_ids = null_resource.monitoring_provisioner.*.id
   user         = "root"
   password     = "linux"
   public_ips   = libvirt_domain.monitoring_domain.*.network_interface.0.addresses.0
-  background   = var.background
+  background   = var.common_variables["background"]
 }

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -1,3 +1,7 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
 variable "monitoring_image" {
   description = "monitoring server base image"
   type        = string
@@ -12,22 +16,6 @@ variable "timezone" {
 variable "name" {
   description = "hostname, without the domain part"
   default     = "grafana"
-}
-
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
 }
 
 variable "network_domain" {
@@ -56,30 +44,9 @@ variable "vcpu" {
   default     = 1
 }
 
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default     = []
-}
-
-variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install HA/SAP deployment packages"
-  type        = string
-}
-
 variable "public_key_location" {
   description = "path of pub ssh key you want to use to access VMs"
   default     = "~/.ssh/id_rsa.pub"
-}
-
-variable "provisioner" {
-  description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
-  default     = "salt"
-}
-
-variable "background" {
-  description = "Run the provisioner execution in background if set to true finishing terraform execution"
-  type        = bool
-  default     = false
 }
 
 variable "monitoring_srv_ip" {

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -3,7 +3,7 @@
 # libvirt_domain.domain (netweaver_node) resources are created (check triggers option).
 
 resource "null_resource" "netweaver_node_provisioner" {
-  count = var.provisioner == "salt" ? var.netweaver_count : 0
+  count = var.common_variables["provisioner"] == "salt" ? var.netweaver_count : 0
   triggers = {
     netweaver_ids = libvirt_domain.netweaver_domain[count.index].id
   }
@@ -16,21 +16,18 @@ resource "null_resource" "netweaver_node_provisioner" {
 
   provisioner "file" {
     content     = <<EOF
+provider: libvirt
+role: netweaver_node
+${var.common_variables["grains_output"]}
 name_prefix: ${var.name}
 hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
-reg_code: ${var.reg_code}
-reg_email: ${var.reg_email}
-reg_additional_modules: {${join(", ", formatlist("'%s': '%s'", keys(var.reg_additional_modules), values(var.reg_additional_modules), ), )}}
-additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}]
 authorized_keys: [${trimspace(file(var.public_key_location))}]
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 hana_ip: ${var.hana_ip}
-provider: libvirt
-role: netweaver_node
 ha_enabled: ${var.ha_enabled}
 netweaver_product_id: ${var.netweaver_product_id}
 netweaver_inst_media: ${var.netweaver_inst_media}
@@ -46,13 +43,11 @@ ascs_instance_number: ${var.ascs_instance_number}
 ers_instance_number: ${var.ers_instance_number}
 pas_instance_number: ${var.pas_instance_number}
 aas_instance_number: ${var.aas_instance_number}
-ha_sap_deployment_repo: ${var.ha_sap_deployment_repo}
 sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/vdb1" : ""}"
 sbd_lun_index: 1
 iscsi_srv_ip: ${var.iscsi_srv_ip}
-monitoring_enabled: ${var.monitoring_enabled}
 EOF
     destination = "/tmp/grains"
   }
@@ -60,10 +55,10 @@ EOF
 
 module "netweaver_provision" {
   source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.provisioner == "salt" ? var.netweaver_count : 0
+  node_count   = var.common_variables["provisioner"] == "salt" ? var.netweaver_count : 0
   instance_ids = null_resource.netweaver_node_provisioner.*.id
   user         = "root"
   password     = "linux"
   public_ips   = libvirt_domain.netweaver_domain.*.network_interface.0.addresses.0
-  background   = var.background
+  background   = var.common_variables["background"]
 }

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -1,3 +1,7 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string
@@ -6,33 +10,6 @@ variable "name" {
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
-}
-
-// repo and pkgs
-variable "reg_code" {
-  description = "If informed, register the product using SUSEConnect"
-  default     = ""
-}
-
-variable "reg_email" {
-  description = "Email used for the registration"
-  default     = ""
-}
-
-variable "reg_additional_modules" {
-  description = "Map of the modules to be registered. Module name = Regcode, when needed."
-  type        = map(string)
-  default     = {}
-}
-
-variable "ha_sap_deployment_repo" {
-  description = "Repository url used to install HA/SAP deployment packages"
-  type        = string
-}
-
-variable "additional_packages" {
-  description = "extra packages which should be installed"
-  default     = []
 }
 
 variable "netweaver_count" {
@@ -169,25 +146,6 @@ variable "ha_enabled" {
   description = "Enable HA cluster in top of Netweaver ASCS and ERS instances"
   type        = bool
   default     = true
-}
-
-variable "provisioner" {
-  description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
-  default     = "salt"
-}
-
-variable "background" {
-  description = "Run the provisioner execution in background if set to true finishing terraform execution"
-  type        = bool
-  default     = false
-}
-
-// monitoring
-
-variable "monitoring_enabled" {
-  description = "enable the host to be monitored by exporters, e.g node_exporter"
-  type        = bool
-  default     = false
 }
 
 // Provider-specific variables

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -77,6 +77,12 @@ variable "ha_sap_deployment_repo" {
   default     = ""
 }
 
+variable "additional_packages" {
+  description = "extra packages which should be installed"
+  type        = list
+  default     = []
+}
+
 variable "provisioner" {
   description = "Used provisioner option. Available options: salt. Let empty to not use any provisioner"
   default     = "salt"


### PR DESCRIPTION
I have create a new terraform module `common_variables` to store the variables that are shared among all of the modules, like the registration code, email, ha repo, etc

The idea of the implementation is to reduce the amount of variables we need to pass from the main terraform file to the modules, wrapping them all in a unique module. It reduces a lot the amount of duplicated code.

After this, it will be easier to add/remove new variables that are common to all the modules (like removing the `qa_mode` and adding new variables like `colored_output` or `offline_provisioning`.

Let me know what do you think? If you like the approach, I will expand the implementation to the other cloud providers, and eventually replace the `qa_mode` variable by other more meaningful options