### PR TITLE
Hotfix/aws fixes

### DIFF
--- a/salt/hana_node/download_hana_inst.sls
+++ b/salt/hana_node/download_hana_inst.sls
@@ -50,7 +50,7 @@ hana_inst_directory:
   file.directory:
     - user: root
     - group: root
-    - dir_mode: "0754"
+    - dir_mode: "0755"
     - file_mode: "0755"
     - recurse:
       - user

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -56,11 +56,11 @@ mount_swpm:
 download_files_from_s3:
   cmd.run:
     - name: |
-        "aws s3 sync {{ grains['s3_bucket'] }} {{ grains['netweaver_inst_folder'] }} \
-        --region {{ grains['region'] }} --only-show-errors"
+        aws s3 sync {{ grains['s3_bucket'] }} {{ grains['netweaver_inst_folder'] }} \
+        --region {{ grains['region'] }} --only-show-errors
     - onlyif: |
-        "aws s3 sync --dryrun {{ grains['s3_bucket'] }} {{ grains['netweaver_inst_folder'] }} \
-        --region {{ grains['region'] }} | grep download > /dev/null 2>&1"
+        aws s3 sync --dryrun {{ grains['s3_bucket'] }} {{ grains['netweaver_inst_folder'] }} \
+        --region {{ grains['region'] }} | grep download > /dev/null 2>&1
     - output_loglevel: quiet
     - hide_output: True
 


### PR DESCRIPTION
2 fixes for AWS deployment:
- Remove quotes from aws command. They are causing an error (even though it was not happening before...). I don't really know the route cause, but having the quotes didn't make much sense neither, as it was changing the bash call
- Update folder permissions to the hana software folder. It might cause errors depending on the used HANA version