### PR TITLE
Add provisioning_log_level variable

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -49,6 +49,7 @@ module "common_variables" {
   additional_packages    = var.additional_packages
   private_key_location   = var.private_key_location
   provisioner            = var.provisioner
+  provisioning_log_level = var.provisioning_log_level
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
   monitoring_srv_ip      = var.monitoring_enabled ? local.monitoring_ip : ""

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -131,6 +131,12 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "provisioning_log_level" {
+  description = "Provisioning process log level. For salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html"
+  type        = string
+  default     = "error"
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   type        = bool

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -51,6 +51,7 @@ module "common_variables" {
   public_key_location    = var.public_key_location
   private_key_location   = var.private_key_location
   provisioner            = var.provisioner
+  provisioning_log_level = var.provisioning_log_level
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
   monitoring_srv_ip      = var.monitoring_enabled ? local.monitoring_ip : ""

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -148,6 +148,12 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "provisioning_log_level" {
+  description = "Provisioning process log level. For salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html"
+  type        = string
+  default     = "error"
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   type        = bool

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -1,21 +1,26 @@
 # Troubleshooting
 
-The goal of this guide is to provide some useful entrypoints for debug.
-
-
+The goal of this guide is to provide some useful entry points for debug.
 Feel free to open an issue with these logs, and/or analyze them accordingly.
 
+# Debugging
 
-# Salt usefull logs
+The variable `provisioning_log_level` variable can be used to change the logging verbosity/level (being `error` by default). Change to `info` or `debug` to get more hints about what's going on.
+Find here the log level options for salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html
+
+
+# Salt useful logs
+
+Besides the `terraform` execution output, more logs are stored within the created machines in the next logging files.
 
 - `/var/log/salt-os-setup.log`:  initial OS setup registering the machines to SCC, updating the system, etc.
-- `/var/log/salt-predeployment.log`:  before executing formula states, execute the saltstack file contained in the repo of ha-sap-terraform-deployments.
+- `/var/log/salt-predeployment.log`:  before executing formula states, execute the saltstack file contained in the repository of ha-sap-terraform-deployments.
 - `/var/log/salt-deployment.log`: this is the log file where the formulas salt execution is logged. (salt-formulas are not part of the github deployments project).
 
 
 # Netweaver debugging
 
-- `/tmp/swpm_unnattended/sapinst.log` is the best first entrypoint to look at when debugging netweaver failures.
+- `/tmp/swpm_unnattended/sapinst.log` is the best first entry point to look at when debugging netweaver failures.
 
 
 # Misc

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -49,6 +49,7 @@ module "common_variables" {
   public_key_location    = var.public_key_location
   private_key_location   = var.private_key_location
   provisioner            = var.provisioner
+  provisioning_log_level = var.provisioning_log_level
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
   monitoring_srv_ip      = var.monitoring_enabled ? local.monitoring_srv_ip : ""

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -112,6 +112,12 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "provisioning_log_level" {
+  description = "Provisioning process log level. For salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html"
+  type        = string
+  default     = "error"
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   type        = bool

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -9,6 +9,7 @@ output "configuration" {
     public_key_location    = var.public_key_location
     private_key_location   = var.private_key_location
     provisioner            = var.provisioner
+    provisioning_log_level = var.provisioning_log_level
     background             = var.background
     monitoring_enabled     = var.monitoring_enabled
     monitoring_srv_ip      = var.monitoring_srv_ip
@@ -23,6 +24,7 @@ additional_packages: [${join(", ", formatlist("'%s'", var.additional_packages))}
 monitoring_enabled: ${var.monitoring_enabled}
 monitoring_srv_ip: ${var.monitoring_srv_ip}
 qa_mode: ${var.qa_mode}
+provisioning_log_level: ${var.provisioning_log_level}
 EOF
   }
 }

--- a/generic_modules/common_variables/variables.tf
+++ b/generic_modules/common_variables/variables.tf
@@ -48,6 +48,12 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "provisioning_log_level" {
+  description = "Provisioning process log level. For salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html"
+  type        = string
+  default     = "error"
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   type        = bool

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -48,6 +48,7 @@ module "common_variables" {
   additional_packages    = var.additional_packages
   public_key_location    = var.public_key_location
   provisioner            = var.provisioner
+  provisioning_log_level = var.provisioning_log_level
   background             = var.background
   monitoring_enabled     = var.monitoring_enabled
   monitoring_srv_ip      = var.monitoring_enabled ? module.monitoring.output_data.private_address : ""

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -94,6 +94,12 @@ variable "provisioner" {
   default     = "salt"
 }
 
+variable "provisioning_log_level" {
+  description = "Provisioning process log level. For salt: https://docs.saltstack.com/en/latest/ref/configuration/logging/index.html"
+  type        = string
+  default     = "error"
+}
+
 variable "background" {
   description = "Run the provisioner execution in background if set to true finishing terraform execution"
   type        = bool

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -17,20 +17,20 @@ get_grain () {
 }
 
 log_ok () {
-  NODE=`hostname`
-  TIMESTAMP=`date -u`
-  GREEN='\033[0;32m'
-  NC='\033[0m' # No Color
-  printf "${GREEN}$TIMESTAMP::$NODE::[INFO] $1 ${NC}\n"
+    NODE=`hostname`
+    TIMESTAMP=`date -u`
+    GREEN='\033[0;32m'
+    NC='\033[0m' # No Color
+    printf "${GREEN}$TIMESTAMP::$NODE::[INFO] $1 ${NC}\n"
 }
 
 log_error () {
-  NODE=`hostname`
-  TIMESTAMP=`date -u`
-  RED='\033[0;31m'
-  NC='\033[0m' # No Color
-  printf "${RED}$TIMESTAMP::$NODE::[ERROR] $1 ${NC}\n"
-  exit 1
+    NODE=`hostname`
+    TIMESTAMP=`date -u`
+    RED='\033[0;31m'
+    NC='\033[0m' # No Color
+    printf "${RED}$TIMESTAMP::$NODE::[ERROR] $1 ${NC}\n"
+    exit 1
 }
 
 salt_output_colored () {
@@ -56,7 +56,7 @@ install_salt_minion () {
       elif [[ $VERSION_ID =~ ^15\.? ]]; then
         SUSEConnect -p sle-module-basesystem/$VERSION_ID/x86_64
       else
-	log_error "SLE Product version not supported by this script. Please, use version 12 or higher."
+        log_error "SLE Product version not supported by this script. Please, use version 12 or higher."
       fi
     fi
 
@@ -71,10 +71,10 @@ install_salt_minion () {
 }
 
 repeat_command () {
-  cmd=$1
-  timeout=${2:-120}
-  interval=${3:-15}
-  timeout $timeout bash -c "until $cmd;do sleep $interval;done"
+    cmd=$1
+    timeout=${2:-120}
+    interval=${3:-15}
+    timeout $timeout bash -c "until $cmd;do sleep $interval;done"
 }
 
 bootstrap_salt () {
@@ -118,12 +118,12 @@ os_setup () {
     # Execute the states within /srv/salt/os_setup
     # This first execution is done to configure the salt minion and install the iscsi formula
     salt-call --local \
-        --log-level=error \
+        --log-level=$(get_grain provisioning_log_level) \
         --log-file=/var/log/salt-os-setup.log \
         --log-file-level=debug \
         --retcode-passthrough \
         $(salt_output_colored) \
-	state.apply os_setup || log_error "os setup failed"
+        state.apply os_setup || log_error "os setup failed"
     log_ok "os setup done"
 }
 
@@ -131,7 +131,7 @@ predeploy () {
     # Execute the states defined in /srv/salt/top.sls
     # This execution is done to pre configure the cluster nodes, the support machines and install the formulas
     salt-call --local \
-        --log-level=error \
+        --log-level=$(get_grain provisioning_log_level) \
         --log-file=/var/log/salt-predeployment.log \
         --log-file-level=debug \
         --retcode-passthrough \
@@ -144,7 +144,7 @@ deploy () {
     # Execute SAP and HA installation with the salt formulas
     if [[ $(get_grain role) =~ .*_node ]]; then
         salt-call --local \
-            --log-level=error \
+            --log-level=$(get_grain provisioning_log_level) \
             --log-file=/var/log/salt-deployment.log \
             --log-file-level=debug \
             --retcode-passthrough \
@@ -162,15 +162,14 @@ run_tests () {
         export HOST=$(hostname)
         # Execute qa state file
         salt-call --local \
-            --log-level=info \
+            --log-level=$(get_grain provisioning_log_level) \
             --log-file=/var/log/salt-qa.log \
-            --log-file-level=info \
+            --log-file-level=debug \
             --retcode-passthrough \
             $(salt_output_colored) \
             state.apply qa_mode || log_error "tests failed"
-	log_ok "tests failed"
+        log_ok "tests failed"
     fi
-    
 }
 
 print_help () {


### PR DESCRIPTION
`provisioning_log_level` variable added to the deployment. Now, we can decide from a user perspective which log level we want to use in our deployments.

I have put `error` by default. The old output was `info`, and we log as `debug` in the log files.

PD: I have indented some lines in `provision.sh` too