### PR TITLE
Set default value to sbd_device_disk in pillar

### DIFF
--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -12,7 +12,7 @@ cluster:
   join_timeout: 180
   {% if grains['sbd_enabled'] %}
   sbd:
-    device: {{ grains['sbd_disk_device'] }}
+    device: {{ grains['sbd_disk_device']|default('') }}
   watchdog:
     module: softdog
     device: /dev/watchdog

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -15,7 +15,7 @@ cluster:
   join_timeout: 180
   {% if grains['sbd_enabled'] %}
   sbd:
-    device: {{ grains['sbd_disk_device'] }}
+    device: {{ grains['sbd_disk_device']|default('') }}
     {% if grains['provider'] == 'azure' %}
     configure_resource:
       params:

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -12,7 +12,7 @@ cluster:
   {%- endif %}
   {% if grains['sbd_enabled'] %}
   sbd:
-    device: {{ grains['sbd_disk_device'] }}
+    device: {{ grains['sbd_disk_device']|default('') }}
   watchdog:
     module: softdog
     device: /dev/watchdog


### PR DESCRIPTION
PIllar examples in `automatic` folder fixed to get a default value for the `sbd_disk_device`. This was causing an error in the cloud providers after https://github.com/SUSE/ha-sap-terraform-deployments/pull/511

As before the pillar files `top.sls` files were splited in multiple files, this value was not needed in the 1st salt execution (which sets this value properly)

PD: Libvirt was not affected as `sbd_disk_device` always has a value