### PR TITLE
Increate wait_for_initialization to 120 to avoid sporadic errors

### DIFF
--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -8,7 +8,7 @@ cluster:
   interface: eth0
   {% endif %}
   unicast: True
-  wait_for_initialization: 20
+  wait_for_initialization: 120
   join_timeout: 180
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -12,6 +12,7 @@ cluster:
   interface: eth0
   unicast: True
   {% endif %}
+  wait_for_initialization: 120
   join_timeout: 500
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -17,7 +17,7 @@ cluster:
     module: softdog
     device: /dev/watchdog
   {% endif %}
-  wait_for_initialization: 40
+  wait_for_initialization: 120
   {%- if grains['app_server_count']|default(2) == 0 %}
   # join_timeout must be large as the 1st machine where the cluster is started will host
   # the DB and PAS installation, taking a long time


### PR DESCRIPTION
Time to time, the cluster joining process fails because the 1st node is not totally initialized (specially in Azure).
To avoid that, I have set a really conservative time that won't make a big difference in the overall deployment time, but it will avoid these errors.