### PR TITLE
Run iscsi-init service to create initiatorname.iscsi file

### DIFF
--- a/salt/cluster_node/ha/iscsi_initiator.sls
+++ b/salt/cluster_node/ha/iscsi_initiator.sls
@@ -10,6 +10,15 @@ lsscsi:
       attempts: 3
       interval: 15
 
+{% if grains['osrelease_info'][0] > 15 or (grains['osrelease_info'][0] == 15 and grains['osrelease_info']|length > 1 and grains['osrelease_info'][1] >= 2) %}
+# We cannot use service.running as this systemd unit will stop after being executed
+# It is used only to create the initiatorname.iscsi file
+start_iscsi_init:
+  module.run:
+    - service.start:
+      - name: iscsi-init
+{% endif %}
+
 /etc/iscsi/initiatorname.iscsi:
   file.replace:
     - pattern: "^InitiatorName=.*"


### PR DESCRIPTION
After open-iscsi has been upgraded to 2.1.2 version, the initiatorname.iscsi file is not shipped by default,and it's created with iscsi-init service.

More information in: https://build.opensuse.org/package/view_file/network/open-iscsi/open-iscsi.changes?expand=1

The new version has only been shipped to SLE15SP2, that's why the filter is set.

**PD: This change should be backported to master branch at some point if we don't plan a new release soon, as it has the same impact there**