### PR TITLE
Make iscsi initiator state idempotent

### DIFF
--- a/salt/cluster_node/ha/iscsi_initiator.sls
+++ b/salt/cluster_node/ha/iscsi_initiator.sls
@@ -45,6 +45,7 @@ iscsi:
 iscsi_discovery:
   cmd.run:
     - name: until iscsiadm -m discovery -t st -p "{{ grains['iscsi_srv_ip'] }}:3260" -l -o new;do sleep 10;done
+    - unless: iscsiadm -m session
     - output_loglevel: quiet
     - hide_output: True
     - timeout: 2400


### PR DESCRIPTION
The re-provisioning of `predeployment` fails if we use `iscsi` as the `iscsiadm` command already finds an existing session.
This `unless` command will check this, and ignore the state if a session is on place