### PR TITLE
Fix ssh keys usage in libvirt to avoid empty strings

### DIFF
--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -1,9 +1,10 @@
 locals {
-  public_key      = fileexists(var.public_key) ? file(var.public_key) : var.public_key
-  private_key     = fileexists(var.private_key) ? file(var.private_key) : var.private_key
+  # fileexists doesn't work properly with empty strings ("")
+  public_key      = var.public_key != "" ? (fileexists(var.public_key) ? file(var.public_key) : var.public_key) : ""
+  private_key     = var.private_key != "" ? (fileexists(var.private_key) ? file(var.private_key) : var.private_key) : ""
   authorized_keys = join(", ", formatlist("\"%s\"",
     concat(
-      [trimspace(local.public_key)],
+      local.public_key != "" ? [trimspace(local.public_key)] : [],
       [for key in var.authorized_keys: trimspace(fileexists(key) ? file(key) : key)])
     )
   )


### PR DESCRIPTION
Fix the SSH keys logic in Libvirt, as I removed the correct logic accidentally.
It looks like terraform's `fileexists` doesn't work properly with empty strings `""` raising an error:

```
  on ../generic_modules/common_variables/outputs.tf line 2, in locals:
   2:   public_key      = fileexists(var.public_key) ? file(var.public_key) : var.public_key
    |----------------
    | var.public_key is ""

Call to function "fileexists" failed: . is not a regular file, but
"drwxr-xr-x".
```

This commit fixes this and the subsequent error as the `authorized_keys` grains was populated with an empty string too:

```
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): [DEBUG   ] LazyLoaded ssh_auth.present
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): [INFO    ] Running state [None] at time 03:42:49.741299
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): [INFO    ] Executing state ssh_auth.present for [None]
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): [DEBUG   ] An exception occurred in this state: expected string or bytes-like object
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): Traceback (most recent call last):
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/state.py", line 1987, in call
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     ret = self.states[cdata['full']](*cdata['args'], **cdata['kwargs'])
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2031, in wrapper
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     return f(*args, **kwargs)
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/states/ssh_auth.py", line 278, in present
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     fullkey = sshre.search(name)
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): TypeError: expected string or bytes-like object
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): [ERROR   ] An exception occurred in this state: Traceback (most recent call last):
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/state.py", line 1987, in call
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     ret = self.states[cdata['full']](*cdata['args'], **cdata['kwargs'])
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2031, in wrapper
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     return f(*args, **kwargs)
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):   File "/usr/lib/python3.6/site-packages/salt/states/ssh_auth.py", line 278, in present
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec):     fullkey = sshre.search(name)
module.hana_node.module.hana_provision.null_resource.provision[1] (remote-exec): TypeError: expected string or bytes-like object
```