### PR TITLE
Increase cluster join timeout

### DIFF
--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -12,7 +12,7 @@ cluster:
   interface: eth0
   unicast: True
   {% endif %}
-  join_timeout: 180
+  join_timeout: 500
   {% if grains['sbd_enabled'] %}
   sbd:
     device: {{ grains['sbd_disk_device']|default('') }}


### PR DESCRIPTION
Our jenkins CI tests are failing many times due the joining cluster operations timeout. This happens because the 1st node needs more time than the 2nd, depending how the HANA installation is done (and mostly the HA enablement actions).

Increasing this timeout should fix the issues (most of the times it fails for 30 seconds or so, let's put more time just in case hehe)