### PR TITLE
Feature/redo os image usage

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -37,6 +37,18 @@ locals {
 
   # Check if iscsi server has to be created
   iscsi_enabled = var.sbd_storage_type == "iscsi" && (var.hana_count > 1 && var.hana_cluster_sbd_enabled == true || var.drbd_enabled && var.drbd_cluster_sbd_enabled == true || local.netweaver_count > 2 && var.netweaver_cluster_sbd_enabled == true) ? true : false
+
+  # Obtain machines os_image and os_owner values
+  hana_os_image       = var.hana_os_image != "" ? var.hana_os_image : var.os_image
+  hana_os_owner       = var.hana_os_owner != "" ? var.hana_os_owner : var.os_owner
+  iscsi_os_image      = var.iscsi_os_image != "" ? var.iscsi_os_image : var.os_image
+  iscsi_os_owner      = var.iscsi_os_owner != "" ? var.iscsi_os_owner : var.os_owner
+  monitoring_os_image = var.monitoring_os_image != "" ? var.monitoring_os_image : var.os_image
+  monitoring_os_owner = var.monitoring_os_owner != "" ? var.monitoring_os_owner : var.os_owner
+  drbd_os_image       = var.drbd_os_image != "" ? var.drbd_os_image : var.os_image
+  drbd_os_owner       = var.drbd_os_owner != "" ? var.drbd_os_owner : var.os_owner
+  netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
+  netweaver_os_owner  = var.netweaver_os_owner != "" ? var.netweaver_os_owner : var.os_owner
 }
 
 module "common_variables" {
@@ -63,8 +75,8 @@ module "drbd_node" {
   instance_type         = var.drbd_instancetype
   aws_region            = var.aws_region
   availability_zones    = data.aws_availability_zones.available.names
-  os_image              = var.drbd_os_image
-  os_owner              = var.drbd_os_owner
+  os_image              = local.drbd_os_image
+  os_owner              = local.drbd_os_owner
   vpc_id                = local.vpc_id
   subnet_address_range  = local.drbd_subnet_address_range
   key_name              = aws_key_pair.key-pair.key_name
@@ -95,8 +107,8 @@ module "iscsi_server" {
   aws_region         = var.aws_region
   availability_zones = data.aws_availability_zones.available.names
   subnet_ids         = aws_subnet.infra-subnet.*.id
-  os_image           = var.iscsi_os_image
-  os_owner           = var.iscsi_os_owner
+  os_image           = local.iscsi_os_image
+  os_owner           = local.iscsi_os_owner
   instance_type      = var.iscsi_instancetype
   key_name           = aws_key_pair.key-pair.key_name
   security_group_id  = local.security_group_id
@@ -119,8 +131,8 @@ module "netweaver_node" {
   name                      = "netweaver"
   aws_region                = var.aws_region
   availability_zones        = data.aws_availability_zones.available.names
-  os_image                  = var.netweaver_os_image
-  os_owner                  = var.netweaver_os_owner
+  os_image                  = local.netweaver_os_image
+  os_owner                  = local.netweaver_os_owner
   vpc_id                    = local.vpc_id
   subnet_address_range      = local.netweaver_subnet_address_range
   key_name                  = aws_key_pair.key-pair.key_name
@@ -166,8 +178,8 @@ module "hana_node" {
   scenario_type              = var.scenario_type
   aws_region                 = var.aws_region
   availability_zones         = data.aws_availability_zones.available.names
-  os_image                   = var.hana_os_image
-  os_owner                   = var.hana_os_owner
+  os_image                   = local.hana_os_image
+  os_owner                   = local.hana_os_owner
   vpc_id                     = local.vpc_id
   subnet_address_range       = local.hana_subnet_address_range
   key_name                   = aws_key_pair.key-pair.key_name
@@ -211,8 +223,8 @@ module "monitoring" {
   monitoring_srv_ip  = local.monitoring_ip
   aws_region         = var.aws_region
   availability_zones = data.aws_availability_zones.available.names
-  os_image           = var.monitoring_os_image
-  os_owner           = var.monitoring_os_owner
+  os_image           = local.monitoring_os_image
+  os_owner           = local.monitoring_os_owner
   subnet_ids         = aws_subnet.infra-subnet.*.id
   timezone           = var.timezone
   hana_targets       = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance

--- a/aws/modules/drbd_node/variables.tf
+++ b/aws/modules/drbd_node/variables.tf
@@ -17,7 +17,7 @@ variable "drbd_count" {
 variable "instance_type" {
   description = "The instance type of drbd node"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.large"
 }
 
 variable "aws_region" {

--- a/aws/modules/iscsi_server/variables.tf
+++ b/aws/modules/iscsi_server/variables.tf
@@ -25,7 +25,7 @@ variable "iscsi_count" {
 variable "instance_type" {
   type        = string
   description = "The instance type of iscsi server node."
-  default     = "t2.micro"
+  default     = "t2.large"
 }
 
 variable "key_name" {

--- a/aws/modules/monitoring/variables.tf
+++ b/aws/modules/monitoring/variables.tf
@@ -11,7 +11,7 @@ variable "monitoring_enabled" {
 variable "instance_type" {
   description = "The instance type of monitoring node."
   type        = string
-  default     = "t2.micro"
+  default     = "t3.micro"
 }
 
 variable "key_name" {

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -28,7 +28,7 @@ aws_secret_access_key = my-secret-access-key
 # aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
 aws_credentials = "~/.aws/credentials"
 
-# If BYOS images are used in the deployment, SCC registration code is required
+# If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
 # By default, all the images are PAYG, so these next parameters are not needed
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
@@ -40,7 +40,7 @@ aws_credentials = "~/.aws/credentials"
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
-# Default os_image and os_owner. These values are not used if the specific values are not set (e.g.: hana_os_image)
+# Default os_image and os_owner. These values are not used if the specific values are set (e.g.: hana_os_image)
 # BYOS example with sles4sap 15 sp1 (this value is a pattern, it will select the latest version that matches this name)
 #os_image = "suse-sles-sap-15-sp1-byos"
 #os_owner = "amazon"
@@ -76,7 +76,7 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
-# Enable all some pre deployment steps (disabled by default)
+# Enable pre deployment steps (disabled by default)
 pre_deployment = true
 
 # To disable the provisioning process
@@ -87,7 +87,7 @@ pre_deployment = true
 
 # QA variables
 
-# Define if the deployment is using for testing purpose
+# Define if the deployment is used for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
@@ -181,15 +181,11 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # SBD related variables
 #######################
 
-# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# In order to enable SBD, an ISCSI server is needed as right now is the only option
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 
-# iSCSI OS image
-#iscsi_os_image = "ami-xxxxxxxxxxxxxxxxx"
-#iscsi_os_owner = "self"
-
-# iSCSI server image. By default, PAYG image is used. The usage is the same than the HANA images
+# iSCSI server image. By default, PAYG image is used. The usage is the same as the HANA images
 #iscsi_os_image = "suse-sles-sap-15-sp1-byos"
 #iscsi_os_owner = "amazon"
 
@@ -207,7 +203,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
-# Monitoring server image. By default, PAYG image is used. The usage is the same than the HANA images
+# Monitoring server image. By default, PAYG image is used. The usage is the same as the HANA images
 #monitoring_os_image = "suse-sles-sap-15-sp1-byos"
 #monitoring_os_owner = "amazon"
 
@@ -224,7 +220,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 
 #drbd_instancetype = "t2.micro"
 
-# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
+# DRBD machines image. By default, PAYG image is used. The usage is the same as the HANA images
 #drbd_os_image = "suse-sles-sap-15-sp1-byos"
 #drbd_os_owner = "amazon"
 

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -17,28 +17,9 @@ aws_region = "eu-central-1"
 # Or to use already existing vpc address ranges
 #vpc_address_range = ""
 
-# Instance type to use for the hana cluster nodes
-hana_instancetype = "r3.8xlarge"
-
-# Disk type for HANA
-hana_data_disk_type = "gp2"
-
-# Number of nodes in the cluster
-hana_count = "2"
-
-# SSH Public key location to configure access to the remote instances
-public_key_location = "/path/to/your/public/ssh/key"
-
-# Private SSH Key location
-private_key_location = "/path/to/your/private/ssh/key"
-
-# Custom AMI for nodes
-#hana_os_image = "ami-xxxxxxxxxxxxxxxxx"
-# Or use a pattern to find the image
-#hana_os_image = "suse-sles-sap-15-sp1-byos"
-
-# Custom owner for private AMI
-#hana_os_owner = "self"
+#################################
+# General configuration variables
+#################################
 
 # aws-cli credentials data
 # access keys parameters have preference over the credentials file (they are self exclusive)
@@ -47,8 +28,94 @@ aws_secret_access_key = my-secret-access-key
 # aws-cli credentials file. Located on ~/.aws/credentials on Linux, MacOS or Unix or at C:\Users\USERNAME\.aws\credentials on Windows
 aws_credentials = "~/.aws/credentials"
 
+# If BYOS images are used in the deployment, SCC registration code is required
+# By default, all the images are PAYG, so these next parameters are not needed
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+
+# To add additional modules from SCC. None of them is needed by default
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
+
+# SSH Public key location to configure access to the remote instances
+public_key_location = "/path/to/your/public/ssh/key"
+
+# Private SSH Key location
+private_key_location = "/path/to/your/private/ssh/key"
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
+
+##########################
+# Other deployment options
+##########################
+
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+#ha_sap_deployment_repo = ""
+
+# Provisioning log level (error by default)
+#provisioning_log_level = "info"
+
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = true
+
+# QA variables
+
+# Define if the deployment is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false (default)
+#qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false
+
+#########################
+# HANA machines variables
+#########################
+
+# Instance type to use for the hana cluster nodes
+#hana_instancetype = "r3.8xlarge"
+
+# Disk type for HANA
+#hana_data_disk_type = "gp2"
+
+# Number of nodes in the cluster
+#hana_count = "2"
+
+# HANA machines image. By default, PAYG images are used
+# BYOS example with sles4sap 15 sp1 (this value is a pattern, it will select the latest version that matches this name)
+#hana_os_image = "suse-sles-sap-15-sp1-byos"
+# Or use a specific ami image
+#hana_os_image = "ami-xxxxxxxxxxxx"
+# Custom owner for private AMI
+#hana_os_owner = "amazon"
+
 # Hostname, without the domain part
-name = "hana"
+#name = "hana"
 
 # Enable system replication and HA cluster
 #hana_ha_enabled = true
@@ -87,9 +154,8 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # at hana_extract_dir (optional, by default /sapmedia_extract/HANA). This folder cannot be the same as `hana_inst_folder`!
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
-
 # Device used by node where HANA will be installed
-hana_disk_device = "/dev/xvdd"
+#hana_disk_device = "/dev/xvdd"
 
 # IP address used to configure the hana cluster floating IP. It must be in other subnet than the machines!
 #hana_cluster_vip = "192.168.1.10"
@@ -100,7 +166,16 @@ hana_disk_device = "/dev/xvdd"
 # Enable Active/Active HANA setup (read-only access in the secondary instance)
 #hana_active_active = true
 
+# Each host IP address (sequential order). The first ip must be in 10.0.0.0/24 subnet and the second in 10.0.1.0/24 subnet
+#hana_ips = ["10.0.0.5", "10.0.1.6"]
+
+# Cost optimized scenario
+#scenario_type: "cost-optimized"
+
+#######################
 # SBD related variables
+#######################
+
 # In order to enable SBD, an ISCSI server is needed as right now is the unique option
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
@@ -109,6 +184,10 @@ hana_disk_device = "/dev/xvdd"
 #iscsi_os_image = "ami-xxxxxxxxxxxxxxxxx"
 #iscsi_os_owner = "self"
 
+# iSCSI server image. By default, PAYG image is used. The usage is the same than the HANA images
+#iscsi_os_image = "suse-sles-sap-15-sp1-byos"
+#iscsi_os_owner = "amazon"
+
 # iSCSI server address. It should be in same iprange as hana_ips
 #iscsi_srv_ip = "10.0.0.254"
 # Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
@@ -116,72 +195,23 @@ hana_disk_device = "/dev/xvdd"
 # Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
 #iscsi_disk_size = 10
 
-# Path to a custom ssh public key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
-
-# Path to a custom ssh private key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
-
-# Each host IP address (sequential order). The first ip must be in 10.0.0.0/24 subnet and the second in 10.0.1.0/24 subnet
-#hana_ips = ["10.0.0.5", "10.0.1.6"]
-
-# Repository url used to install HA/SAP deployment packages"
-# The latest RPM packages can be found at:
-# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
-# Contains the salt formulas rpm packages.
-# To auto detect the SLE version
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
-# Specific SLE version used in all the created machines
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-ha_sap_deployment_repo = ""
-
-# Optional SUSE Customer Center Registration parameters
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
-# Cost optimized scenario
-#scenario_type: "cost-optimized"
-
-# To disable the provisioning process
-#provisioner = ""
-
-# Run provisioner execution in background
-#background = true
-
-# Monitoring variables
+##############################
+# Monitoring related variables
+##############################
 
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
-#monitoring_os_image = "ami-xxxxxxxxxxxxxxxxx"
-#monitoring_os_owner = "self"
+# Monitoring server image. By default, PAYG image is used. The usage is the same than the HANA images
+#monitoring_os_image = "suse-sles-sap-15-sp1-byos"
+#monitoring_os_owner = "amazon"
 
 # IP address of the machine where Prometheus and Grafana are running. Must be in 10.0.0.0/24 subnet
 #monitoring_srv_ip = "10.0.0.253"
 
-# QA variables
-
-# Define if the deployment is using for testing purpose
-# Disable all extra packages that do not come from the image
-# Except salt-minion (for the moment) and salt formulas
-# true or false (default)
-#qa_mode = false
-
-# Execute HANA Hardware Configuration Check Tool to bench filesystems
-# qa_mode must be set to true for executing hwcct
-# true or false (default)
-#hwcct = false
-
-# drbd related variables
+########################
+# DRBD related variables
+########################
 
 # netweaver will use AWS efs for nfs share by default, unless drbd is enabled
 # Enable drbd cluster
@@ -189,8 +219,9 @@ ha_sap_deployment_repo = ""
 
 #drbd_instancetype = "t2.micro"
 
-#drbd_os_image = "ami-xxxxxxxxxxxxxxxxx"
-#drbd_os_owner = "self"
+# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
+#drbd_os_image = "suse-sles-sap-15-sp1-byos"
+#drbd_os_owner = "amazon"
 
 #drbd_data_disk_size = 15
 
@@ -200,17 +231,21 @@ ha_sap_deployment_repo = ""
 #drbd_ips = ["10.0.5.20", "10.0.6.21"]
 #drbd_cluster_vip = "192.168.1.20"
 
-# Netweaver variables
+#############################
+# Netweaver related variables
+#############################
 
 #netweaver_enabled = true
 #netweaver_instancetype = "r3.8xlarge"
-#netweaver_os_image = "ami-xxxxxxxxxxxxxxxxx"
-#netweaver_os_owner = "self"
+
+# Netweaver machines image. By default, PAYG image is used. The usage is the same than the HANA images
+#netweaver_os_image = "suse-sles-sap-15-sp1-byos"
+#netweaver_os_owner = "amazon"
+
 #AWS efs performance mode used by netweaver nfs share, if efs storage is used
 #netweaver_efs_performance_mode = "generalPurpose"
 #netweaver_ips = ["10.0.2.7", "10.0.3.8", "10.0.2.9", "10.0.3.10"]
 #netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
-
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers
 # Set to false to only create a ASCS and PAS instances
@@ -243,8 +278,3 @@ ha_sap_deployment_repo = ""
 #netweaver_sapexe_folder   =  "kernel_nw75_sar"
 # Additional media archives or folders (added in start_dir.cd), relative to the netweaver_s3_bucket folder
 #netweaver_additional_dvds = ["dvd1", "dvd2"]
-
-# Pre deployment
-
-# Enable all some pre deployment steps (disabled by default)
-#pre_deployment = true

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -40,6 +40,11 @@ aws_credentials = "~/.aws/credentials"
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
+# Default os_image and os_owner. These values are not used if the specific values are not set (e.g.: hana_os_image)
+# BYOS example with sles4sap 15 sp1 (this value is a pattern, it will select the latest version that matches this name)
+#os_image = "suse-sles-sap-15-sp1-byos"
+#os_owner = "amazon"
+
 # SSH Public key location to configure access to the remote instances
 public_key_location = "/path/to/your/public/ssh/key"
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -154,13 +154,13 @@ variable "hana_count" {
 variable "hana_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp1-byos"
+  default     = "suse-sles-sap-15-sp2"
 }
 
 variable "hana_os_owner" {
-  description = "OS image owner"
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "amazon"
+  default     = "679593333241"
 }
 
 variable "hana_instancetype" {
@@ -274,19 +274,19 @@ variable "drbd_enabled" {
 variable "drbd_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp1-byos"
+  default     = "suse-sles-sap-15-sp2"
 }
 
 variable "drbd_os_owner" {
-  description = "OS image owner"
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "amazon"
+  default     = "679593333241"
 }
 
 variable "drbd_instancetype" {
   description = "The instance type of the drbd node"
   type        = string
-  default     = "t2.micro"
+  default     = "t2.large"
 }
 
 variable "drbd_cluster_vip" {
@@ -341,19 +341,19 @@ variable "sbd_storage_type" {
 variable "iscsi_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp1-byos"
+  default     = "suse-sles-sap-15-sp2"
 }
 
 variable "iscsi_os_owner" {
-  description = "OS image owner"
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "amazon"
+  default     = "679593333241"
 }
 
 variable "iscsi_instancetype" {
   description = "The instance type of the iscsi server node."
   type        = string
-  default     = "t2.micro"
+  default     = "t2.large"
 }
 
 variable "iscsi_srv_ip" {
@@ -378,19 +378,19 @@ variable "iscsi_disk_size" {
 variable "monitoring_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp1-byos"
+  default     = "suse-sles-sap-15-sp2"
 }
 
 variable "monitoring_os_owner" {
-  description = "OS image owner"
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "amazon"
+  default     = "679593333241"
 }
 
 variable "monitor_instancetype" {
   description = "The instance type of the monitoring node."
   type        = string
-  default     = "t2.micro"
+  default     = "t3.micro"
 }
 
 variable "monitoring_srv_ip" {
@@ -416,13 +416,13 @@ variable "netweaver_enabled" {
 variable "netweaver_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp1-byos"
+  default     = "suse-sles-sap-15-sp2"
 }
 
 variable "netweaver_os_owner" {
-  description = "OS image owner"
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "amazon"
+  default     = "679593333241"
 }
 
 variable "netweaver_instancetype" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -70,6 +70,18 @@ variable "name" {
   type        = string
 }
 
+variable "os_image" {
+  description = "Default OS image for all the machines. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
+  type        = string
+  default     = "suse-sles-sap-15-sp2"
+}
+
+variable "os_owner" {
+  description = "Default OS image owner. For BYOS images the owner usually is 'amazon'"
+  type        = string
+  default     = "679593333241"
+}
+
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
@@ -154,13 +166,13 @@ variable "hana_count" {
 variable "hana_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp2"
+  default     = ""
 }
 
 variable "hana_os_owner" {
   description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "679593333241"
+  default     = ""
 }
 
 variable "hana_instancetype" {
@@ -274,13 +286,13 @@ variable "drbd_enabled" {
 variable "drbd_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp2"
+  default     = ""
 }
 
 variable "drbd_os_owner" {
   description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "679593333241"
+  default     = ""
 }
 
 variable "drbd_instancetype" {
@@ -341,13 +353,13 @@ variable "sbd_storage_type" {
 variable "iscsi_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp2"
+  default     = ""
 }
 
 variable "iscsi_os_owner" {
   description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "679593333241"
+  default     = ""
 }
 
 variable "iscsi_instancetype" {
@@ -378,13 +390,13 @@ variable "iscsi_disk_size" {
 variable "monitoring_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp2"
+  default     = ""
 }
 
 variable "monitoring_os_owner" {
   description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "679593333241"
+  default     = ""
 }
 
 variable "monitor_instancetype" {
@@ -416,13 +428,13 @@ variable "netweaver_enabled" {
 variable "netweaver_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
-  default     = "suse-sles-sap-15-sp2"
+  default     = ""
 }
 
 variable "netweaver_os_owner" {
   description = "OS image owner. For BYOS images the owner usually is 'amazon'"
   type        = string
-  default     = "679593333241"
+  default     = ""
 }
 
 variable "netweaver_instancetype" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -65,10 +65,7 @@ module "drbd_node" {
   drbd_count            = var.drbd_enabled == true ? 2 : 0
   vm_size               = var.drbd_vm_size
   drbd_image_uri        = var.drbd_image_uri
-  drbd_public_publisher = var.drbd_public_publisher
-  drbd_public_offer     = var.drbd_public_offer
-  drbd_public_sku       = var.drbd_public_sku
-  drbd_public_version   = var.drbd_public_version
+  os_image              = var.drbd_os_image
   resource_group_name   = local.resource_group_name
   network_subnet_id     = local.subnet_id
   sec_group_id          = azurerm_network_security_group.mysecgroup.id
@@ -100,10 +97,7 @@ module "netweaver_node" {
   data_disk_size              = var.netweaver_data_disk_size
   data_disk_type              = var.netweaver_data_disk_type
   netweaver_image_uri         = var.netweaver_image_uri
-  netweaver_public_publisher  = var.netweaver_public_publisher
-  netweaver_public_offer      = var.netweaver_public_offer
-  netweaver_public_sku        = var.netweaver_public_sku
-  netweaver_public_version    = var.netweaver_public_version
+  os_image                    = var.netweaver_os_image
   resource_group_name         = local.resource_group_name
   network_subnet_id           = local.subnet_id
   sec_group_id                = azurerm_network_security_group.mysecgroup.id
@@ -168,10 +162,7 @@ module "hana_node" {
   bastion_host                  = module.bastion.public_ip
   bastion_private_key           = local.bastion_private_key
   hana_data_disks_configuration = var.hana_data_disks_configuration
-  hana_public_publisher         = var.hana_public_publisher
-  hana_public_offer             = var.hana_public_offer
-  hana_public_sku               = var.hana_public_sku
-  hana_public_version           = var.hana_public_version
+  os_image                      = var.hana_os_image
   admin_user                    = var.admin_user
   sbd_enabled                   = var.hana_cluster_sbd_enabled
   sbd_storage_type              = var.sbd_storage_type
@@ -190,10 +181,7 @@ module "monitoring" {
   sec_group_id                = azurerm_network_security_group.mysecgroup.id
   storage_account             = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   monitoring_uri              = var.monitoring_uri
-  monitoring_public_publisher = var.monitoring_public_publisher
-  monitoring_public_offer     = var.monitoring_public_offer
-  monitoring_public_sku       = var.monitoring_public_sku
-  monitoring_public_version   = var.monitoring_public_version
+  os_image                    = var.monitoring_os_image
   monitoring_srv_ip           = local.monitoring_ip
   bastion_enabled             = var.bastion_enabled
   bastion_host                = module.bastion.public_ip
@@ -215,10 +203,7 @@ module "iscsi_server" {
   sec_group_id           = azurerm_network_security_group.mysecgroup.id
   storage_account        = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   iscsi_srv_uri          = var.iscsi_srv_uri
-  iscsi_public_publisher = var.iscsi_public_publisher
-  iscsi_public_offer     = var.iscsi_public_offer
-  iscsi_public_sku       = var.iscsi_public_sku
-  iscsi_public_version   = var.iscsi_public_version
+  os_image               = var.iscsi_os_image
   bastion_enabled        = var.bastion_enabled
   bastion_host           = module.bastion.public_ip
   bastion_private_key    = local.bastion_private_key

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -167,7 +167,7 @@ resource "azurerm_image" "drbd-image" {
 
 # drbd instances
 
-module "os_image" {
+module "os_image_reference" {
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }
@@ -192,10 +192,10 @@ resource "azurerm_virtual_machine" "drbd" {
 
   storage_image_reference {
     id        = var.drbd_image_uri != "" ? join(",", azurerm_image.drbd-image.*.id) : ""
-    publisher = var.drbd_image_uri != "" ? "" : module.os_image.publisher
-    offer     = var.drbd_image_uri != "" ? "" : module.os_image.offer
-    sku       = var.drbd_image_uri != "" ? "" : module.os_image.sku
-    version   = var.drbd_image_uri != "" ? "" : module.os_image.version
+    publisher = var.drbd_image_uri != "" ? "" : module.os_image_reference.publisher
+    offer     = var.drbd_image_uri != "" ? "" : module.os_image_reference.offer
+    sku       = var.drbd_image_uri != "" ? "" : module.os_image_reference.sku
+    version   = var.drbd_image_uri != "" ? "" : module.os_image_reference.version
   }
 
   storage_data_disk {

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -167,6 +167,11 @@ resource "azurerm_image" "drbd-image" {
 
 # drbd instances
 
+module "os_image" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 resource "azurerm_virtual_machine" "drbd" {
   count                            = var.drbd_count
   name                             = "vm${var.name}0${count.index + 1}"
@@ -187,10 +192,10 @@ resource "azurerm_virtual_machine" "drbd" {
 
   storage_image_reference {
     id        = var.drbd_image_uri != "" ? join(",", azurerm_image.drbd-image.*.id) : ""
-    publisher = var.drbd_image_uri != "" ? "" : var.drbd_public_publisher
-    offer     = var.drbd_image_uri != "" ? "" : var.drbd_public_offer
-    sku       = var.drbd_image_uri != "" ? "" : var.drbd_public_sku
-    version   = var.drbd_image_uri != "" ? "" : var.drbd_public_version
+    publisher = var.drbd_image_uri != "" ? "" : module.os_image.publisher
+    offer     = var.drbd_image_uri != "" ? "" : module.os_image.offer
+    sku       = var.drbd_image_uri != "" ? "" : module.os_image.sku
+    version   = var.drbd_image_uri != "" ? "" : module.os_image.version
   }
 
   storage_data_disk {

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -46,7 +46,7 @@ variable "drbd_image_uri" {
 }
 
 variable "os_image" {
-  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
 

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -45,24 +45,9 @@ variable "drbd_image_uri" {
   default = ""
 }
 
-variable "drbd_public_publisher" {
-  type    = string
-  default = "SUSE"
-}
-
-variable "drbd_public_offer" {
-  type    = string
-  default = "SLES-SAP-BYOS"
-}
-
-variable "drbd_public_sku" {
-  type    = string
-  default = "15"
-}
-
-variable "drbd_public_version" {
-  type    = string
-  default = "latest"
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
 }
 
 variable "vm_size" {

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -202,6 +202,11 @@ resource "azurerm_image" "sles4sap" {
 
 # hana instances
 
+module "os_image" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 locals {
   disks_number           = length(split(",", var.hana_data_disks_configuration["disks_size"]))
   disks_size             = [for disk_size in split(",", var.hana_data_disks_configuration["disks_size"]) : tonumber(trimspace(disk_size))]
@@ -230,10 +235,10 @@ resource "azurerm_virtual_machine" "hana" {
 
   storage_image_reference {
     id        = var.sles4sap_uri != "" ? join(",", azurerm_image.sles4sap.*.id) : ""
-    publisher = var.sles4sap_uri != "" ? "" : var.hana_public_publisher
-    offer     = var.sles4sap_uri != "" ? "" : var.hana_public_offer
-    sku       = var.sles4sap_uri != "" ? "" : var.hana_public_sku
-    version   = var.sles4sap_uri != "" ? "" : var.hana_public_version
+    publisher = var.sles4sap_uri != "" ? "" : module.os_image.publisher
+    offer     = var.sles4sap_uri != "" ? "" : module.os_image.offer
+    sku       = var.sles4sap_uri != "" ? "" : module.os_image.sku
+    version   = var.sles4sap_uri != "" ? "" : module.os_image.version
   }
 
   dynamic "storage_data_disk" {

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -202,7 +202,7 @@ resource "azurerm_image" "sles4sap" {
 
 # hana instances
 
-module "os_image" {
+module "os_image_reference" {
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }
@@ -235,10 +235,10 @@ resource "azurerm_virtual_machine" "hana" {
 
   storage_image_reference {
     id        = var.sles4sap_uri != "" ? join(",", azurerm_image.sles4sap.*.id) : ""
-    publisher = var.sles4sap_uri != "" ? "" : module.os_image.publisher
-    offer     = var.sles4sap_uri != "" ? "" : module.os_image.offer
-    sku       = var.sles4sap_uri != "" ? "" : module.os_image.sku
-    version   = var.sles4sap_uri != "" ? "" : module.os_image.version
+    publisher = var.sles4sap_uri != "" ? "" : module.os_image_reference.publisher
+    offer     = var.sles4sap_uri != "" ? "" : module.os_image_reference.offer
+    sku       = var.sles4sap_uri != "" ? "" : module.os_image_reference.sku
+    version   = var.sles4sap_uri != "" ? "" : module.os_image_reference.version
   }
 
   dynamic "storage_data_disk" {

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -69,7 +69,7 @@ variable "sles4sap_uri" {
 }
 
 variable "os_image" {
-  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
 

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -68,20 +68,9 @@ variable "sles4sap_uri" {
   default = ""
 }
 
-variable "hana_public_publisher" {
-  type = string
-}
-
-variable "hana_public_offer" {
-  type = string
-}
-
-variable "hana_public_sku" {
-  type = string
-}
-
-variable "hana_public_version" {
-  type = string
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
 }
 
 variable "vm_size" {

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -59,6 +59,11 @@ resource "azurerm_image" "iscsi_srv" {
 
 # iSCSI server VM
 
+module "os_image" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 resource "azurerm_virtual_machine" "iscsisrv" {
   count                            = var.iscsi_count
   name                             = "vmiscsisrv0${count.index + 1}"
@@ -78,10 +83,10 @@ resource "azurerm_virtual_machine" "iscsisrv" {
 
   storage_image_reference {
     id        = var.iscsi_srv_uri != "" ? join(",", azurerm_image.iscsi_srv.*.id) : ""
-    publisher = var.iscsi_srv_uri != "" ? "" : var.iscsi_public_publisher
-    offer     = var.iscsi_srv_uri != "" ? "" : var.iscsi_public_offer
-    sku       = var.iscsi_srv_uri != "" ? "" : var.iscsi_public_sku
-    version   = var.iscsi_srv_uri != "" ? "" : var.iscsi_public_version
+    publisher = var.iscsi_srv_uri != "" ? "" : module.os_image.publisher
+    offer     = var.iscsi_srv_uri != "" ? "" : module.os_image.offer
+    sku       = var.iscsi_srv_uri != "" ? "" : module.os_image.sku
+    version   = var.iscsi_srv_uri != "" ? "" : module.os_image.version
   }
 
   storage_data_disk {

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_image" "iscsi_srv" {
 
 # iSCSI server VM
 
-module "os_image" {
+module "os_image_reference" {
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }
@@ -83,10 +83,10 @@ resource "azurerm_virtual_machine" "iscsisrv" {
 
   storage_image_reference {
     id        = var.iscsi_srv_uri != "" ? join(",", azurerm_image.iscsi_srv.*.id) : ""
-    publisher = var.iscsi_srv_uri != "" ? "" : module.os_image.publisher
-    offer     = var.iscsi_srv_uri != "" ? "" : module.os_image.offer
-    sku       = var.iscsi_srv_uri != "" ? "" : module.os_image.sku
-    version   = var.iscsi_srv_uri != "" ? "" : module.os_image.version
+    publisher = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.publisher
+    offer     = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.offer
+    sku       = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.sku
+    version   = var.iscsi_srv_uri != "" ? "" : module.os_image_reference.version
   }
 
   storage_data_disk {

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -24,7 +24,7 @@ variable "storage_account" {
 }
 
 variable "os_image" {
-  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
 

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -23,24 +23,9 @@ variable "storage_account" {
   type = string
 }
 
-variable "iscsi_public_publisher" {
-  type    = string
-  default = "SUSE"
-}
-
-variable "iscsi_public_offer" {
-  type    = string
-  default = "SLES-SAP-BYOS"
-}
-
-variable "iscsi_public_sku" {
-  type    = string
-  default = "15"
-}
-
-variable "iscsi_public_version" {
-  type    = string
-  default = "latest"
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
 }
 
 variable "iscsi_srv_uri" {

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -59,7 +59,7 @@ resource "azurerm_image" "monitoring" {
 
 # monitoring VM
 
-module "os_image" {
+module "os_image_reference" {
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }
@@ -83,10 +83,10 @@ resource "azurerm_virtual_machine" "monitoring" {
 
   storage_image_reference {
     id        = var.monitoring_uri != "" ? azurerm_image.monitoring.0.id : ""
-    publisher = var.monitoring_uri != "" ? "" : module.os_image.publisher
-    offer     = var.monitoring_uri != "" ? "" : module.os_image.offer
-    sku       = var.monitoring_uri != "" ? "" : module.os_image.sku
-    version   = var.monitoring_uri != "" ? "" : module.os_image.version
+    publisher = var.monitoring_uri != "" ? "" : module.os_image_reference.publisher
+    offer     = var.monitoring_uri != "" ? "" : module.os_image_reference.offer
+    sku       = var.monitoring_uri != "" ? "" : module.os_image_reference.sku
+    version   = var.monitoring_uri != "" ? "" : module.os_image_reference.version
   }
 
   storage_data_disk {

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -59,6 +59,11 @@ resource "azurerm_image" "monitoring" {
 
 # monitoring VM
 
+module "os_image" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 resource "azurerm_virtual_machine" "monitoring" {
   name                             = "vmmonitoring"
   count                            = var.monitoring_enabled == true ? 1 : 0
@@ -78,10 +83,10 @@ resource "azurerm_virtual_machine" "monitoring" {
 
   storage_image_reference {
     id        = var.monitoring_uri != "" ? azurerm_image.monitoring.0.id : ""
-    publisher = var.monitoring_uri != "" ? "" : var.monitoring_public_publisher
-    offer     = var.monitoring_uri != "" ? "" : var.monitoring_public_offer
-    sku       = var.monitoring_uri != "" ? "" : var.monitoring_public_sku
-    version   = var.monitoring_uri != "" ? "" : var.monitoring_public_version
+    publisher = var.monitoring_uri != "" ? "" : module.os_image.publisher
+    offer     = var.monitoring_uri != "" ? "" : module.os_image.offer
+    sku       = var.monitoring_uri != "" ? "" : module.os_image.sku
+    version   = var.monitoring_uri != "" ? "" : module.os_image.version
   }
 
   storage_data_disk {

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -40,7 +40,7 @@ variable "storage_account" {
 }
 
 variable "os_image" {
-  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
 

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -39,24 +39,9 @@ variable "storage_account" {
   type = string
 }
 
-variable "monitoring_public_publisher" {
-  type    = string
-  default = "SUSE"
-}
-
-variable "monitoring_public_offer" {
-  type    = string
-  default = "SLES-SAP-BYOS"
-}
-
-variable "monitoring_public_sku" {
-  type    = string
-  default = "15"
-}
-
-variable "monitoring_public_version" {
-  type    = string
-  default = "latest"
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
 }
 
 variable "monitoring_uri" {

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -261,7 +261,7 @@ resource "azurerm_virtual_machine_data_disk_attachment" "app_server_disk" {
 
 # netweaver instances
 
-module "os_image" {
+module "os_image_reference" {
   source   = "../../modules/os_image_reference"
   os_image = var.os_image
 }
@@ -286,10 +286,10 @@ resource "azurerm_virtual_machine" "netweaver" {
 
   storage_image_reference {
     id        = var.netweaver_image_uri != "" ? join(",", azurerm_image.netweaver-image.*.id) : ""
-    publisher = var.netweaver_image_uri != "" ? "" : module.os_image.publisher
-    offer     = var.netweaver_image_uri != "" ? "" : module.os_image.offer
-    sku       = var.netweaver_image_uri != "" ? "" : module.os_image.sku
-    version   = var.netweaver_image_uri != "" ? "" : module.os_image.version
+    publisher = var.netweaver_image_uri != "" ? "" : module.os_image_reference.publisher
+    offer     = var.netweaver_image_uri != "" ? "" : module.os_image_reference.offer
+    sku       = var.netweaver_image_uri != "" ? "" : module.os_image_reference.sku
+    version   = var.netweaver_image_uri != "" ? "" : module.os_image_reference.version
   }
 
   os_profile {

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -261,6 +261,11 @@ resource "azurerm_virtual_machine_data_disk_attachment" "app_server_disk" {
 
 # netweaver instances
 
+module "os_image" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 resource "azurerm_virtual_machine" "netweaver" {
   count                            = local.vm_count
   name                             = "vmnetweaver0${count.index + 1}"
@@ -281,10 +286,10 @@ resource "azurerm_virtual_machine" "netweaver" {
 
   storage_image_reference {
     id        = var.netweaver_image_uri != "" ? join(",", azurerm_image.netweaver-image.*.id) : ""
-    publisher = var.netweaver_image_uri != "" ? "" : var.netweaver_public_publisher
-    offer     = var.netweaver_image_uri != "" ? "" : var.netweaver_public_offer
-    sku       = var.netweaver_image_uri != "" ? "" : var.netweaver_public_sku
-    version   = var.netweaver_image_uri != "" ? "" : var.netweaver_public_version
+    publisher = var.netweaver_image_uri != "" ? "" : module.os_image.publisher
+    offer     = var.netweaver_image_uri != "" ? "" : module.os_image.offer
+    sku       = var.netweaver_image_uri != "" ? "" : module.os_image.sku
+    version   = var.netweaver_image_uri != "" ? "" : module.os_image.version
   }
 
   os_profile {

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -202,24 +202,9 @@ variable "netweaver_image_uri" {
   default = ""
 }
 
-variable "netweaver_public_publisher" {
-  type    = string
-  default = "SUSE"
-}
-
-variable "netweaver_public_offer" {
-  type    = string
-  default = "SLES-SAP-BYOS"
-}
-
-variable "netweaver_public_sku" {
-  type    = string
-  default = "15"
-}
-
-variable "netweaver_public_version" {
-  type    = string
-  default = "latest"
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
 }
 
 variable "hana_ip" {

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -203,7 +203,7 @@ variable "netweaver_image_uri" {
 }
 
 variable "os_image" {
-  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
 }
 

--- a/azure/modules/os_image_reference/outputs.tf
+++ b/azure/modules/os_image_reference/outputs.tf
@@ -1,0 +1,41 @@
+# Terraform module to wrap up a method to split the os_image information used in all of the
+# other modules
+
+# Usage example
+####################
+#
+#module "os_image" {
+#  source   = "../../modules/os_image_reference"
+#  os_image = var.os_image
+#}
+#
+#storage_image_reference {
+#  publisher = module.os_image.publisher
+#  offer     = module.os_image.offer
+#  sku       = module.os_image.sku
+#  version   = module.os_image.version
+#}
+
+locals {
+  data      = split(":", var.os_image)
+  publisher = local.data[0]
+  offer     = local.data[1]
+  sku       = local.data[2]
+  version   = local.data[3]
+}
+
+output "publisher" {
+  value = local.publisher
+}
+
+output "offer" {
+  value = local.offer
+}
+
+output "sku" {
+  value = local.sku
+}
+
+output "version" {
+  value = local.version
+}

--- a/azure/modules/os_image_reference/variables.tf
+++ b/azure/modules/os_image_reference/variables.tf
@@ -1,0 +1,4 @@
+variable "os_image" {
+  description = "sles4sap image used to create the this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
+}

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -20,15 +20,92 @@ az_region = "westeurope"
 #vnet_address_range = ""
 #subnet_address_range = ""
 
-# HANA configuration (this example shows the demo option values.Find more options in the README file)
+#################################
+# General configuration variables
+#################################
+
+# Admin user for the created machines
+admin_user = "cloudadmin"
+
+# If BYOS images are used in the deployment, SCC registration code is required
+# By default, all the images are PAYG, so these next parameters are not needed
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+
+# To add additional modules from SCC. None of them is needed by default
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
+
+# SSH Public key to configure access to the remote instances
+public_key_location = "/path/to/your/public/ssh/key"
+
+# Private SSH Key location
+private_key_location = "/path/to/your/private/ssh/key"
+
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
+
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
+
+##########################
+# Other deployment options
+##########################
+
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+#ha_sap_deployment_repo = ""
+
+# Provisioning log level (error by default)
+#provisioning_log_level = "info"
+
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = true
+
+# QA variables
+
+# Define if the deployment is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false (default)
+#qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false
+
+#########################
+# HANA machines variables
+# This example shows the demo option values.Find more options in the README file
+#########################
+
+# HANA configuration ()
 # VM size to use for the cluster nodes
 #hana_vm_size = "Standard_E4s_v3"
 
 # Number of nodes in the cluster
-hana_count = "2"
+#hana_count = "2"
 
 # Instance number for the HANA database. 00 by default.
-hana_instance_number = "00"
+#hana_instance_number = "00"
 
 # Network options
 #hana_enable_accelerated_networking = false
@@ -50,47 +127,11 @@ hana_instance_number = "00"
 # Custom sles4sap image
 #sles4sap_uri = "/path/to/your/image"
 
-# Custom iscsi server image
-#iscsi_srv_uri = "/path/to/your/iscsi/image"
-
-# Custom monitoring server image
-#monitoring_uri = "/path/to/your/monitoring/image"
-
-# Custom drbd nodes image
-#drbd_image_uri = "/path/to/your/monitoring/image"
-
-# Public sles4sap image
-hana_public_publisher = "SUSE"
-hana_public_offer     = "SLES-SAP-BYOS"
-hana_public_sku       = "12-sp4"
-hana_public_version   = "latest"
-
-# Public iscsi server image
-iscsi_public_publisher = "SUSE"
-iscsi_public_offer     = "SLES-SAP-BYOS"
-iscsi_public_sku       = "15"
-iscsi_public_version   = "latest"
-
-# Public monitoring server image
-monitoring_public_publisher = "SUSE"
-monitoring_public_offer     = "SLES-SAP-BYOS"
-monitoring_public_sku       = "15"
-monitoring_public_version   = "latest"
-
-# Public drbd nodes image
-drbd_public_publisher = "SUSE"
-drbd_public_offer     = "SLES-SAP-BYOS"
-drbd_public_sku       = "15"
-drbd_public_version   = "latest"
-
-# Admin user
-admin_user = "YOUR_USERNAME_HERE"
-
-# SSH Public key to configure access to the remote instances
-public_key_location = "/path/to/your/public/ssh/key"
-
-# Private SSH Key location
-private_key_location = "/path/to/your/private/ssh/key"
+# Public OS images
+# Run the next command to get the possible options and use the 4th column value (version can be changed by `latest`)
+# az vm image list --output table --publisher SUSE --all
+# BYOS example
+# hana_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
 
 # The next variables define how the HANA installation software is obtained.
 # The installation software must be located in a Azure storage account
@@ -131,26 +172,6 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # at hana_extract_dir (optional, by default /sapmedia_extract/HANA). This folder cannot be the same as `hana_inst_folder`!
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
-# SBD related variables
-# In order to enable SBD, an ISCSI server is needed as right now is the unique option
-# All the clusters will use the same mechanism
-# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
-
-# IP address of the iSCSI server. If it's not set the address will be auto generated from the provided vnet address range
-#iscsi_srv_ip = "10.74.1.14"
-# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
-#iscsi_lun_count = 3
-# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
-#iscsi_disk_size = 10
-
-# Path to a custom ssh public key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
-
-# Path to a custom ssh private key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
-
 # Enable system replication and HA cluster
 #hana_ha_enabled = true
 
@@ -164,43 +185,55 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Enable Active/Active HANA setup (read-only access in the secondary instance)
 #hana_active_active = true
 
-# Repository url used to install HA/SAP deployment packages"
-# The latest RPM packages can be found at:
-# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
-# Contains the salt formulas rpm packages.
-# To auto detect the SLE version
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
-# Specific SLE version used in all the created machines
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-ha_sap_deployment_repo = ""
-
-# Optional SUSE Customer Center Registration parameters
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
-
 # Cost optimized scenario
 #scenario_type: "cost-optimized"
 
-# To disable the provisioning process
-#provisioner = ""
+#######################
+# SBD related variables
+#######################
 
-# Run provisioner execution in background
-#background = true
+# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# All the clusters will use the same mechanism
+# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 
-# Monitoring variables
+# Custom iscsi server image
+#iscsi_srv_uri = "/path/to/your/iscsi/image"
+
+# Public image usage for iSCSI. BYOS example
+#iscsi_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
+
+# IP address of the iSCSI server. If it's not set the address will be auto generated from the provided vnet address range
+#iscsi_srv_ip = "10.74.1.14"
+# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
+#iscsi_lun_count = 3
+# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
+#iscsi_disk_size = 10
+
+##############################
+# Monitoring related variables
+##############################
+
+# Custom monitoring server image
+#monitoring_uri = "/path/to/your/monitoring/image"
+
+# Public image usage for the monitoring server. BYOS example
+#monitoring_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
 
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
 # IP address of the machine where Prometheus and Grafana are running. If it's not set the address will be auto generated from the provided vnet address range
 #monitoring_srv_ip = "10.74.1.13"
+
+########################
+# DRBD related variables
+########################
+
+# Custom drbd nodes image
+#drbd_image_uri = "/path/to/your/monitoring/image"
+
+# Public image usage for the DRBD machines. BYOS example
+#drbd_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
 
 # Enable drbd cluster
 #drbd_enabled = true
@@ -212,9 +245,18 @@ ha_sap_deployment_repo = ""
 # Enable SBD for the drbd cluster
 #drbd_cluster_sbd_enabled = true
 
-# Netweaver variables
+#############################
+# Netweaver related variables
+#############################
 
 #netweaver_enabled = true
+
+# Custom drbd nodes image
+#netweaver_image_uri = "/path/to/your/monitoring/image"
+
+# Public image usage for the Netweaver machines. BYOS example
+#netweaver_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
+
 # If the addresses are not set they will be auto generated from the provided vnet address range
 #netweaver_ips = ["10.74.1.30", "10.74.1.31", "10.74.1.32", "10.74.1.33"]
 #netweaver_virtual_ips = ["10.74.1.35", "10.74.1.36", "10.74.1.37", "10.74.1.38"]
@@ -257,21 +299,3 @@ ha_sap_deployment_repo = ""
 #netweaver_sapexe_folder   =  "kernel_nw75_sar"
 # Additional media archives or folders (added in start_dir.cd), relative to the netweaver_storage_account mounting point
 #netweaver_additional_dvds = ["dvd1", "dvd2"]
-
-# QA variables
-
-# Define if the deployment is using for testing purpose
-# Disable all extra packages that do not come from the image
-# Except salt-minion (for the moment) and salt formulas
-# true or false (default)
-#qa_mode = false
-
-# Execute HANA Hardware Configuration Check Tool to bench filesystems
-# qa_mode must be set to true for executing hwcct
-# true or false (default)
-#hwcct = false
-
-# Pre deployment
-
-# Enable all some pre deployment steps (disabled by default)
-#pre_deployment = true

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -39,6 +39,12 @@ admin_user = "cloudadmin"
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
+# Default os_image. This value is not used to create the machines if the specific values are set (e.g.: hana_os_image)
+# Run the next command to get the possible options and use the 4th column value (version can be changed by `latest`)
+# az vm image list --output table --publisher SUSE --all
+# BYOS example with sles4sap 15 sp2 (this value is a pattern, it will select the latest version that matches this name)
+#os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
+
 # SSH Public key to configure access to the remote instances
 public_key_location = "/path/to/your/public/ssh/key"
 
@@ -128,8 +134,6 @@ pre_deployment = true
 #sles4sap_uri = "/path/to/your/image"
 
 # Public OS images
-# Run the next command to get the possible options and use the 4th column value (version can be changed by `latest`)
-# az vm image list --output table --publisher SUSE --all
 # BYOS example
 # hana_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
 

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -27,7 +27,7 @@ az_region = "westeurope"
 # Admin user for the created machines
 admin_user = "cloudadmin"
 
-# If BYOS images are used in the deployment, SCC registration code is required
+# If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
 # By default, all the images are PAYG, so these next parameters are not needed
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
@@ -39,7 +39,7 @@ admin_user = "cloudadmin"
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
-# Default os_image. This value is not used to create the machines if the specific values are set (e.g.: hana_os_image)
+# Default os_image. This value is not used if the specific values are set (e.g.: hana_os_image)
 # Run the next command to get the possible options and use the 4th column value (version can be changed by `latest`)
 # az vm image list --output table --publisher SUSE --all
 # BYOS example with sles4sap 15 sp2 (this value is a pattern, it will select the latest version that matches this name)
@@ -76,7 +76,7 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
-# Enable all some pre deployment steps (disabled by default)
+# Enable pre deployment steps (disabled by default)
 pre_deployment = true
 
 # To disable the provisioning process
@@ -87,7 +87,7 @@ pre_deployment = true
 
 # QA variables
 
-# Define if the deployment is using for testing purpose
+# Define if the deployment is used for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
@@ -196,7 +196,7 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # SBD related variables
 #######################
 
-# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# In order to enable SBD, an ISCSI server is needed as right now is the only option
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -87,6 +87,12 @@ variable "name" {
   default     = "hana"
 }
 
+variable "os_image" {
+  description = "Default OS image for all the machines. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
+  type        = string
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+}
+
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
@@ -171,7 +177,7 @@ variable "hana_count" {
 variable "hana_os_image" {
   description = "sles4sap image used to create the HANA machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+  default     = ""
 }
 
 variable "sles4sap_uri" {
@@ -324,7 +330,7 @@ variable "sbd_storage_type" {
 variable "iscsi_os_image" {
   description = "sles4sap image used to create the ISCSI machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+  default     = ""
 }
 
 variable "iscsi_srv_uri" {
@@ -373,7 +379,7 @@ variable "monitoring_vm_size" {
 variable "monitoring_os_image" {
   description = "sles4sap image used to create the Monitoring server machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+  default     = ""
 }
 
 variable "monitoring_uri" {
@@ -411,7 +417,7 @@ variable "drbd_ips" {
 variable "drbd_os_image" {
   description = "sles4sap image used to create the DRBD machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+  default     = ""
 }
 
 variable "drbd_image_uri" {
@@ -449,7 +455,7 @@ variable "netweaver_app_server_count" {
 variable "netweaver_os_image" {
   description = "sles4sap image used to create the Netweaver machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
+  default     = ""
 }
 
 variable "netweaver_image_uri" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -88,7 +88,7 @@ variable "name" {
 }
 
 variable "os_image" {
-  description = "Default OS image for all the machines. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
+  description = "Default OS image for all the machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: 'SUSE:sles-sap-15-sp2:gen2:latest'. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
   type        = string
   default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -168,28 +168,10 @@ variable "hana_count" {
   default     = "2"
 }
 
-variable "hana_public_publisher" {
-  description = "Public image publisher name used to create the hana machines"
+variable "hana_os_image" {
+  description = "sles4sap image used to create the HANA machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE"
-}
-
-variable "hana_public_offer" {
-  description = "Public image offer name used to create the hana machines"
-  type        = string
-  default     = "sles-sap-15-sp1-byos"
-}
-
-variable "hana_public_sku" {
-  description = "Public image sku used to create the hana machines"
-  type        = string
-  default     = "gen2"
-}
-
-variable "hana_public_version" {
-  description = "Public image version used to create the hana machines"
-  type        = string
-  default     = "latest"
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }
 
 variable "sles4sap_uri" {
@@ -339,28 +321,10 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
-variable "iscsi_public_publisher" {
-  description = "Public image publisher name used to create the iscsi machines"
+variable "iscsi_os_image" {
+  description = "sles4sap image used to create the ISCSI machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE"
-}
-
-variable "iscsi_public_offer" {
-  description = "Public image offer name used to create the iscsi machines"
-  type        = string
-  default     = "sles-sap-15-sp1-byos"
-}
-
-variable "iscsi_public_sku" {
-  description = "Public image sku used to create the iscsi machines"
-  type        = string
-  default     = "gen2"
-}
-
-variable "iscsi_public_version" {
-  description = "Public image version used to create the iscsi machines"
-  type        = string
-  default     = "latest"
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }
 
 variable "iscsi_srv_uri" {
@@ -406,28 +370,10 @@ variable "monitoring_vm_size" {
   default     = "Standard_D2s_v3"
 }
 
-variable "monitoring_public_publisher" {
-  description = "Public image publisher name used to create the monitoring machines"
+variable "monitoring_os_image" {
+  description = "sles4sap image used to create the Monitoring server machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE"
-}
-
-variable "monitoring_public_offer" {
-  description = "Public image offer name used to create the monitoring machines"
-  type        = string
-  default     = "sles-sap-15-sp1-byos"
-}
-
-variable "monitoring_public_sku" {
-  description = "Public image sku used to create the monitoring machines"
-  type        = string
-  default     = "gen2"
-}
-
-variable "monitoring_public_version" {
-  description = "Public image version used to create the monitoring machines"
-  type        = string
-  default     = "latest"
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }
 
 variable "monitoring_uri" {
@@ -462,28 +408,10 @@ variable "drbd_ips" {
   default     = []
 }
 
-variable "drbd_public_publisher" {
-  description = "Public image publisher name used to create the drbd machines"
+variable "drbd_os_image" {
+  description = "sles4sap image used to create the DRBD machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE"
-}
-
-variable "drbd_public_offer" {
-  description = "Public image offer name used to create the drbd machines"
-  type        = string
-  default     = "sles-sap-15-sp1-byos"
-}
-
-variable "drbd_public_sku" {
-  description = "Public image sku used to create the drbd machines"
-  type        = string
-  default     = "gen2"
-}
-
-variable "drbd_public_version" {
-  description = "Public image sku used to create the drbd machines"
-  type        = string
-  default     = "latest"
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }
 
 variable "drbd_image_uri" {
@@ -518,28 +446,10 @@ variable "netweaver_app_server_count" {
   default     = 2
 }
 
-variable "netweaver_public_publisher" {
-  description = "Public image publisher name used to create the netweaver machines"
+variable "netweaver_os_image" {
+  description = "sles4sap image used to create the Netweaver machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
-  default     = "SUSE"
-}
-
-variable "netweaver_public_offer" {
-  description = "Public image offer name used to create the netweaver machines"
-  type        = string
-  default     = "sles-sap-15-sp1-byos"
-}
-
-variable "netweaver_public_sku" {
-  description = "Public image sku used to create the netweaver machines"
-  type        = string
-  default     = "gen2"
-}
-
-variable "netweaver_public_version" {
-  description = "Public image sku used to create the netweaver machines"
-  type        = string
-  default     = "latest"
+  default     = "SUSE:sles-sap-15-sp2:gen2:latest"
 }
 
 variable "netweaver_image_uri" {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -36,6 +36,13 @@ locals {
 
   # Check if iscsi server has to be created
   iscsi_enabled = var.sbd_storage_type == "iscsi" && ((var.hana_count > 1 && var.hana_cluster_sbd_enabled == true) || (var.drbd_enabled && var.drbd_cluster_sbd_enabled == true) || (var.netweaver_enabled && var.netweaver_cluster_sbd_enabled == true)) ? true : false
+
+  # Obtain machines os_image value
+  hana_os_image       = var.hana_os_image != "" ? var.hana_os_image : var.os_image
+  iscsi_os_image      = var.iscsi_os_image != "" ? var.iscsi_os_image : var.os_image
+  monitoring_os_image = var.monitoring_os_image != "" ? var.monitoring_os_image : var.os_image
+  drbd_os_image       = var.drbd_os_image != "" ? var.drbd_os_image : var.os_image
+  netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
 }
 
 module "common_variables" {
@@ -64,7 +71,7 @@ module "drbd_node" {
   compute_zones        = data.google_compute_zones.available.names
   network_name         = local.vpc_name
   network_subnet_name  = local.subnet_name
-  os_image             = var.drbd_image
+  os_image             = local.drbd_os_image
   drbd_data_disk_size  = var.drbd_data_disk_size
   drbd_data_disk_type  = var.drbd_data_disk_type
   drbd_cluster_vip     = local.drbd_cluster_vip
@@ -89,7 +96,7 @@ module "netweaver_node" {
   compute_zones             = data.google_compute_zones.available.names
   network_name              = local.vpc_name
   network_subnet_name       = local.subnet_name
-  os_image                  = var.netweaver_image
+  os_image                  = local.netweaver_os_image
   gcp_credentials_file      = var.gcp_credentials_file
   network_domain            = "tf.local"
   host_ips                  = local.netweaver_ips
@@ -124,7 +131,7 @@ module "hana_node" {
   compute_zones              = data.google_compute_zones.available.names
   network_name               = local.vpc_name
   network_subnet_name        = local.subnet_name
-  os_image                   = var.sles4sap_boot_image
+  os_image                   = local.hana_os_image
   gcp_credentials_file       = var.gcp_credentials_file
   host_ips                   = local.hana_ips
   sbd_enabled                = var.hana_cluster_sbd_enabled
@@ -159,7 +166,7 @@ module "monitoring" {
   monitoring_enabled  = var.monitoring_enabled
   compute_zones       = data.google_compute_zones.available.names
   network_subnet_name = local.subnet_name
-  os_image            = var.sles4sap_boot_image
+  os_image            = local.monitoring_os_image
   monitoring_srv_ip   = local.monitoring_srv_ip
   hana_targets        = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets        = var.drbd_enabled ? local.drbd_ips : []
@@ -170,16 +177,16 @@ module "monitoring" {
 }
 
 module "iscsi_server" {
-  source                  = "./modules/iscsi_server"
-  common_variables        = module.common_variables.configuration
-  iscsi_count             = local.iscsi_enabled == true ? 1 : 0
-  machine_type            = var.machine_type_iscsi_server
-  compute_zones           = data.google_compute_zones.available.names
-  network_subnet_name     = local.subnet_name
-  os_image                = var.iscsi_server_boot_image
-  host_ips                = [local.iscsi_srv_ip]
-  lun_count               = var.iscsi_lun_count
-  iscsi_disk_size         = var.iscsi_disk_size
+  source              = "./modules/iscsi_server"
+  common_variables    = module.common_variables.configuration
+  iscsi_count         = local.iscsi_enabled == true ? 1 : 0
+  machine_type        = var.machine_type_iscsi_server
+  compute_zones       = data.google_compute_zones.available.names
+  network_subnet_name = local.subnet_name
+  os_image            = local.iscsi_os_image
+  host_ips            = [local.iscsi_srv_ip]
+  lun_count           = var.iscsi_lun_count
+  iscsi_disk_size     = var.iscsi_disk_size
   on_destroy_dependencies = [
     google_compute_firewall.ha_firewall_allow_tcp
   ]

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -64,7 +64,7 @@ module "drbd_node" {
   compute_zones        = data.google_compute_zones.available.names
   network_name         = local.vpc_name
   network_subnet_name  = local.subnet_name
-  drbd_image           = var.drbd_image
+  os_image             = var.drbd_image
   drbd_data_disk_size  = var.drbd_data_disk_size
   drbd_data_disk_type  = var.drbd_data_disk_type
   drbd_cluster_vip     = local.drbd_cluster_vip
@@ -89,7 +89,7 @@ module "netweaver_node" {
   compute_zones             = data.google_compute_zones.available.names
   network_name              = local.vpc_name
   network_subnet_name       = local.subnet_name
-  netweaver_image           = var.netweaver_image
+  os_image                  = var.netweaver_image
   gcp_credentials_file      = var.gcp_credentials_file
   network_domain            = "tf.local"
   host_ips                  = local.netweaver_ips
@@ -124,7 +124,7 @@ module "hana_node" {
   compute_zones              = data.google_compute_zones.available.names
   network_name               = local.vpc_name
   network_subnet_name        = local.subnet_name
-  sles4sap_boot_image        = var.sles4sap_boot_image
+  os_image                   = var.sles4sap_boot_image
   gcp_credentials_file       = var.gcp_credentials_file
   host_ips                   = local.hana_ips
   sbd_enabled                = var.hana_cluster_sbd_enabled
@@ -159,7 +159,7 @@ module "monitoring" {
   monitoring_enabled  = var.monitoring_enabled
   compute_zones       = data.google_compute_zones.available.names
   network_subnet_name = local.subnet_name
-  sles4sap_boot_image = var.sles4sap_boot_image
+  os_image            = var.sles4sap_boot_image
   monitoring_srv_ip   = local.monitoring_srv_ip
   hana_targets        = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets        = var.drbd_enabled ? local.drbd_ips : []
@@ -176,7 +176,7 @@ module "iscsi_server" {
   machine_type            = var.machine_type_iscsi_server
   compute_zones           = data.google_compute_zones.available.names
   network_subnet_name     = local.subnet_name
-  iscsi_server_boot_image = var.iscsi_server_boot_image
+  os_image                = var.iscsi_server_boot_image
   host_ips                = [local.iscsi_srv_ip]
   lun_count               = var.iscsi_lun_count
   iscsi_disk_size         = var.iscsi_disk_size

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -45,7 +45,7 @@ resource "google_compute_instance" "drbd" {
 
   boot_disk {
     initialize_params {
-      image = var.drbd_image
+      image = var.os_image
     }
 
     auto_delete = true

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -28,10 +28,9 @@ variable "drbd_count" {
   default     = "2"
 }
 
-variable "drbd_image" {
-  description = "image of the drbd nodes"
+variable "os_image" {
+  description = "Image used to create the machine"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sap-byos"
 }
 
 variable "drbd_data_disk_size" {

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -76,7 +76,7 @@ resource "google_compute_instance" "clusternodes" {
 
   boot_disk {
     initialize_params {
-      image = var.sles4sap_boot_image
+      image = var.os_image
     }
 
     auto_delete = true

--- a/gcp/modules/hana_node/variables.tf
+++ b/gcp/modules/hana_node/variables.tf
@@ -27,10 +27,9 @@ variable "network_subnet_name" {
   type        = string
 }
 
-variable "sles4sap_boot_image" {
-  description = "The image used to create the hana machines"
+variable "os_image" {
+  description = "Image used to create the machine"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sap-byos"
 }
 
 variable "gcp_credentials_file" {

--- a/gcp/modules/iscsi_server/main.tf
+++ b/gcp/modules/iscsi_server/main.tf
@@ -34,7 +34,7 @@ resource "google_compute_instance" "iscsisrv" {
 
   boot_disk {
     initialize_params {
-      image = var.iscsi_server_boot_image
+      image = var.os_image
     }
 
     auto_delete = true

--- a/gcp/modules/iscsi_server/variables.tf
+++ b/gcp/modules/iscsi_server/variables.tf
@@ -17,9 +17,9 @@ variable "network_subnet_name" {
   type        = string
 }
 
-variable "iscsi_server_boot_image" {
-  type    = string
-  default = "suse-byos-cloud/sles-15-sap-byos"
+variable "os_image" {
+  description = "Image used to create the machine"
+  type        = string
 }
 
 variable "iscsi_count" {

--- a/gcp/modules/monitoring/main.tf
+++ b/gcp/modules/monitoring/main.tf
@@ -37,7 +37,7 @@ resource "google_compute_instance" "monitoring" {
 
   boot_disk {
     initialize_params {
-      image = var.sles4sap_boot_image
+      image = var.os_image
     }
 
     auto_delete = true

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -18,9 +18,9 @@ variable "network_subnet_name" {
   type        = string
 }
 
-variable "sles4sap_boot_image" {
-  type    = string
-  default = "suse-byos-cloud/sles-15-sap-byos"
+variable "os_image" {
+  description = "Image used to create the machine"
+  type        = string
 }
 
 variable "monitoring_srv_ip" {

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -59,7 +59,7 @@ resource "google_compute_instance" "netweaver" {
 
   boot_disk {
     initialize_params {
-      image = var.netweaver_image
+      image = var.os_image
     }
 
     auto_delete = true

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -27,10 +27,9 @@ variable "netweaver_count" {
   default = "2"
 }
 
-variable "netweaver_image" {
-  description = "image of the netweaver nodes"
+variable "os_image" {
+  description = "Image used to create the machine"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sap-byos"
 }
 
 variable "gcp_credentials_file" {

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -37,6 +37,13 @@ region = "europe-west1"
 #    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
 #}
 
+# Default os_image. This value is not used if the specific values are set (e.g.: hana_os_image)
+# If `gcloud` utility is available in your local machine, the next command shows some of the available options
+# gcloud compute images list --standard-images --filter=sles
+# Combine the project and name values. The version part can be ignored to get the latest version
+# BYOS images are usually available using `suse-byos-cloud` and addind `byos` sufix to the nanem
+#os_image = "suse-byos-cloud/sles-15-sp1-sap-byos"
+
 # SSH public key file
 public_key_location = "/path/to/your/public/ssh/key"
 

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -21,39 +21,101 @@ region = "europe-west1"
 # Or to use already existing address ranges
 #ip_cidr_range = ""
 
-# SSH private key file
-private_key_location = "/path/to/your/private/ssh/key"
+#################################
+# General configuration variables
+#################################
+
+# If BYOS images are used in the deployment, SCC registration code is required
+# By default, all the images are PAYG, so these next parameters are not needed
+#reg_code = "<<REG_CODE>>"
+#reg_email = "<<your email>>"
+
+# To add additional modules from SCC. None of them is needed by default
+#reg_additional_modules = {
+#    "sle-module-adv-systems-management/12/x86_64" = ""
+#    "sle-module-containers/12/x86_64" = ""
+#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
+#}
 
 # SSH public key file
 public_key_location = "/path/to/your/public/ssh/key"
 
-# SBD related variables
-# In order to enable SBD, an ISCSI server is needed as right now is the unique option
-# All the clusters will use the same mechanism
-# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
+# SSH private key file
+private_key_location = "/path/to/your/private/ssh/key"
 
-# iSCSI server address
-#iscsi_srv_ip = "10.0.0.253"
-# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
-#iscsi_lun_count = 3
-# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
-#iscsi_disk_size = 10
+# Path to a custom ssh public key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
 
-# Type of VM (vCPUs and RAM)
-machine_type = "n1-highmem-32"
-machine_type_iscsi_server = "custom-1-2048"
+# Path to a custom ssh private key to upload to the nodes
+# Used for cluster communication for example
+cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
+
+##########################
+# Other deployment options
+##########################
+
+# Repository url used to install HA/SAP deployment packages"
+# The latest RPM packages can be found at:
+# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
+# Contains the salt formulas rpm packages.
+# To auto detect the SLE version
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
+# Specific SLE version used in all the created machines
+#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
+#ha_sap_deployment_repo = ""
+
+# Provisioning log level (error by default)
+#provisioning_log_level = "info"
+
+# Enable all some pre deployment steps (disabled by default)
+pre_deployment = true
+
+# To disable the provisioning process
+#provisioner = ""
+
+# Run provisioner execution in background
+#background = true
+
+# QA variables
+
+# Define if the deployment is using for testing purpose
+# Disable all extra packages that do not come from the image
+# Except salt-minion (for the moment) and salt formulas
+# true or false (default)
+#qa_mode = false
+
+# Execute HANA Hardware Configuration Check Tool to bench filesystems
+# qa_mode must be set to true for executing hwcct
+# true or false (default)
+#hwcct = false
+
+#########################
+# HANA machines variables
+#########################
+
+# HANA machine type
+#machine_type = "n1-highmem-32"
+
+# Custom sles4sap image
+# HANA machines image. By default, PAYG image is used (it will select the latest version that matches this name)
+# If `gcloud` utility is available in your local machine, the next command shows some of the available options
+# gcloud compute images list --standard-images --filter=sles
+# Combine the project and name values. The version part can be ignored to get the latest version
+# BYOS images are usually available using `suse-byos-cloud` and addind `byos` sufix to the nanem
+#sles4sap_boot_image = "suse-byos-cloud/sles-15-sp1-sap-byos"
 
 # Disk type for HANA
-hana_data_disk_type = "pd-ssd"
+#hana_data_disk_type = "pd-ssd"
 
 # Disk size for HANA in GB
-hana_data_disk_size = "834"
+#hana_data_disk_size = "834"
 
 # Disk type for HANA backup
-hana_backup_disk_type = "pd-standard"
+#hana_backup_disk_type = "pd-standard"
 
 # Disk size for HANA backup in GB
-hana_backup_disk_size = "416"
+#hana_backup_disk_size = "416"
 
 # HANA cluster vip
 #hana_cluster_vip = "10.0.1.200"
@@ -101,51 +163,33 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # at hana_extract_dir (optional, by default /sapmedia_extract/HANA). This folder cannot be the same as `hana_inst_folder`!
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
-# Custom sles4sap image
-sles4sap_boot_image = "MySles4SapImage"
-
-# Path to a custom ssh public key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_pub = "salt://sshkeys/cluster.id_rsa.pub"
-
-# Path to a custom ssh private key to upload to the nodes
-# Used for cluster communication for example
-cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
-
 # Each host IP address (sequential order).
 #hana_ips = ["10.0.0.2", "10.0.0.3"]
-
-# Repository url used to install HA/SAP deployment packages"
-# The latest RPM packages can be found at:
-# https://download.opensuse.org/repositories/network:/ha-clustering:/Factory/{YOUR OS VERSION}
-# Contains the salt formulas rpm packages.
-# To auto detect the SLE version
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
-# Specific SLE version used in all the created machines
-#ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-ha_sap_deployment_repo = ""
-
-# Optional SUSE Customer Center Registration parameters
-#reg_code = "<<REG_CODE>>"
-#reg_email = "<<your email>>"
-
-# For any sle12 version the additional module sle-module-adv-systems-management/12/x86_64 is mandatory if reg_code is provided
-#reg_additional_modules = {
-#    "sle-module-adv-systems-management/12/x86_64" = ""
-#    "sle-module-containers/12/x86_64" = ""
-#    "sle-ha-geo/12.4/x86_64" = "<<REG_CODE>>"
-#}
 
 # Cost optimized scenario
 #scenario_type: "cost-optimized"
 
-# To disable the provisioning process
-#provisioner = ""
+#######################
+# SBD related variables
+#######################
 
-# Run provisioner execution in background
-#background = true
+# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# All the clusters will use the same mechanism
+# In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
 
-# Monitoring variables
+# iSCSI server address
+#iscsi_srv_ip = "10.0.0.253"
+# Number of LUN (logical units) to serve with the iscsi server. Each LUN can be used as a unique sbd disk
+#iscsi_lun_count = 3
+# Disk size in GB used to create the LUNs and partitions to be served by the ISCSI service
+#iscsi_disk_size = 10
+
+# Type of VM (vCPUs and RAM)
+#machine_type_iscsi_server = "custom-1-2048"
+
+##############################
+# Monitoring related variables
+##############################
 
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
@@ -153,27 +197,17 @@ ha_sap_deployment_repo = ""
 # IP address of the machine where Prometheus and Grafana are running
 #monitoring_srv_ip = "10.0.0.4"
 
-# QA variables
-
-# Define if the deployment is using for testing purpose
-# Disable all extra packages that do not come from the image
-# Except salt-minion (for the moment) and salt formulas
-# true or false (default)
-#qa_mode = false
-
-# Execute HANA Hardware Configuration Check Tool to bench filesystems
-# qa_mode must be set to true for executing hwcct
-# true or false (default)
-#hwcct = false
-
-# drbd related variables
+########################
+# DRBD related variables
+########################
 
 # Enable drbd cluster
 #drbd_enabled = true
 
 #drbd_machine_type = n1-standard-4
 
-#drbd_image = suse-byos-cloud/sles-15-sap-byos
+# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
+#drbd_image = suse-byos-cloud/sles-15-sp2-sap-byos
 
 #drbd_data_disk_size = 15
 
@@ -186,14 +220,17 @@ ha_sap_deployment_repo = ""
 # Enable SBD for the drbd cluster
 #drbd_cluster_sbd_enabled = true
 
-# netweaver related variables
+#############################
+# Netweaver related variables
+#############################
 
 # Enable netweaver cluster
 #netweaver_enabled = true
 
 #netweaver_machine_type = n1-standard-4
 
-#netweaver_image = suse-byos-cloud/sles-15-sap-byos
+# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
+#netweaver_image = suse-byos-cloud/sles-15-sp2-sap-byos
 
 # This storage bucket must contain the next software (select the version you want to install of course)
 #SWPM - `IND:SLTOOLSET:2.0:SWPM:*:LINUX_X86_64:*x`
@@ -231,8 +268,3 @@ ha_sap_deployment_repo = ""
 
 # Enable SBD for the netweaver cluster
 #netweaver_cluster_sbd_enabled = true
-
-# Pre deployment
-
-# Enable all some pre deployment steps (disabled by default)
-#pre_deployment = true

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -25,7 +25,7 @@ region = "europe-west1"
 # General configuration variables
 #################################
 
-# If BYOS images are used in the deployment, SCC registration code is required
+# If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
 # By default, all the images are PAYG, so these next parameters are not needed
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
@@ -75,7 +75,7 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
-# Enable all some pre deployment steps (disabled by default)
+# Enable pre deployment steps (disabled by default)
 pre_deployment = true
 
 # To disable the provisioning process
@@ -86,7 +86,7 @@ pre_deployment = true
 
 # QA variables
 
-# Define if the deployment is using for testing purpose
+# Define if the deployment is used for testing purpose
 # Disable all extra packages that do not come from the image
 # Except salt-minion (for the moment) and salt formulas
 # true or false (default)
@@ -110,7 +110,7 @@ pre_deployment = true
 # gcloud compute images list --standard-images --filter=sles
 # Combine the project and name values. The version part can be ignored to get the latest version
 # BYOS images are usually available using `suse-byos-cloud` and addind `byos` sufix to the nanem
-#sles4sap_boot_image = "suse-byos-cloud/sles-15-sp1-sap-byos"
+#hana_os_image = "suse-byos-cloud/sles-15-sp1-sap-byos"
 
 # Disk type for HANA
 #hana_data_disk_type = "pd-ssd"
@@ -180,9 +180,12 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # SBD related variables
 #######################
 
-# In order to enable SBD, an ISCSI server is needed as right now is the unique option
+# In order to enable SBD, an ISCSI server is needed as right now is the only option
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation sbd_enabled must be set to true for any of the clusters
+
+# iSCSI server image. By default, PAYG image is used. The usage is the same as the HANA images
+#iscsi_os_image = suse-byos-cloud/sles-15-sp2-sap-byos
 
 # iSCSI server address
 #iscsi_srv_ip = "10.0.0.253"
@@ -201,6 +204,9 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
+# Monitoring server image. By default, PAYG image is used. The usage is the same as the HANA images
+#monitoring_os_image = suse-byos-cloud/sles-15-sp2-sap-byos
+
 # IP address of the machine where Prometheus and Grafana are running
 #monitoring_srv_ip = "10.0.0.4"
 
@@ -213,8 +219,8 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 #drbd_machine_type = n1-standard-4
 
-# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
-#drbd_image = suse-byos-cloud/sles-15-sp2-sap-byos
+# DRBD machines image. By default, PAYG image is used. The usage is the same as the HANA images
+#drbd_os_image = suse-byos-cloud/sles-15-sp2-sap-byos
 
 #drbd_data_disk_size = 15
 
@@ -236,8 +242,8 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 #netweaver_machine_type = n1-standard-4
 
-# DRBD machines image. By default, PAYG image is used. The usage is the same than the HANA images
-#netweaver_image = suse-byos-cloud/sles-15-sp2-sap-byos
+# Netweaver machines image. By default, PAYG image is used. The usage is the same as the HANA images
+#netweaver_os_image = suse-byos-cloud/sles-15-sp2-sap-byos
 
 # This storage bucket must contain the next software (select the version you want to install of course)
 #SWPM - `IND:SLTOOLSET:2.0:SWPM:*:LINUX_X86_64:*x`

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -51,6 +51,12 @@ variable "private_key_location" {
 
 # Deployment variables
 
+variable "os_image" {
+  description = "Default OS image for all the machines. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
+  type        = string
+  default     = "suse-sap-cloud/sles-15-sp2-sap"
+}
+
 variable "timezone" {
   description = "Timezone setting for all VMs"
   default     = "Europe/Berlin"
@@ -138,10 +144,10 @@ variable "machine_type" {
   default     = "n1-highmem-32"
 }
 
-variable "sles4sap_boot_image" {
+variable "hana_os_image" {
   description = "The image used to create the hana machines"
   type        = string
-  default     = "suse-sap-cloud/sles-15-sp2-sap"
+  default     = ""
 }
 
 variable "hana_ips" {
@@ -256,6 +262,13 @@ variable "monitoring_srv_ip" {
   type        = string
   default     = ""
 }
+
+variable "monitoring_os_image" {
+  description = "The image used to create the monitoring machines"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "Enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool
@@ -275,10 +288,10 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
-variable "iscsi_server_boot_image" {
+variable "iscsi_os_image" {
   description = "The image used to create the iscsi machines"
   type        = string
-  default     = "suse-sap-cloud/sles-15-sp2-sap"
+  default     = ""
 }
 
 variable "machine_type_iscsi_server" {
@@ -318,10 +331,10 @@ variable "drbd_machine_type" {
   default     = "n1-standard-4"
 }
 
-variable "drbd_image" {
+variable "drbd_os_image" {
   description = "The image used to create the drbd machines"
   type        = string
-  default     = "suse-sap-cloud/sles-15-sp2-sap"
+  default     = ""
 }
 
 variable "drbd_data_disk_size" {
@@ -368,10 +381,10 @@ variable "netweaver_machine_type" {
   default     = "n1-highmem-8"
 }
 
-variable "netweaver_image" {
+variable "netweaver_os_image" {
   description = "The image used to create the netweaver machines"
   type        = string
-  default     = "suse-sap-cloud/sles-15-sp2-sap"
+  default     = ""
 }
 
 variable "netweaver_software_bucket" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -141,7 +141,7 @@ variable "machine_type" {
 variable "sles4sap_boot_image" {
   description = "The image used to create the hana machines"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sp1-sap-byos"
+  default     = "suse-sap-cloud/sles-15-sp2-sap"
 }
 
 variable "hana_ips" {
@@ -278,7 +278,7 @@ variable "sbd_storage_type" {
 variable "iscsi_server_boot_image" {
   description = "The image used to create the iscsi machines"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sp1-sap-byos"
+  default     = "suse-sap-cloud/sles-15-sp2-sap"
 }
 
 variable "machine_type_iscsi_server" {
@@ -321,7 +321,7 @@ variable "drbd_machine_type" {
 variable "drbd_image" {
   description = "The image used to create the drbd machines"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sp1-sap-byos"
+  default     = "suse-sap-cloud/sles-15-sp2-sap"
 }
 
 variable "drbd_data_disk_size" {
@@ -371,7 +371,7 @@ variable "netweaver_machine_type" {
 variable "netweaver_image" {
   description = "The image used to create the netweaver machines"
   type        = string
-  default     = "suse-byos-cloud/sles-15-sp1-sap-byos"
+  default     = "suse-sap-cloud/sles-15-sp2-sap"
 }
 
 variable "netweaver_software_bucket" {

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -49,7 +49,7 @@ mount_swpm:
 {{ download_from_google_storage(
   grains['gcp_credentials_file'],
   grains['netweaver_software_bucket'],
-  sapcd) }}
+  grains['netweaver_inst_folder']) }}
 
 {% elif grains['provider'] == 'aws' %}
 


### PR DESCRIPTION
Some new implementations to the mechanism used to select the OS image for the machines.

It brings:

- Use PAYG images by default. We receive some issues because the users use default values (BYOS) and they don't have (or don't use) the registration code. For newcomers (or the most standard user), PAYG are better.
- Create new os_image variable as default OS image. Right now, we need to set the OS image for all of the nodes (hana, iscsi, etc). As most of the users will use the same OS for all the machines, having this option makes things easier, as you only need to change 1 variable. Specific customization is still possible of course.
- Unify naming. Now, all the variables for all providers follow the same syntax (`*_os_image).
- Change how Azure images are selected. I think that is easier to only have unique variable, instead of 4, that can be obtained from CLI commands output
- Reformat the terraform.tfvars.example to be more informative (I think I will split this file in terraform.tfvars.example.basic and terraform.tfvars.example.advanced in the future)

FYI @peteratsuse