### PR TITLE
[Blue-horizon]: Add groups  for better visualisation

### DIFF
--- a/blue_horizon/azure/sources/variables.tf.json
+++ b/blue_horizon/azure/sources/variables.tf.json
@@ -1,10 +1,5 @@
 {
   "variable": {
-    "azure_region": {
-      "type": "string",
-      "default": "westeurope",
-      "description": "Azure region where the deployment machines will be created <!--[group:azure]-->"
-    },
     "ssh_authorized_keys": {
       "type": "list",
       "description": "List of additional authorized SSH public keys paths to access the created machines with the used admin user <!--[group:hana]-->"
@@ -26,7 +21,12 @@
     "deployment_type": {
       "type": "string",
       "default": "2-tier",
-      "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:azure]-->"
+      "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:hana]-->"
+    },
+    "azure_region": {
+      "type": "string",
+      "default": "westeurope",
+      "description": "Azure region where the deployment machines will be created <!--[group:azure]-->"
     },
     "deployment_size": {
       "type": "string",

--- a/blue_horizon/azure/sources/variables.tf.json
+++ b/blue_horizon/azure/sources/variables.tf.json
@@ -3,7 +3,7 @@
     "azure_region": {
       "type": "string",
       "default": "westeurope",
-      "description": "Azure region where the deployment machines will be created <!--[group:hana]-->"
+      "description": "Azure region where the deployment machines will be created <!--[group:azure]-->"
     },
     "ssh_authorized_keys": {
       "type": "list",
@@ -26,24 +26,24 @@
     "deployment_type": {
       "type": "string",
       "default": "2-tier",
-      "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:hana]-->"
+      "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:azure]-->"
     },
     "deployment_size": {
       "type": "string",
       "default": "demo",
-      "description": "Select the desired deployment size. options=['demo','small','medium','large'].More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:storage]-->"
+      "description": "Select the desired deployment size. options=['demo','small','medium','large'].More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:azure]-->"
     },
     "hana_installation_software_path": {
       "type": "string",
-      "description": "Azure storage account file share where HANA installation platform is available <!--[group:storage]-->"
+      "description": "Azure storage account file share where HANA installation platform is available <!--[group:azure]-->"
     },
     "storage_account_name": {
       "type": "string",
-      "description": "Azure storage account where the file share is located <!--[group:storage]-->"
+      "description": "Azure storage account where the file share is located <!--[group:azure]-->"
     },
     "storage_account_key": {
       "type": "string",
-      "description": "password_key: Azure storage account access key <!--[group:storage]-->"
+      "description": "password_key: Azure storage account access key <!--[group:azure]-->"
     }
   }
 }

--- a/blue_horizon/azure/sources/variables.tf.json
+++ b/blue_horizon/azure/sources/variables.tf.json
@@ -23,15 +23,15 @@
       "default": "2-tier",
       "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:hana]-->"
     },
+    "deployment_size": {
+      "type": "string",
+      "default": "demo",
+      "description": "Select the desired deployment size. options=['demo','small','medium','large'].More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:hana]-->"
+    },
     "azure_region": {
       "type": "string",
       "default": "westeurope",
       "description": "Azure region where the deployment machines will be created <!--[group:azure]-->"
-    },
-    "deployment_size": {
-      "type": "string",
-      "default": "demo",
-      "description": "Select the desired deployment size. options=['demo','small','medium','large'].More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:azure]-->"
     },
     "hana_installation_software_path": {
       "type": "string",

--- a/blue_horizon/azure/sources/variables.tf.json
+++ b/blue_horizon/azure/sources/variables.tf.json
@@ -3,46 +3,47 @@
     "azure_region": {
       "type": "string",
       "default": "westeurope",
-      "description": "Azure region where the deployment machines will be created"
+      "description": "Azure region where the deployment machines will be created <!--[group:hana]-->"
     },
     "ssh_authorized_keys": {
       "type": "list",
-      "description": "List of additional authorized SSH public keys paths to access the created machines with the used admin user"
+      "description": "List of additional authorized SSH public keys paths to access the created machines with the used admin user <!--[group:hana]-->"
     },
     "system_identifier": {
       "type": "string",
       "default": "prd",
-      "description": "HANA system identifier. System identifier must be 3 letters string]"
+      "description": "HANA system identifier. System identifier must be 3 letters string] <!--[group:hana]-->"
     },
     "instance_number": {
       "type": "string",
       "default": "00",
-      "description": "HANA system instance number. Instance number must be 2 digits string]"
+      "description": "HANA system instance number. Instance number must be 2 digits string] <!--[group:hana]-->"
     },
     "sap_admin_password": {
       "type": "string",
-      "description": "SAP administrator password"
+      "description": "SAP administrator password <!--[group:hana]-->"
     },
     "deployment_type": {
       "type": "string",
-      "default": "HA",
-      "description": "Select between HA (SAP HANA system replication and HA capabilities) or non HA deployment. Options=[\"HA\",\"non HA\"]"
+      "default": "2-tier",
+      "description": "Select the desired deployment type. Options=[\"2-tier\",\"2-tier-HA\"]. More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:hana]-->"
     },
-    "instance_type": {
+    "deployment_size": {
       "type": "string",
-      "description": "Only used to create the 'Size cluster' page"
+      "default": "demo",
+      "description": "Select the desired deployment size. options=['demo','small','medium','large'].More information in: https://documentation.suse.com/sbp/all/html/SBP-SAP-AzureSolutionTemplates/index.html <!--[group:storage]-->"
     },
     "hana_installation_software_path": {
       "type": "string",
-      "description": "Azure storage account file share where HANA installation platform is available"
+      "description": "Azure storage account file share where HANA installation platform is available <!--[group:storage]-->"
     },
     "storage_account_name": {
       "type": "string",
-      "description": "Azure storage account where the file share is located"
+      "description": "Azure storage account where the file share is located <!--[group:storage]-->"
     },
     "storage_account_key": {
       "type": "string",
-      "description": "password_key: Azure storage account access key"
+      "description": "password_key: Azure storage account access key <!--[group:storage]-->"
     }
   }
 }


### PR DESCRIPTION
# Description:

This pr add possibility to group variable in groups which are visualized in different frames.

I prefer the `hana and azure` combination. I think having 2 categories is most ordered and simple approach

# Possible grouping:

##  1)  Hana and Azure:

![image](https://user-images.githubusercontent.com/10886597/96604546-86a24100-12f5-11eb-8238-7d97690dea81.png)



## 2)  Hana and Storage:

![image](https://user-images.githubusercontent.com/10886597/96602771-a6386a00-12f3-11eb-93ed-cb6efbf98a40.png)



## 3) Additional data, Hana, Azure 

![image](https://user-images.githubusercontent.com/10886597/96606498-a175b500-12f7-11eb-93a4-bcb2cdd44521.png)

