### PR TITLE
Update /mnt and NW sid usage by a variable

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -93,6 +93,8 @@ module "drbd_node" {
   cluster_ssh_pub       = var.cluster_ssh_pub
   cluster_ssh_key       = var.cluster_ssh_key
   iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  nfs_mounting_point    = var.drbd_nfs_mounting_point
+  nfs_export_name       = var.netweaver_sid
   on_destroy_dependencies = [
     aws_route.public,
     aws_security_group_rule.ssh,
@@ -144,6 +146,7 @@ module "netweaver_node" {
   aws_access_key_id         = var.aws_access_key_id
   aws_secret_access_key     = var.aws_secret_access_key
   s3_bucket                 = var.netweaver_s3_bucket
+  netweaver_sid             = var.netweaver_sid
   netweaver_product_id      = var.netweaver_product_id
   netweaver_inst_folder     = var.netweaver_inst_folder
   netweaver_extract_dir     = var.netweaver_extract_dir
@@ -152,7 +155,7 @@ module "netweaver_node" {
   netweaver_swpm_sar        = var.netweaver_swpm_sar
   netweaver_sapexe_folder   = var.netweaver_sapexe_folder
   netweaver_additional_dvds = var.netweaver_additional_dvds
-  netweaver_nfs_share       = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : "${join("", aws_efs_file_system.netweaver-efs.*.dns_name)}:"
+  netweaver_nfs_share       = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : "${join("", aws_efs_file_system.netweaver-efs.*.dns_name)}:"
   hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   host_ips                  = local.netweaver_ips
   virtual_host_ips          = local.netweaver_virtual_ips

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -41,6 +41,8 @@ sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
+nfs_mounting_point: ${var.nfs_mounting_point}
+nfs_export_name: ${var.nfs_export_name}
 partitions:
   1:
     start: 0%

--- a/aws/modules/drbd_node/variables.tf
+++ b/aws/modules/drbd_node/variables.tf
@@ -131,3 +131,13 @@ variable "os_owner" {
   description = "OS image owner"
   type        = string
 }
+
+variable "nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+}
+
+variable "nfs_export_name" {
+  description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
+  type        = string
+}

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -41,6 +41,7 @@ sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 1
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+netweaver_sid: ${var.netweaver_sid}
 ascs_instance_number: ${var.ascs_instance_number}
 ers_instance_number: ${var.ers_instance_number}
 pas_instance_number: ${var.pas_instance_number}

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -156,6 +156,12 @@ variable "virtual_host_ips" {
   default     = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
 }
 
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
+}
+
 variable "ascs_instance_number" {
   description = "ASCS instance number"
   type        = string

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -232,6 +232,10 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #drbd_ips = ["10.0.5.20", "10.0.6.21"]
 #drbd_cluster_vip = "192.168.1.20"
 
+# NFS share mounting point and export. Warning: Since cloud images are using cloud-init, /mnt folder cannot be used as standard mounting point folder
+# If DRBD is used, it will create the NFS export in /mnt_permanent/sapdata/{netweaver_sid} to be connected as {drbd_cluster_vip}:/{netwaever_sid} (e.g.: )192.168.1.20:/HA1
+#drbd_nfs_mounting_point = "/mnt_permanent/sapdata"
+
 #############################
 # Netweaver related variables
 #############################
@@ -247,6 +251,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #netweaver_efs_performance_mode = "generalPurpose"
 #netweaver_ips = ["10.0.2.7", "10.0.3.8", "10.0.2.9", "10.0.3.10"]
 #netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
+
+# Netweaver system identifier
+#netweaver_sid = "HA1"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers
 # Set to false to only create a ASCS and PAS instances

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -337,6 +337,12 @@ variable "drbd_cluster_sbd_enabled" {
   default     = false
 }
 
+variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+  default     = "/mnt_permanent/sapdata"
+}
+
 # SBD related variables
 # In order to enable SBD, an ISCSI server is needed as right now is the unique option
 # All the clusters will use the same mechanism
@@ -477,6 +483,12 @@ variable "netweaver_cluster_sbd_enabled" {
   description = "Enable sbd usage in the netweaver HA cluster"
   type        = bool
   default     = false
+}
+
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
 }
 
 variable "netweaver_product_id" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -86,6 +86,8 @@ module "drbd_node" {
   sbd_enabled         = var.drbd_cluster_sbd_enabled
   sbd_storage_type    = var.sbd_storage_type
   iscsi_srv_ip        = join("", module.iscsi_server.iscsisrv_ip)
+  nfs_mounting_point  = var.drbd_nfs_mounting_point
+  nfs_export_name     = var.netweaver_sid
   drbd_cluster_vip    = local.drbd_cluster_vip
 }
 
@@ -114,6 +116,7 @@ module "netweaver_node" {
   cluster_ssh_pub             = var.cluster_ssh_pub
   cluster_ssh_key             = var.cluster_ssh_key
   admin_user                  = var.admin_user
+  netweaver_sid               = var.netweaver_sid
   netweaver_product_id        = var.netweaver_product_id
   netweaver_inst_folder       = var.netweaver_inst_folder
   netweaver_extract_dir       = var.netweaver_extract_dir
@@ -122,7 +125,7 @@ module "netweaver_node" {
   netweaver_swpm_sar          = var.netweaver_swpm_sar
   netweaver_sapexe_folder     = var.netweaver_sapexe_folder
   netweaver_additional_dvds   = var.netweaver_additional_dvds
-  netweaver_nfs_share         = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : var.netweaver_nfs_share
+  netweaver_nfs_share         = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   storage_account_name        = var.netweaver_storage_account_name
   storage_account_key         = var.netweaver_storage_account_key
   storage_account_path        = var.netweaver_storage_account

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -33,6 +33,8 @@ sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+nfs_mounting_point: ${var.nfs_mounting_point}
+nfs_export_name: ${var.nfs_export_name}
 partitions:
   1:
     start: 0%

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -114,3 +114,13 @@ variable "drbd_cluster_vip" {
   description = "Virtual ip for the drbd cluster"
   type        = string
 }
+
+variable "nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+}
+
+variable "nfs_export_name" {
+  description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
+  type        = string
+}

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -35,6 +35,7 @@ sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 1
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+netweaver_sid: ${var.netweaver_sid}
 ascs_instance_number: ${var.ascs_instance_number}
 ers_instance_number: ${var.ers_instance_number}
 pas_instance_number: ${var.pas_instance_number}

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -87,6 +87,12 @@ variable "data_disk_caching" {
   default = "ReadWrite"
 }
 
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
+}
+
 variable "ascs_instance_number" {
   description = "ASCS instance number"
   type        = string

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -249,6 +249,10 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # Enable SBD for the drbd cluster
 #drbd_cluster_sbd_enabled = true
 
+# NFS share mounting point and export. Warning: Since cloud images are using cloud-init, /mnt folder cannot be used as standard mounting point folder
+# It will create the NFS export in /mnt_permanent/sapdata/{netweaver_sid} to be connected as {drbd_cluster_vip}:/{netwaever_sid} (e.g.: )192.168.1.20:/HA1
+#drbd_nfs_mounting_point = "/mnt_permanent/sapdata"
+
 #############################
 # Netweaver related variables
 #############################
@@ -264,6 +268,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # If the addresses are not set they will be auto generated from the provided vnet address range
 #netweaver_ips = ["10.74.1.30", "10.74.1.31", "10.74.1.32", "10.74.1.33"]
 #netweaver_virtual_ips = ["10.74.1.35", "10.74.1.36", "10.74.1.37", "10.74.1.38"]
+
+# Netweaver system identifier
+#netweaver_sid = "HA1"
 
 # Enabling this option will create a ASCS/ERS HA available cluster
 #netweaver_ha_enabled = true

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -438,6 +438,12 @@ variable "drbd_cluster_sbd_enabled" {
   default     = true
 }
 
+variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+  default     = "/mnt_permanent/sapdata"
+}
+
 # Netweaver related variables
 
 variable "netweaver_enabled" {
@@ -546,6 +552,12 @@ variable "netweaver_storage_account" {
   description = "Azure storage account path"
   type        = string
   default     = ""
+}
+
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
 }
 
 variable "netweaver_product_id" {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -83,6 +83,8 @@ module "drbd_node" {
   iscsi_srv_ip         = module.iscsi_server.iscsisrv_ip
   cluster_ssh_pub      = var.cluster_ssh_pub
   cluster_ssh_key      = var.cluster_ssh_key
+  nfs_mounting_point   = var.drbd_nfs_mounting_point
+  nfs_export_name      = var.netweaver_sid
   on_destroy_dependencies = [
     google_compute_firewall.ha_firewall_allow_tcp
   ]
@@ -105,6 +107,7 @@ module "netweaver_node" {
   iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
+  netweaver_sid             = var.netweaver_sid
   netweaver_product_id      = var.netweaver_product_id
   netweaver_software_bucket = var.netweaver_software_bucket
   netweaver_inst_folder     = var.netweaver_inst_folder
@@ -114,7 +117,7 @@ module "netweaver_node" {
   netweaver_swpm_sar        = var.netweaver_swpm_sar
   netweaver_sapexe_folder   = var.netweaver_sapexe_folder
   netweaver_additional_dvds = var.netweaver_additional_dvds
-  netweaver_nfs_share       = "${local.drbd_cluster_vip}:/HA1"
+  netweaver_nfs_share       = "${local.drbd_cluster_vip}:/${var.netweaver_sid}"
   ha_enabled                = var.netweaver_ha_enabled
   hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   virtual_host_ips          = local.netweaver_virtual_ips

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -32,6 +32,8 @@ sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+nfs_mounting_point: ${var.nfs_mounting_point}
+nfs_export_name: ${var.nfs_export_name}
 vpc_network_name: ${var.network_name}
 route_name: ${google_compute_route.drbd-route[0].name}
 partitions:

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -92,6 +92,16 @@ variable "cluster_ssh_key" {
   type        = string
 }
 
+variable "nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+}
+
+variable "nfs_export_name" {
+  description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
+  type        = string
+}
+
 variable "on_destroy_dependencies" {
   description = "Resources objects need in the on_destroy script (everything that allows ssh connection)"
   type        = any

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -43,6 +43,7 @@ sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 1
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 netweaver_software_bucket: ${var.netweaver_software_bucket}
+netweaver_sid: ${var.netweaver_sid}
 ascs_instance_number: ${var.ascs_instance_number}
 ers_instance_number: ${var.ers_instance_number}
 pas_instance_number: ${var.pas_instance_number}

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -87,6 +87,12 @@ variable "netweaver_software_bucket" {
   type        = string
 }
 
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
+}
+
 variable "ascs_instance_number" {
   description = "ASCS instance number"
   type        = string

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -233,6 +233,10 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # Enable SBD for the drbd cluster
 #drbd_cluster_sbd_enabled = true
 
+# NFS share mounting point and export. Warning: Since cloud images are using cloud-init, /mnt folder cannot be used as standard mounting point folder
+# It will create the NFS export in /mnt_permanent/sapdata/{netweaver_sid} to be connected as {drbd_cluster_vip}:/{netwaever_sid} (e.g.: )192.168.1.20:/HA1
+#drbd_nfs_mounting_point = "/mnt_permanent/sapdata"
+
 #############################
 # Netweaver related variables
 #############################
@@ -269,6 +273,9 @@ sap_hana_deployment_bucket = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 #netweaver_ips = ["10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23"]
 
 #netweaver_virtual_ips = ["10.0.1.25", "10.0.1.26", "10.0.0.27", "10.0.0.28"]
+
+# Netweaver system identifier
+#netweaver_sid = "HA1"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers
 # Set to false to only create a ASCS and PAS instances

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -367,6 +367,12 @@ variable "drbd_cluster_sbd_enabled" {
   default     = false
 }
 
+variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+  default     = "/mnt_permanent/sapdata"
+}
+
 # Netweaver related variables
 
 variable "netweaver_enabled" {
@@ -409,6 +415,12 @@ variable "netweaver_cluster_sbd_enabled" {
   description = "Enable sbd usage in the netweaver HA cluster"
   type        = bool
   default     = false
+}
+
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
 }
 
 variable "netweaver_product_id" {

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -125,6 +125,8 @@ module "drbd_node" {
   isolated_network_id   = local.internal_network_id
   isolated_network_name = local.internal_network_name
   storage_pool          = var.storage_pool
+  nfs_mounting_point    = var.drbd_nfs_mounting_point
+  nfs_export_name       = var.netweaver_sid
 }
 
 module "monitoring" {
@@ -166,6 +168,7 @@ module "netweaver_node" {
   shared_disk_id            = module.netweaver_shared_disk.id
   iscsi_srv_ip              = module.iscsi_server.output_data.private_addresses.0
   hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
+  netweaver_sid             = var.netweaver_sid
   netweaver_product_id      = var.netweaver_product_id
   netweaver_inst_media      = var.netweaver_inst_media
   netweaver_inst_folder     = var.netweaver_inst_folder
@@ -175,6 +178,6 @@ module "netweaver_node" {
   netweaver_swpm_sar        = var.netweaver_swpm_sar
   netweaver_sapexe_folder   = var.netweaver_sapexe_folder
   netweaver_additional_dvds = var.netweaver_additional_dvds
-  netweaver_nfs_share       = var.drbd_enabled ? "${local.drbd_cluster_vip}:/HA1" : var.netweaver_nfs_share
+  netweaver_nfs_share       = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   ha_enabled                = var.netweaver_ha_enabled
 }

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -32,6 +32,8 @@ sbd_storage_type: ${var.sbd_storage_type}
 sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/vdc" : ""}"
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
+nfs_mounting_point: ${var.nfs_mounting_point}
+nfs_export_name: ${var.nfs_export_name}
 partitions:
   1:
     start: 0%

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -37,6 +37,16 @@ variable "drbd_cluster_vip" {
   type        = string
 }
 
+variable "nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+}
+
+variable "nfs_export_name" {
+  description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
+  type        = string
+}
+
 variable "sbd_enabled" {
   description = "Enable sbd usage in the HA cluster"
   type        = bool

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -28,6 +28,7 @@ virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 hana_ip: ${var.hana_ip}
 ha_enabled: ${var.ha_enabled}
+netweaver_sid: ${var.netweaver_sid}
 netweaver_product_id: ${var.netweaver_product_id}
 netweaver_inst_media: ${var.netweaver_inst_media}
 netweaver_inst_folder: ${var.netweaver_inst_folder}

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -113,6 +113,12 @@ variable "netweaver_nfs_share" {
   type        = string
 }
 
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
+}
+
 variable "ascs_instance_number" {
   description = "ASCS instance number"
   type        = string

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -157,6 +157,10 @@ ha_sap_deployment_repo = ""
 # IP addresses of the machines hosting Netweaver instances
 #netweaver_ips = ["192.168.XXX.Y+2", "192.168.XXX.Y+3", "192.168.XXX.Y+4", "192.168.XXX.Y+5"]
 #netweaver_virtual_ips = ["192.168.XXX.Y+6", "192.168.XXX.Y+7", "192.168.XXX.Y+8", "192.168.XXX.Y+9"]
+
+# Netweaver system identifier
+#netweaver_sid = "HA1"
+
 # Enable SBD for the netweaver cluster
 #netweaver_cluster_sbd_enabled = true
 
@@ -168,6 +172,10 @@ ha_sap_deployment_repo = ""
 
 # Enable SBD for the drbd cluster
 #drbd_cluster_sbd_enabled = true
+
+# NFS share mounting point and export. Warning: Since cloud images are using cloud-init, /mnt folder cannot be used as standard mounting point folder
+# It will create the NFS export in /mnt_permanent/sapdata/{netweaver_sid} to be connected as {drbd_cluster_vip}:/{netwaever_sid} (e.g.: )192.168.1.20:/HA1
+#drbd_nfs_mounting_point = "/mnt_permanent/sapdata"
 
 # libvirt storage pool, select the libvirt storage pool where the volume will stored
 

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -368,6 +368,12 @@ variable "netweaver_virtual_ips" {
   default     = []
 }
 
+variable "netweaver_sid" {
+  description = "System identifier of the Netweaver installation (e.g.: HA1 or PRD)"
+  type        = string
+  default     = "HA1"
+}
+
 variable "netweaver_cluster_sbd_enabled" {
   description = "Enable sbd usage in the netweaver HA cluster"
   type        = bool
@@ -495,6 +501,12 @@ variable "drbd_cluster_sbd_enabled" {
   description = "Enable sbd usage in the drbd HA cluster"
   type        = bool
   default     = true
+}
+
+variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+  default     = "/mnt_permanent/sapdata"
 }
 
 #

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -67,7 +67,7 @@ drbd:
       disk: {{ drbd_disk_device }}1
 
       file_system: "xfs"
-      mount_point: "/mnt/sapdata/HA1"
+      mount_point: "{{ grains['nfs_mounting_point'] }}/{{ grains['nfs_export_name'] }}"
       virtual_ip: {{ grains['drbd_cluster_vip'] }}
 
       nodes:

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -8,19 +8,21 @@
 {%- else %}
 {%- set virtual_host_mask = 24 %}
 {%- endif %}
+{%- set sid_lower = grains['netweaver_sid'].lower() %}
+{%- set sid_upper = grains['netweaver_sid'].upper() %}
 
 netweaver:
   {%- set app_start_index = 2 if grains['ha_enabled'] else 1 %}
   {%- set app_server_count = grains['app_server_count']|default(2) %}
   virtual_addresses:
-    {{ grains['virtual_host_ips'][0] }}: sapha1as
+    {{ grains['virtual_host_ips'][0] }}: sap{{ sid_lower }}as
     {%- if grains['ha_enabled'] %}
-    {{ grains['virtual_host_ips'][1] }}: sapha1er
+    {{ grains['virtual_host_ips'][1] }}: sap{{ sid_lower }}er
     {%- endif %}
     {%- if app_server_count > 0 %}
-    {{ grains['virtual_host_ips'][app_start_index] }}: sapha1pas
+    {{ grains['virtual_host_ips'][app_start_index] }}: sap{{ sid_lower }}pas
     {%- for index in range(app_server_count-1) %}
-    {{ grains['virtual_host_ips'][loop.index+app_start_index] }}: sapha1aas{{ loop.index }}
+    {{ grains['virtual_host_ips'][loop.index+app_start_index] }}: sap{{ sid_lower }}aas{{ loop.index }}
     {%- endfor %}
     {%- endif %}
 
@@ -74,10 +76,10 @@ netweaver:
 
   nodes:
     - host: {{ grains['name_prefix'] }}01
-      virtual_host: sapha1as
+      virtual_host: sap{{ sid_lower }}as
       virtual_host_interface: {{ virtual_host_interface }}
       virtual_host_mask: {{ virtual_host_mask }}
-      sid: HA1
+      sid: {{ sid_upper }}
       instance: {{ '{:0>2}'.format(grains['ascs_instance_number']) }}
       root_user: root
       root_password: linux
@@ -91,10 +93,10 @@ netweaver:
 
     {% if grains['ha_enabled'] %}
     - host: {{ grains['name_prefix'] }}02
-      virtual_host: sapha1er
+      virtual_host: sap{{ sid_lower }}er
       virtual_host_interface: {{ virtual_host_interface }}
       virtual_host_mask: {{ virtual_host_mask }}
-      sid: HA1
+      sid: {{ sid_upper }}
       instance: {{ '{:0>2}'.format(grains['ers_instance_number']) }}
       root_user: root
       root_password: linux
@@ -108,21 +110,21 @@ netweaver:
 
     {% if app_server_count > 0 %}
     - host: {{ grains['name_prefix'] }}0{{ app_start_index+1 }}
-      virtual_host: sapha1pas
+      virtual_host: sap{{ sid_lower }}pas
       virtual_host_interface: {{ virtual_host_interface }}
       virtual_host_mask: {{ virtual_host_mask }}
-      sid: HA1
+      sid: {{ sid_upper }}
       instance: '00' # Not used
       root_user: root
       root_password: linux
       sap_instance: db
 
     - host: {{ grains['name_prefix'] }}0{{ app_start_index+1 }}
-      virtual_host: sapha1pas
+      virtual_host: sap{{ sid_lower }}pas
       virtual_host_interface: {{ virtual_host_interface }}
       virtual_host_mask: {{ virtual_host_mask }}
-      ascs_virtual_host: sapha1as
-      sid: HA1
+      ascs_virtual_host: sap{{ sid_lower }}as
+      sid: {{ sid_upper }}
       instance: {{ '{:0>2}'.format(grains['pas_instance_number']) }}
       root_user: root
       root_password: linux
@@ -133,10 +135,10 @@ netweaver:
 
     {%- for index in range(app_server_count-1) %}
     - host: {{ grains['name_prefix'] }}0{{ app_start_index+1+loop.index }}
-      virtual_host: sapha1aas{{ loop.index }}
+      virtual_host: sap{{ sid_lower }}aas{{ loop.index }}
       virtual_host_interface: {{ virtual_host_interface }}
       virtual_host_mask: {{ virtual_host_mask }}
-      sid: HA1
+      sid: {{ sid_upper }}
       instance: {{ '{:0>2}'.format(grains['pas_instance_number']+loop.index) }}
       root_user: root
       root_password: linux

--- a/salt/drbd_node/nfs.sls
+++ b/salt/drbd_node/nfs.sls
@@ -1,6 +1,6 @@
 create_nfs_folder:
   file.directory:
-    - name: /mnt/sapdata
+    - name: {{ grains['nfs_mounting_point'] }}
     - user: root
     - mode: "0755"
     - makedirs: True
@@ -8,7 +8,7 @@ create_nfs_folder:
 
 configure_nfs:
   nfs_export.present:
-    - name: /mnt/sapdata
+    - name: {{ grains['nfs_mounting_point'] }}
     - hosts: '*'
     - options:
       - rw


### PR DESCRIPTION
Fix for https://github.com/SUSE/ha-sap-terraform-deployments/issues/549

As new SUSE cloud images are based in cloud-init, this new approach uses the `/mnt` folder as a swap disk, so we need to make this variable.

Please, propose better names for `/mnt_permanent` if needed

https://docs.microsoft.com/en-us/azure/virtual-machines/linux/using-cloud-init

FYI: @peteratsuse