### PR TITLE
WIP: Failhard feature

### DIFF
--- a/salt/os_setup/minion_configuration.sls
+++ b/salt/os_setup/minion_configuration.sls
@@ -7,6 +7,7 @@ configure_file_roots:
   file.append:
     - name: /etc/salt/minion
     - text: |
+        failhard: True
         file_roots:
           base:
             - /srv/salt


### PR DESCRIPTION
# Description
this PR add `failhard` global option enabled by default to true.

What does this feature? IN a cloud native environment, failing fast is saving money.

So we exit the salt process at **first failure**. Note: we don't do this right now, and the behavious is we are continuing executing states, which is quite confusing when users have issue/debug.

I think we don't need to add yet another variable for disabling this.

Thoughts?

The only possible alternative, would be that we have a configurable variable which can set this to false, if user want default .

But I personally think, in sake for minimalism and variable overflow we shouldn't add it now. If we have user request  we can still `expose` that variable later

More info here: https://docs.saltstack.com/en/latest/ref/states/failhard.html