### PR TITLE
Improve logging and debugging in context of logs format

### DIFF
--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -222,7 +222,7 @@ done
 
 if [[ -n $log_to_file ]]; then
     argument_number=$((argument_number - 1))
-    exec 1>> $log_to_file
+    2>&1 | tee $log_to_file
 fi
 
 if [ $argument_number -eq 0 ]; then


### PR DESCRIPTION
# description

This PR:

1)  add `log_ok` and `log_error` helper function and adapt them in script. 

2) Print during execution only salt `error` and a resume of state at the end. 

3) create a `phase` logger a first v1 of logger, with colors which says the status of phase  with timestamp, hostname and msg

4) add back the colored output


We do have also a `debug` file for the full verbose mode in case needed .


# Screenshot:


![image](https://user-images.githubusercontent.com/10886597/92375488-73e6fa80-f101-11ea-9032-c968eb8f7fdc.png)


![image](https://user-images.githubusercontent.com/10886597/92402984-dd323200-f130-11ea-99a2-ead1fd8217d3.png)




