### PR TITLE
Feature/bastion proxy server

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -251,6 +251,7 @@ module "bastion" {
   source              = "./modules/bastion"
   common_variables    = module.common_variables.configuration
   az_region           = var.az_region
+  os_image            = local.bastion_os_image
   vm_size             = "Standard_B1s"
   resource_group_name = local.resource_group_name
   vnet_name           = local.vnet_name

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -248,15 +248,12 @@ resource "azurerm_network_security_group" "mysecgroup" {
 # Bastion
 
 module "bastion" {
-  bastion_enabled     = var.bastion_enabled
   source              = "./modules/bastion"
+  common_variables    = module.common_variables.configuration
   az_region           = var.az_region
   vm_size             = "Standard_B1s"
   resource_group_name = local.resource_group_name
   vnet_name           = local.vnet_name
-  admin_user          = var.admin_user
-  deployment_name     = local.deployment_name
-  public_key          = var.bastion_public_key != "" ? var.bastion_public_key : var.public_key
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   snet_address_range  = cidrsubnet(local.vnet_address_range, 8, 2)
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -62,7 +62,6 @@ module "common_variables" {
   authorized_keys        = var.authorized_keys
   authorized_user        = var.admin_user
   bastion_enabled        = var.bastion_enabled
-  bastion_host           = module.bastion.public_ip
   bastion_public_key     = var.bastion_public_key
   bastion_private_key    = var.bastion_private_key
   provisioner            = var.provisioner
@@ -76,6 +75,7 @@ module "common_variables" {
 module "drbd_node" {
   source              = "./modules/drbd_node"
   common_variables    = module.common_variables.configuration
+  bastion_host        = module.bastion.public_ip
   az_region           = var.az_region
   drbd_count          = var.drbd_enabled == true ? 2 : 0
   vm_size             = var.drbd_vm_size
@@ -100,6 +100,7 @@ module "drbd_node" {
 module "netweaver_node" {
   source                      = "./modules/netweaver_node"
   common_variables            = module.common_variables.configuration
+  bastion_host                = module.bastion.public_ip
   az_region                   = var.az_region
   xscs_server_count           = local.netweaver_xscs_server_count
   app_server_count            = var.netweaver_enabled ? var.netweaver_app_server_count : 0
@@ -151,6 +152,7 @@ module "netweaver_node" {
 module "hana_node" {
   source                              = "./modules/hana_node"
   common_variables                    = module.common_variables.configuration
+  bastion_host                        = module.bastion.public_ip
   az_region                           = var.az_region
   hana_count                          = var.hana_count
   vm_size                             = var.hana_vm_size
@@ -196,6 +198,7 @@ module "hana_node" {
 module "monitoring" {
   source              = "./modules/monitoring"
   common_variables    = module.common_variables.configuration
+  bastion_host        = module.bastion.public_ip
   monitoring_enabled  = var.monitoring_enabled
   az_region           = var.az_region
   vm_size             = var.monitoring_vm_size
@@ -215,6 +218,7 @@ module "monitoring" {
 module "iscsi_server" {
   source              = "./modules/iscsi_server"
   common_variables    = module.common_variables.configuration
+  bastion_host        = module.bastion.public_ip
   iscsi_count         = local.iscsi_enabled ? 1 : 0
   az_region           = var.az_region
   vm_size             = var.iscsi_vm_size

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -87,7 +87,6 @@ module "drbd_node" {
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
-  admin_user          = var.admin_user
   host_ips            = local.drbd_ips
   fencing_mechanism   = var.drbd_cluster_fencing_mechanism
   sbd_storage_type    = var.sbd_storage_type
@@ -119,7 +118,6 @@ module "netweaver_node" {
   storage_account             = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   cluster_ssh_pub             = var.cluster_ssh_pub
   cluster_ssh_key             = var.cluster_ssh_key
-  admin_user                  = var.admin_user
   hana_ip                     = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   hana_sid                    = var.hana_sid
   hana_instance_number        = var.hana_instance_number
@@ -188,7 +186,6 @@ module "hana_node" {
   cluster_ssh_key                     = var.cluster_ssh_key
   hana_data_disks_configuration       = var.hana_data_disks_configuration
   os_image                            = local.hana_os_image
-  admin_user                          = var.admin_user
   fencing_mechanism                   = var.hana_cluster_fencing_mechanism
   sbd_storage_type                    = var.sbd_storage_type
   iscsi_srv_ip                        = join("", module.iscsi_server.iscsisrv_ip)
@@ -209,7 +206,6 @@ module "monitoring" {
   monitoring_uri      = var.monitoring_uri
   os_image            = local.monitoring_os_image
   monitoring_srv_ip   = local.monitoring_ip
-  admin_user          = var.admin_user
   hana_targets        = concat(local.hana_ips, var.hana_ha_enabled ? [local.hana_cluster_vip] : [local.hana_ips[0]]) # we use the vip for HA scenario and 1st hana machine for non HA to target the active hana instance
   drbd_targets        = var.drbd_enabled ? local.drbd_ips : []
   netweaver_targets   = var.netweaver_enabled ? local.netweaver_virtual_ips : []
@@ -231,5 +227,4 @@ module "iscsi_server" {
   host_ips            = [local.iscsi_ip]
   lun_count           = var.iscsi_lun_count
   iscsi_disk_size     = var.iscsi_disk_size
-  admin_user          = var.admin_user
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -46,6 +46,7 @@ locals {
   monitoring_os_image = var.monitoring_os_image != "" ? var.monitoring_os_image : var.os_image
   drbd_os_image       = var.drbd_os_image != "" ? var.drbd_os_image : var.os_image
   netweaver_os_image  = var.netweaver_os_image != "" ? var.netweaver_os_image : var.os_image
+  bastion_os_image    = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
 }
 
 module "common_variables" {

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -1,6 +1,5 @@
 locals {
-  bastion_enabled = var.bastion_enabled ? 1 : 0
-  public_key      = fileexists(var.public_key) ? file(var.public_key) : var.public_key
+  bastion_enabled = var.common_variables["bastion_enabled"] ? 1 : 0
 }
 
 
@@ -65,7 +64,7 @@ resource "azurerm_network_interface" "bastion" {
   }
 
   tags = {
-    workspace = var.deployment_name
+    workspace = var.common_variables["deployment_name"]
   }
 }
 
@@ -78,7 +77,7 @@ resource "azurerm_public_ip" "bastion" {
   idle_timeout_in_minutes = 30
 
   tags = {
-    workspace = var.deployment_name
+    workspace = var.common_variables["deployment_name"]
   }
 }
 
@@ -108,15 +107,15 @@ resource "azurerm_virtual_machine" "bastion" {
 
   os_profile {
     computer_name  = "vmbastion"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
-      key_data = local.public_key
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
+      key_data = var.common_variables["bastion_public_key"]
     }
   }
 
@@ -126,6 +125,6 @@ resource "azurerm_virtual_machine" "bastion" {
   }
 
   tags = {
-    workspace = var.deployment_name
+    workspace = var.common_variables["deployment_name"]
   }
 }

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -97,6 +97,11 @@ resource "azurerm_public_ip" "bastion" {
   }
 }
 
+module "os_image_reference" {
+  source   = "../../modules/os_image_reference"
+  os_image = var.os_image
+}
+
 resource "azurerm_virtual_machine" "bastion" {
   count                            = local.bastion_enabled
   name                             = "vmbastion"
@@ -115,10 +120,10 @@ resource "azurerm_virtual_machine" "bastion" {
   }
 
   storage_image_reference {
-    publisher = "SUSE"
-    offer     = "sles-sap-15-sp1-byos" # need to change this
-    sku       = "gen2"
-    version   = "latest"
+    publisher = module.os_image_reference.publisher
+    offer     = module.os_image_reference.offer
+    sku       = module.os_image_reference.sku
+    version   = module.os_image_reference.version
   }
 
   os_profile {

--- a/azure/modules/bastion/outputs.tf
+++ b/azure/modules/bastion/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "bastion" {
-  count               = var.bastion_enabled ? 1 : 0
+  count               = local.bastion_enabled
   name                = azurerm_public_ip.bastion[0].name
   resource_group_name = azurerm_virtual_machine.bastion[0].resource_group_name
 }

--- a/azure/modules/bastion/salt_provisioner.tf
+++ b/azure/modules/bastion/salt_provisioner.tf
@@ -34,4 +34,5 @@ module "bastion_provision" {
   private_key          = var.common_variables["bastion_private_key"]
   public_ips           = data.azurerm_public_ip.bastion.*.ip_address
   background           = var.common_variables["background"]
+  reboot               = false
 }

--- a/azure/modules/bastion/salt_provisioner.tf
+++ b/azure/modules/bastion/salt_provisioner.tf
@@ -1,0 +1,37 @@
+locals {
+  salt_enabled      = var.common_variables["provisioner"] == "salt" ? local.bastion_enabled : 0
+  provision_enabled = var.common_variables["monitoring_enabled"] ? local.salt_enabled : 0
+}
+
+resource "null_resource" "bastion_provisioner" {
+  count = local.provision_enabled
+
+  triggers = {
+    bastion_id = join(",", azurerm_virtual_machine.bastion.*.id)
+  }
+
+  connection {
+    host        = element(data.azurerm_public_ip.bastion.*.ip_address, count.index)
+    type        = "ssh"
+    user        = var.common_variables["authorized_user"]
+    private_key = var.common_variables["bastion_private_key"]
+  }
+
+  provisioner "file" {
+    content     = <<EOF
+role: bastion
+${var.common_variables["grains_output"]}
+EOF
+    destination = "/tmp/grains"
+  }
+}
+
+module "bastion_provision" {
+  source               = "../../../generic_modules/salt_provisioner"
+  node_count           = local.provision_enabled
+  instance_ids         = null_resource.bastion_provisioner.*.id
+  user                 = var.common_variables["authorized_user"]
+  private_key          = var.common_variables["bastion_private_key"]
+  public_ips           = data.azurerm_public_ip.bastion.*.ip_address
+  background           = var.common_variables["background"]
+}

--- a/azure/modules/bastion/variables.tf
+++ b/azure/modules/bastion/variables.tf
@@ -1,7 +1,5 @@
-variable "bastion_enabled" {
-  description = "Enable bastion machine creation"
-  type        = bool
-  default     = true
+variable "common_variables" {
+  description = "Output of the common_variables module"
 }
 
 variable "az_region" {
@@ -28,22 +26,6 @@ variable "vnet_name" {
 
 variable "snet_address_range" {
   description = "Subnet address range of the bastion subnet"
-}
-
-variable "deployment_name" {
-  description = "Name used to complement some of the infrastructure resources name as sufix. If it is not provided, the terraform workspace string is used"
-  type        = string
-}
-
-variable "admin_user" {
-  description = "Administration user used to create the machines"
-  type        = string
-  default     = "azadmin"
-}
-
-variable "public_key" {
-  description = "Content of a SSH private key or path to an already existing SSH private key to the bastion"
-  type        = string
 }
 
 variable "storage_account" {

--- a/azure/modules/bastion/variables.tf
+++ b/azure/modules/bastion/variables.tf
@@ -8,6 +8,11 @@ variable "az_region" {
   default = "westeurope"
 }
 
+variable "os_image" {
+  description = "sles4sap image used to create this module machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
+}
+
 variable "vm_size" {
   description = "Bastion machine vm size"
   type        = string

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -210,14 +210,14 @@ resource "azurerm_virtual_machine" "drbd" {
 
   os_profile {
     computer_name  = "vmdrbd0${count.index + 1}"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
       key_data = var.common_variables["public_key"]
     }
   }
@@ -236,7 +236,7 @@ module "drbd_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.drbd_count
   instance_ids         = azurerm_virtual_machine.drbd.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -238,7 +238,7 @@ module "drbd_on_destroy" {
   instance_ids         = azurerm_virtual_machine.drbd.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.drbd]

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -11,7 +11,7 @@ resource "null_resource" "drbd_provisioner" {
     user        = var.admin_user
     private_key = var.common_variables["private_key"]
 
-    bastion_host        = var.common_variables["bastion_host"]
+    bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
@@ -50,7 +50,7 @@ module "drbd_provision" {
   instance_ids         = null_resource.drbd_provisioner.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -8,11 +8,11 @@ resource "null_resource" "drbd_provisioner" {
   connection {
     host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = var.admin_user
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
 
     bastion_host        = var.bastion_host
-    bastion_user        = var.admin_user
+    bastion_user        = var.common_variables["authorized_user"]
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
@@ -48,7 +48,7 @@ module "drbd_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
   instance_ids         = null_resource.drbd_provisioner.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "az_region" {
   type    = string
   default = "westeurope"

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -61,11 +61,6 @@ variable "vm_size" {
   default = "Standard_D2s_v3"
 }
 
-variable "admin_user" {
-  type    = string
-  default = "azadmin"
-}
-
 variable "network_domain" {
   type    = string
   default = "tf.local"

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -257,14 +257,14 @@ resource "azurerm_virtual_machine" "hana" {
 
   os_profile {
     computer_name  = "vm${var.name}0${count.index + 1}"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
       key_data = var.common_variables["public_key"]
     }
   }
@@ -283,7 +283,7 @@ module "hana_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.hana_count
   instance_ids         = azurerm_virtual_machine.hana.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -285,7 +285,7 @@ module "hana_on_destroy" {
   instance_ids         = azurerm_virtual_machine.hana.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.hana]

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -11,7 +11,7 @@ resource "null_resource" "hana_node_provisioner" {
     user        = var.admin_user
     private_key = var.common_variables["private_key"]
 
-    bastion_host        = var.common_variables["bastion_host"]
+    bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
@@ -64,7 +64,7 @@ module "hana_provision" {
   instance_ids         = null_resource.hana_node_provisioner.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -8,11 +8,11 @@ resource "null_resource" "hana_node_provisioner" {
   connection {
     host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = var.admin_user
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
 
     bastion_host        = var.bastion_host
-    bastion_user        = var.admin_user
+    bastion_user        = var.common_variables["authorized_user"]
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
@@ -62,7 +62,7 @@ module "hana_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
   instance_ids         = null_resource.hana_node_provisioner.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "az_region" {
   type    = string
   default = "westeurope"

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -118,11 +118,6 @@ variable "vm_size" {
   default = "Standard_E4s_v3"
 }
 
-variable "admin_user" {
-  type    = string
-  default = "azadmin"
-}
-
 variable "fencing_mechanism" {
   description = "Choose the fencing mechanism for the cluster. Options: sbd"
   type        = string

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -101,14 +101,14 @@ resource "azurerm_virtual_machine" "iscsisrv" {
 
   os_profile {
     computer_name  = "vmiscsisrv"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
       key_data = var.common_variables["public_key"]
     }
   }
@@ -127,7 +127,7 @@ module "iscsi_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.iscsi_count
   instance_ids         = azurerm_virtual_machine.iscsisrv.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -129,7 +129,7 @@ module "iscsi_on_destroy" {
   instance_ids         = azurerm_virtual_machine.iscsisrv.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.iscsisrv]

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -8,11 +8,11 @@ resource "null_resource" "iscsi_provisioner" {
   connection {
     host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = var.admin_user
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
 
     bastion_host        = var.bastion_host
-    bastion_user        = var.admin_user
+    bastion_user        = var.common_variables["authorized_user"]
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
@@ -40,7 +40,7 @@ module "iscsi_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? var.iscsi_count : 0
   instance_ids         = null_resource.iscsi_provisioner.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -11,7 +11,7 @@ resource "null_resource" "iscsi_provisioner" {
     user        = var.admin_user
     private_key = var.common_variables["private_key"]
 
-    bastion_host        = var.common_variables["bastion_host"]
+    bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
@@ -42,7 +42,7 @@ module "iscsi_provision" {
   instance_ids         = null_resource.iscsi_provisioner.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -44,11 +44,6 @@ variable "vm_size" {
   default = "Standard_D2s_v3"
 }
 
-variable "admin_user" {
-  type    = string
-  default = "azadmin"
-}
-
 variable "iscsi_count" {
   description = "Number of iscsi machines to deploy"
   type        = number

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "az_region" {
   type    = string
   default = "westeurope"

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -101,14 +101,14 @@ resource "azurerm_virtual_machine" "monitoring" {
 
   os_profile {
     computer_name  = "vmmonitoring"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
       key_data = var.common_variables["public_key"]
     }
   }
@@ -127,7 +127,7 @@ module "monitoring_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.monitoring_enabled ? 1 : 0
   instance_ids         = azurerm_virtual_machine.monitoring.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -129,7 +129,7 @@ module "monitoring_on_destroy" {
   instance_ids         = azurerm_virtual_machine.monitoring.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.monitoring]

--- a/azure/modules/monitoring/salt_provisioner.tf
+++ b/azure/modules/monitoring/salt_provisioner.tf
@@ -8,11 +8,11 @@ resource "null_resource" "monitoring_provisioner" {
   connection {
     host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = var.admin_user
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
 
     bastion_host        = var.bastion_host
-    bastion_user        = var.admin_user
+    bastion_user        = var.common_variables["authorized_user"]
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
@@ -38,7 +38,7 @@ module "monitoring_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
   instance_ids         = null_resource.monitoring_provisioner.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/monitoring/salt_provisioner.tf
+++ b/azure/modules/monitoring/salt_provisioner.tf
@@ -11,7 +11,7 @@ resource "null_resource" "monitoring_provisioner" {
     user        = var.admin_user
     private_key = var.common_variables["private_key"]
 
-    bastion_host        = var.common_variables["bastion_host"]
+    bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
@@ -40,7 +40,7 @@ module "monitoring_provision" {
   instance_ids         = null_resource.monitoring_provisioner.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -61,11 +61,6 @@ variable "monitoring_srv_ip" {
   default     = ""
 }
 
-variable "admin_user" {
-  type    = string
-  default = "azadmin"
-}
-
 variable "hana_targets" {
   description = "IPs of HANA hosts you want to monitor; the last one is assumed to be the virtual IP of the active HA instance."
   type        = list(string)

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -295,14 +295,14 @@ resource "azurerm_virtual_machine" "netweaver" {
 
   os_profile {
     computer_name  = "vmnetweaver0${count.index + 1}"
-    admin_username = var.admin_user
+    admin_username = var.common_variables["authorized_user"]
   }
 
   os_profile_linux_config {
     disable_password_authentication = true
 
     ssh_keys {
-      path     = "/home/${var.admin_user}/.ssh/authorized_keys"
+      path     = "/home/${var.common_variables["authorized_user"]}/.ssh/authorized_keys"
       key_data = var.common_variables["public_key"]
     }
   }
@@ -321,7 +321,7 @@ module "netweaver_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = local.vm_count
   instance_ids         = azurerm_virtual_machine.netweaver.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -323,7 +323,7 @@ module "netweaver_on_destroy" {
   instance_ids         = azurerm_virtual_machine.netweaver.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   dependencies         = [data.azurerm_public_ip.netweaver]

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -8,11 +8,11 @@ resource "null_resource" "netweaver_provisioner" {
   connection {
     host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = var.admin_user
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
 
     bastion_host        = var.bastion_host
-    bastion_user        = var.admin_user
+    bastion_user        = var.common_variables["authorized_user"]
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
@@ -65,7 +65,7 @@ module "netweaver_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
   instance_ids         = null_resource.netweaver_provisioner.*.id
-  user                 = var.admin_user
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
   bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -11,7 +11,7 @@ resource "null_resource" "netweaver_provisioner" {
     user        = var.admin_user
     private_key = var.common_variables["private_key"]
 
-    bastion_host        = var.common_variables["bastion_host"]
+    bastion_host        = var.bastion_host
     bastion_user        = var.admin_user
     bastion_private_key = var.common_variables["bastion_private_key"]
   }
@@ -67,7 +67,7 @@ module "netweaver_provision" {
   instance_ids         = null_resource.netweaver_provisioner.*.id
   user                 = var.admin_user
   private_key          = var.common_variables["private_key"]
-  bastion_host         = var.common_variables["bastion_host"]
+  bastion_host         = var.bastion_host
   bastion_private_key  = var.common_variables["bastion_private_key"]
   public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "az_region" {
   type    = string
   default = "westeurope"

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -29,11 +29,6 @@ variable "storage_account" {
   type = string
 }
 
-variable "admin_user" {
-  type    = string
-  default = "azadmin"
-}
-
 variable "network_domain" {
   type    = string
   default = "tf.local"

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -122,6 +122,21 @@ pre_deployment = true
 # true or false (default)
 #hwcct = false
 
+##########################
+# Bastion (jumpbox) machine variables
+##########################
+
+# Enable bastion usage. This option configures the deployment to only create a unique public ip address that is attached to the bastion machine
+#bastion_enabled = true
+
+# Bastion SSH keys. If they are not set the public_key and private_key are used
+#bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
+#bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
+
+# Bastion machine os image. If it is not provided, the os_image variable data is used
+# BYOS example
+# bastion_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
+
 #########################
 # HANA machines variables
 # This example shows the demo option values.Find more options in the README file

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -73,6 +73,12 @@ variable "bastion_enabled" {
   default     = true
 }
 
+variable "bastion_os_image" {
+  description = "sles4sap image used to create the bastion machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_public_key" {
   description = "Content of a SSH public key or path to an already existing SSH public key to the bastion. If it's not set the key provided in public_key will be used"
   type        = string

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -26,7 +26,6 @@ output "configuration" {
     private_key            = local.private_key
     authorized_keys        = var.authorized_keys
     bastion_enabled        = var.bastion_enabled
-    bastion_host           = var.bastion_host
     bastion_public_key     = local.bastion_public_key
     bastion_private_key    = local.bastion_private_key
     authorized_user        = var.authorized_user

--- a/generic_modules/common_variables/variables.tf
+++ b/generic_modules/common_variables/variables.tf
@@ -66,12 +66,6 @@ variable "bastion_enabled" {
   default     = true
 }
 
-variable "bastion_host" {
-  description = "Bastion host address"
-  type        = string
-  default     = ""
-}
-
 variable "bastion_public_key" {
   description = "Path to a SSH public key used to connect to the bastion. If it's not set the key provided in public_key_location will be used"
   type        = string

--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -70,7 +70,7 @@ resource "null_resource" "provision" {
 
   provisioner "remote-exec" {
     inline = [
-      "[ -f /var/run/reboot-needed ] && echo \"Rebooting the machine...\" && (nohup sudo sh -c 'systemctl stop sshd;/sbin/reboot' &) && sleep 5",
+      "${var.reboot} && [ -f /var/run/reboot-needed ] && echo \"Rebooting the machine...\" && (nohup sudo sh -c 'systemctl stop sshd;/sbin/reboot' &) && sleep 5",
     ]
     on_failure = continue
   }

--- a/generic_modules/salt_provisioner/variables.tf
+++ b/generic_modules/salt_provisioner/variables.tf
@@ -48,3 +48,9 @@ variable "background" {
   type        = bool
   default     = false
 }
+
+variable "reboot" {
+  description = "Reboot the machines after the initial update of the packages"
+  type        = bool
+  default     = true
+}

--- a/salt/bastion/init.sls
+++ b/salt/bastion/init.sls
@@ -1,0 +1,2 @@
+include:
+  - bastion.nginx

--- a/salt/bastion/nginx.sls
+++ b/salt/bastion/nginx.sls
@@ -1,0 +1,22 @@
+nginx:
+  pkg.installed
+
+nginx_config_file:
+  file.managed:
+    - name:  /etc/nginx/nginx.conf
+    - source: salt://bastion/templates/nginx.conf.j2
+    - template: jinja
+    - makedirs: True
+    - context:
+        monitoring_srv_ip: {{ grains['monitoring_srv_ip'] }}
+    - require:
+      - pkg: nginx
+
+nginx_service:
+  service.running:
+    - name: nginx
+    - enable: True
+    - restart: True
+    - require:
+      - pkg: nginx
+      - file: nginx_config_file

--- a/salt/bastion/templates/nginx.conf.j2
+++ b/salt/bastion/templates/nginx.conf.j2
@@ -1,0 +1,16 @@
+worker_processes  1;
+
+events {
+    worker_connections  1024;
+    use epoll;
+}
+
+http {
+  server {
+    listen 3000;
+    listen [::]:3000;
+    location / {
+      proxy_pass http://{{ monitoring_srv_ip }}:3000;
+    }
+  }
+}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -47,3 +47,7 @@ predeployment:
     - match: grain
     - default
     - monitoring_srv
+
+  'role:bastion':
+    - match: grain
+    - bastion


### PR DESCRIPTION
This PR implements a Nginx proxy server in the Azure bastion machine. This helps to access the monitoring machine through the bastion, so we don't need to have an additional public address.

In order to achieve that:
- Bastion machine uses now the `common_variables` variables. This is important to be able to apply some of the configuration we apply during salt provisioning, like authorizing additional SSH keys. This is required in blue-horizon
- The bastion runs the salt provisioner to install and configure nginx
- As the bastion machine must not be rebooted (this would cut the connection to the other machines), implement a new variable to `enable/disable` the reboot
- Set the `bastion_host` in the modules to avoid cyclic imports
- Bastion image OS is configurable.

**INFO: It only opens `http` connection by now**

FYI: @petersatsuse