### PR TITLE
Fix salt result output logging issues

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -511,6 +511,6 @@ Examples of the JSON files used in this document have been added to this repo.
 
 This configuration is leaving logs in `/var/log` folder in each of the instances. Connect as `ssh ec2-user@<remote_ip>`, then do a `sudo su -` and check the following files:
 
-* **/var/log/provisioning.log**: This is the global log file, inside it you will find the logs for user_data, salt-predeployment and salt-deployment
+* **/var/log/salt-result.log**: This is the global log file, inside it you will find the logs for user_data, salt-predeployment and salt-deployment
 * **/var/log/salt-predeployment.log**: Check here the debug log for the salt pre-deployment execution if you need to troubleshoot something.
 * **/var/log/salt-deployment.log**: Same as above but for the final SAP/HA/DRBD deployments salt execution logs.

--- a/doc/qa.md
+++ b/doc/qa.md
@@ -13,5 +13,5 @@ Below is the expected behavior:
 
 <br>
 
-**`hwcct`**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /var/log/provisioning.log. 
+**`hwcct`**: If set to true, it executes HANA Hardware Configuration Check Tool to bench filesystems. It's a very long test (about 2 hours), results will be both in /root/hwcct_out and in the global log file /var/log/salt-result.log. 
 By default, `hwcct` is set to false. Variable **`qa_mode` must be set to true**.

--- a/doc/troubleshooting.md
+++ b/doc/troubleshooting.md
@@ -13,6 +13,7 @@ Find here the log level options for salt: https://docs.saltstack.com/en/latest/r
 
 Besides the `terraform` execution output, more logs are stored within the created machines in the next logging files.
 
+- `/var/log/salt-result.log`: Summarized result of the salt execution processes.
 - `/var/log/salt-os-setup.log`:  initial OS setup registering the machines to SCC, updating the system, etc.
 - `/var/log/salt-predeployment.log`:  before executing formula states, execute the saltstack file contained in the repository of ha-sap-terraform-deployments.
 - `/var/log/salt-deployment.log`: this is the log file where the formulas salt execution is logged. (salt-formulas are not part of the github deployments project).

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -28,7 +28,7 @@ resource "null_resource" "provision_background" {
 
   provisioner "remote-exec" {
     inline = [
-      "nohup sudo sh /tmp/salt/provision.sh -l /var/log/provisioning.log > /dev/null 2>&1 &",
+      "nohup sudo bash /tmp/salt/provision.sh -l /var/log/salt-result.log > /dev/null 2>&1 &",
       "return_code=$? && sleep 1 && exit $return_code",
     ] # Workaround to let the process start in background properly
   }
@@ -64,7 +64,7 @@ resource "null_resource" "provision" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo sh /tmp/salt/provision.sh -sol /var/log/provisioning.log",
+      "sudo bash /tmp/salt/provision.sh -sol /var/log/salt-result.log",
     ]
   }
 
@@ -77,7 +77,7 @@ resource "null_resource" "provision" {
 
   provisioner "remote-exec" {
     inline = [
-      "sudo sh /srv/salt/provision.sh -pdql /var/log/provisioning.log",
+      "sudo bash /srv/salt/provision.sh -pdql /var/log/salt-result.log",
     ]
   }
 }

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/bin/bash -xeo pipefail
 # Script to provision the machines using salt. It provides different stages to install and
 # configure salt and run different salt executions. Find more information in print_help method
 # or running `sh provision.sh -h`
@@ -225,7 +225,8 @@ done
 
 if [[ -n $log_to_file ]]; then
     argument_number=$((argument_number - 1))
-    2>&1 | tee $log_to_file
+    # Find the logic of the next command in: https://unix.stackexchange.com/questions/145651/using-exec-and-tee-to-redirect-logs-to-stdout-and-a-log-file-in-the-same-time
+    exec > >(tee -a $log_to_file)
 fi
 
 if [ $argument_number -eq 0 ]; then


### PR DESCRIPTION
Log properly the salt execution result summary to a file (besides the standard output)

Besides that, I have changed the `provisioning.log` file name to `salt-result.log`.

**PD: Now the `provision.sh` is executed with `bash` what makes sense as actually it was defined in the shebang. I don't really know why we put `sh` honestly...**