### PR TITLE
Use disk name instead of device in azure

### DIFF
--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -27,7 +27,7 @@ host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
-drbd_disk_device: /dev/sdc
+drbd_disk_device: /dev/disk/azure/scsi1/lun0
 drbd_cluster_vip: ${var.drbd_cluster_vip}
 sbd_enabled: ${var.sbd_enabled}
 sbd_storage_type: ${var.sbd_storage_type}

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -21,7 +21,7 @@ resource "null_resource" "iscsi_provisioner" {
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
 iscsi_srv_ip: ${element(var.host_ips, count.index)}
-iscsidev: /dev/sdc
+iscsidev: /dev/disk/azure/scsi1/lun0
 ${yamlencode(
   {partitions: {for index in range(var.lun_count) :
     tonumber(index+1) => {


### PR DESCRIPTION
Fix for https://github.com/SUSE/ha-sap-terraform-deployments/issues/548

Azure always use the same disk names, so the name for the storage disk 1st lun always is: `/dev/disk/azure/scsi1/lun0`

Some info here:https://docs.microsoft.com/en-us/azure/virtual-machines/troubleshooting/troubleshoot-device-names-problems
I guess there is more information in Azure docks, but I was not able to find it.

FYI: @peteratsuse