### PR TITLE
Make output quite for command who check only

### DIFF
--- a/salt/cluster_node/ha/iscsi_initiator.sls
+++ b/salt/cluster_node/ha/iscsi_initiator.sls
@@ -62,6 +62,7 @@ iscsid:
 wait_disk_id_available:
   cmd.run:
     - name: until [ "$(lsscsi -i | grep "LIO-ORG" | awk "{{ sbd_disk_id_pattern }}{print \$NF }")" != "-" ];do sleep 3;done
+    - output_loglevel: quiet
     - timeout: 120
     - require:
       - lsscsi

--- a/salt/netweaver_node/nfs.sls
+++ b/salt/netweaver_node/nfs.sls
@@ -21,6 +21,7 @@ netcat-openbsd:
 wait_until_nfs_is_ready:
   cmd.run:
     - name: until nc -zvw5 {{ nfs_server_ip }} 2049;do sleep 30;done
+    - output_loglevel: quiet
     - timeout: 1200
     - require:
       - pkg: netcat-openbsd


### PR DESCRIPTION
this PR fix `false` failure we print as error. Is better to use quiet so we don't print errors which aren't