### PR TITLE
Feature/terraform v0.13

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ matrix:
     - language: bash
       install:
         - set -e
-        - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.12.6/terraform_0.12.6_linux_amd64.zip
+        - curl -sLo /tmp/terraform.zip https://releases.hashicorp.com/terraform/0.13.4/terraform_0.13.4_linux_amd64.zip
         - unzip /tmp/terraform -d /tmp
         - chmod +x /tmp/terraform
         - /tmp/terraform -version

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Automated SAP/HA Deployments in Public/Private Clouds with Terraform
 
 [![Build Status](https://travis-ci.org/SUSE/ha-sap-terraform-deployments.svg?branch=master)](https://travis-ci.org/SUSE/ha-sap-terraform-deployments)
-**Supported terraform version  `0.12.6`**
+**Supported terraform version  `0.13.4`**
 ___
 
 # Supported cloud providers

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -1,7 +1,11 @@
 # Configure the AWS Provider
 provider "aws" {
-  version = "~> 2.7"
+  version = "~> 3.11.0"
   region  = var.aws_region
+}
+
+terraform {
+  required_version = ">= 0.13"
 }
 
 data "aws_vpc" "current-vpc" {

--- a/aws/modules/get_os_image/main.tf
+++ b/aws/modules/get_os_image/main.tf
@@ -1,7 +1,7 @@
 # Data used to get the correct AMI image
 data "aws_ami" "image" {
   most_recent = true
-  owners      = ["${var.os_owner}"]
+  owners      = [var.os_owner]
 
   filter {
     name   = "name"
@@ -10,7 +10,7 @@ data "aws_ami" "image" {
 
   filter {
     name   = "image-id"
-    values = substr(var.os_image, 0, 4) == "ami-" ? ["${var.os_image}"] : ["*"]
+    values = substr(var.os_image, 0, 4) == "ami-" ? [var.os_image] : ["*"]
   }
 
   filter {

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -131,9 +131,8 @@ pre_deployment = true
 #hana_data_disk_type = "gp2"
 
 # Disk size for HANA database content in GB
-#hana_data_disk_size  = 64 # 64GB
-# For S/4HANA set a big disk size
-#hana_data_disk_size  = 350 # 350GB
+# For S/4HANA a big disk size is required, at least 350GB
+#hana_data_disk_size  = 1024 # 1024GB
 
 # Number of nodes in the cluster
 #hana_count = "2"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -249,7 +249,7 @@ variable "hana_data_disk_type" {
 variable "hana_data_disk_size" {
   description = "Disk size in GB for the disk used to store HANA database content"
   type        = number
-  default     = 60
+  default     = 1024
 }
 
 

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -1,10 +1,11 @@
 # Configure the Azure Provider
 provider "azurerm" {
-  version = "~> 1.44"
+  version = "~> 2.32.0"
+  features {}
 }
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }
 
 data "azurerm_subscription" "current" {
@@ -73,7 +74,7 @@ resource "azurerm_subnet" "mysubnet" {
   name                 = "snet-${lower(local.deployment_name)}"
   resource_group_name  = local.resource_group_name
   virtual_network_name = local.vnet_name
-  address_prefix       = local.subnet_address_range
+  address_prefixes     = [local.subnet_address_range]
 }
 
 resource "azurerm_subnet_network_security_group_association" "mysubnet" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -84,7 +84,6 @@ module "drbd_node" {
   os_image            = local.drbd_os_image
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
-  sec_group_id        = azurerm_network_security_group.mysecgroup.id
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
@@ -115,7 +114,6 @@ module "netweaver_node" {
   os_image                    = local.netweaver_os_image
   resource_group_name         = local.resource_group_name
   network_subnet_id           = local.subnet_id
-  sec_group_id                = azurerm_network_security_group.mysecgroup.id
   storage_account             = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   cluster_ssh_pub             = var.cluster_ssh_pub
   cluster_ssh_key             = var.cluster_ssh_key
@@ -167,7 +165,6 @@ module "hana_node" {
   scenario_type                       = var.scenario_type
   resource_group_name                 = local.resource_group_name
   network_subnet_id                   = local.subnet_id
-  sec_group_id                        = azurerm_network_security_group.mysecgroup.id
   storage_account                     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   storage_account_name                = var.storage_account_name
   storage_account_key                 = var.storage_account_key
@@ -202,7 +199,6 @@ module "monitoring" {
   vm_size             = var.monitoring_vm_size
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
-  sec_group_id        = azurerm_network_security_group.mysecgroup.id
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   monitoring_uri      = var.monitoring_uri
   os_image            = local.monitoring_os_image
@@ -221,7 +217,6 @@ module "iscsi_server" {
   vm_size             = var.iscsi_vm_size
   resource_group_name = local.resource_group_name
   network_subnet_id   = local.subnet_id
-  sec_group_id        = azurerm_network_security_group.mysecgroup.id
   storage_account     = azurerm_storage_account.mytfstorageacc.primary_blob_endpoint
   iscsi_srv_uri       = var.iscsi_srv_uri
   os_image            = local.iscsi_os_image

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -9,7 +9,7 @@ resource "azurerm_subnet" "bastion" {
   name                 = "snet-bastion"
   resource_group_name  = var.resource_group_name
   virtual_network_name = var.vnet_name
-  address_prefix       = var.snet_address_range
+  address_prefixes     = [var.snet_address_range]
 }
 
 resource "azurerm_network_security_group" "bastion" {
@@ -69,7 +69,6 @@ resource "azurerm_network_interface" "bastion" {
   name                      = "nic-bastion"
   location                  = var.az_region
   resource_group_name       = var.resource_group_name
-  network_security_group_id = azurerm_network_security_group.bastion[0].id
 
   ip_configuration {
     name                          = "ipconf-primary"

--- a/azure/modules/bastion/outputs.tf
+++ b/azure/modules/bastion/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "bastion" {
   count               = local.bastion_enabled
   name                = azurerm_public_ip.bastion[0].name
   resource_group_name = azurerm_virtual_machine.bastion[0].resource_group_name
+  depends_on          = [azurerm_virtual_machine.bastion]
 }
 
 output "public_ip" {

--- a/azure/modules/bastion/outputs.tf
+++ b/azure/modules/bastion/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "bastion" {
   count               = local.bastion_enabled
   name                = azurerm_public_ip.bastion[0].name
   resource_group_name = azurerm_virtual_machine.bastion[0].resource_group_name
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.bastion]
 }
 

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -131,7 +131,6 @@ resource "azurerm_network_interface" "drbd" {
   name                      = "nic-drbd0${count.index + 1}"
   location                  = var.az_region
   resource_group_name       = var.resource_group_name
-  network_security_group_id = var.sec_group_id
 
   ip_configuration {
     name                          = "ipconf-primary"

--- a/azure/modules/drbd_node/outputs.tf
+++ b/azure/modules/drbd_node/outputs.tf
@@ -2,12 +2,14 @@ data "azurerm_public_ip" "drbd" {
   count               = local.bastion_enabled ? 0 : var.drbd_count
   name                = element(azurerm_public_ip.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.drbd]
 }
 
 data "azurerm_network_interface" "drbd" {
   count               = var.drbd_count
   name                = element(azurerm_network_interface.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.drbd]
 }
 
 output "drbd_ip" {

--- a/azure/modules/drbd_node/outputs.tf
+++ b/azure/modules/drbd_node/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "drbd" {
   count               = local.bastion_enabled ? 0 : var.drbd_count
   name                = element(azurerm_public_ip.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.drbd]
 }
 
@@ -9,6 +10,7 @@ data "azurerm_network_interface" "drbd" {
   count               = var.drbd_count
   name                = element(azurerm_network_interface.drbd.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.drbd.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.drbd]
 }
 

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -21,10 +21,6 @@ variable "network_subnet_id" {
   type = string
 }
 
-variable "sec_group_id" {
-  type = string
-}
-
 variable "storage_account" {
   type = string
 }

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -154,7 +154,6 @@ resource "azurerm_network_interface" "hana" {
   name                          = "nic-${var.name}0${count.index + 1}"
   location                      = var.az_region
   resource_group_name           = var.resource_group_name
-  network_security_group_id     = var.sec_group_id
   enable_accelerated_networking = var.enable_accelerated_networking
 
   ip_configuration {

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "hana" {
   count               = local.bastion_enabled ? 0 : var.hana_count
   name                = element(azurerm_public_ip.hana.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.hana]
 }
 
@@ -9,6 +10,7 @@ data "azurerm_network_interface" "hana" {
   count               = var.hana_count
   name                = element(azurerm_network_interface.hana.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.hana]
 }
 

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -2,12 +2,14 @@ data "azurerm_public_ip" "hana" {
   count               = local.bastion_enabled ? 0 : var.hana_count
   name                = element(azurerm_public_ip.hana.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.hana]
 }
 
 data "azurerm_network_interface" "hana" {
   count               = var.hana_count
   name                = element(azurerm_network_interface.hana.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.hana.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.hana]
 }
 
 output "cluster_nodes_ip" {

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -21,10 +21,6 @@ variable "network_subnet_id" {
   type = string
 }
 
-variable "sec_group_id" {
-  type = string
-}
-
 variable "storage_account" {
   type = string
 }

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -10,7 +10,6 @@ resource "azurerm_network_interface" "iscsisrv" {
   name                      = "nic-iscsisrv0${count.index + 1}"
   location                  = var.az_region
   resource_group_name       = var.resource_group_name
-  network_security_group_id = var.sec_group_id
 
   ip_configuration {
     name                          = "ipconf-primary"

--- a/azure/modules/iscsi_server/outputs.tf
+++ b/azure/modules/iscsi_server/outputs.tf
@@ -2,12 +2,14 @@ data "azurerm_public_ip" "iscsisrv" {
   count               = local.bastion_enabled ? 0 : var.iscsi_count
   name                = element(azurerm_public_ip.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.iscsisrv]
 }
 
 data "azurerm_network_interface" "iscsisrv" {
   count               = var.iscsi_count
   name                = element(azurerm_network_interface.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.iscsisrv]
 }
 
 output "iscsisrv_ip" {

--- a/azure/modules/iscsi_server/outputs.tf
+++ b/azure/modules/iscsi_server/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "iscsisrv" {
   count               = local.bastion_enabled ? 0 : var.iscsi_count
   name                = element(azurerm_public_ip.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.iscsisrv]
 }
 
@@ -9,6 +10,7 @@ data "azurerm_network_interface" "iscsisrv" {
   count               = var.iscsi_count
   name                = element(azurerm_network_interface.iscsisrv.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.iscsisrv.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.iscsisrv]
 }
 

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -21,10 +21,6 @@ variable "network_subnet_id" {
   type = string
 }
 
-variable "sec_group_id" {
-  type = string
-}
-
 variable "storage_account" {
   type = string
 }

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -10,7 +10,6 @@ resource "azurerm_network_interface" "monitoring" {
   count                     = var.monitoring_enabled == true ? 1 : 0
   location                  = var.az_region
   resource_group_name       = var.resource_group_name
-  network_security_group_id = var.sec_group_id
 
   ip_configuration {
     name                          = "ipconf-primary"

--- a/azure/modules/monitoring/outputs.tf
+++ b/azure/modules/monitoring/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "monitoring" {
   count               = local.bastion_enabled == false && var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_public_ip.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.monitoring]
 }
 
@@ -9,6 +10,7 @@ data "azurerm_network_interface" "monitoring" {
   count               = var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_network_interface.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.monitoring]
 }
 

--- a/azure/modules/monitoring/outputs.tf
+++ b/azure/modules/monitoring/outputs.tf
@@ -2,12 +2,14 @@ data "azurerm_public_ip" "monitoring" {
   count               = local.bastion_enabled == false && var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_public_ip.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  depends_on          = [azurerm_virtual_machine.monitoring]
 }
 
 data "azurerm_network_interface" "monitoring" {
   count               = var.monitoring_enabled == true ? 1 : 0
   name                = azurerm_network_interface.monitoring.0.name
   resource_group_name = azurerm_virtual_machine.monitoring.0.resource_group_name
+  depends_on          = [azurerm_virtual_machine.monitoring]
 }
 
 output "monitoring_ip" {

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -23,10 +23,6 @@ variable "resource_group_name" {
   type = string
 }
 
-variable "sec_group_id" {
-  type = string
-}
-
 variable "vm_size" {
   type    = string
   default = "Standard_D2s_v3"

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -204,7 +204,6 @@ resource "azurerm_network_interface" "netweaver" {
   name                          = "nic-netweaver0${count.index + 1}"
   location                      = var.az_region
   resource_group_name           = var.resource_group_name
-  network_security_group_id     = var.sec_group_id
   enable_accelerated_networking = count.index < var.xscs_server_count ? var.xscs_accelerated_networking : var.app_accelerated_networking
 
   ip_configuration {

--- a/azure/modules/netweaver_node/outputs.tf
+++ b/azure/modules/netweaver_node/outputs.tf
@@ -2,12 +2,14 @@ data "azurerm_public_ip" "netweaver" {
   count               = local.bastion_enabled ? 0 : local.vm_count
   name                = element(azurerm_public_ip.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.netweaver]
 }
 
 data "azurerm_network_interface" "netweaver" {
   count               = local.vm_count
   name                = element(azurerm_network_interface.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  depends_on          = [azurerm_virtual_machine.netweaver]
 }
 
 output "netweaver_ip" {

--- a/azure/modules/netweaver_node/outputs.tf
+++ b/azure/modules/netweaver_node/outputs.tf
@@ -2,6 +2,7 @@ data "azurerm_public_ip" "netweaver" {
   count               = local.bastion_enabled ? 0 : local.vm_count
   name                = element(azurerm_public_ip.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.netweaver]
 }
 
@@ -9,6 +10,7 @@ data "azurerm_network_interface" "netweaver" {
   count               = local.vm_count
   name                = element(azurerm_network_interface.netweaver.*.name, count.index)
   resource_group_name = element(azurerm_virtual_machine.netweaver.*.resource_group_name, count.index)
+  # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476
   depends_on          = [azurerm_virtual_machine.netweaver]
 }
 

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -21,10 +21,6 @@ variable "network_subnet_id" {
   type = string
 }
 
-variable "sec_group_id" {
-  type = string
-}
-
 variable "storage_account" {
   type = string
 }

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -1,17 +1,18 @@
 # Configure the GCP Provider
 provider "google" {
+  version     = "~> 3.43.0"
   credentials = file(var.gcp_credentials_file)
   project     = var.project
   region      = var.region
 }
 
+terraform {
+  required_version = ">= 0.13"
+}
+
 data "google_compute_zones" "available" {
   region = var.region
   status = "UP"
-}
-
-terraform {
-  required_version = ">= 0.12"
 }
 
 data "google_compute_subnetwork" "current-subnet" {

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -133,22 +133,21 @@ pre_deployment = true
 # If `gcloud` utility is available in your local machine, the next command shows some of the available options
 # gcloud compute images list --standard-images --filter=sles
 # Combine the project and name values. The version part can be ignored to get the latest version
-# BYOS images are usually available using `suse-byos-cloud` and addind `byos` sufix to the nanem
+# BYOS images are usually available using `suse-byos-cloud` and adding `byos` suffix to the name
 #hana_os_image = "suse-byos-cloud/sles-15-sp1-sap-byos"
 
 # Disk type for HANA
 #hana_data_disk_type = "pd-ssd"
 
 # Disk size for HANA database content in GB
-#hana_data_disk_size  = 64 # 64GB
-# For S/4HANA set a big disk size
-#hana_data_disk_size  = 350 # 350GB
+# For S/4HANA a big disk size is required, at least 350GB
+#hana_data_disk_size  = 896 # 896GB
 
 # Disk type for HANA backup
 #hana_backup_disk_type = "pd-standard"
 
 # Disk size for HANA backup in GB
-#hana_backup_disk_size = "64"
+#hana_backup_disk_size = "128" # 128GB
 
 # HANA cluster vip
 #hana_cluster_vip = "10.0.1.200"

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -212,7 +212,7 @@ variable "hana_data_disk_type" {
 variable "hana_data_disk_size" {
   description = "Disk size of the disks used to store hana database content"
   type        = string
-  default     = "64"
+  default     = "896"
 }
 
 variable "hana_backup_disk_type" {
@@ -224,7 +224,7 @@ variable "hana_backup_disk_type" {
 variable "hana_backup_disk_size" {
   description = "Disk size of the disks used to store hana database backup content"
   type        = string
-  default     = "64"
+  default     = "128"
 }
 
 variable "hana_fstype" {

--- a/libvirt/README.md
+++ b/libvirt/README.md
@@ -18,6 +18,8 @@
    [openSUSE Build Service](http://download.opensuse.org/repositories/systemsmanagement:/terraform/) or
    [build from source](https://github.com/dmacvicar/terraform-provider-libvirt)
 
+   **Note:** The project only supports `terraform v0.13.x`. In order to install correctly the `terraform-libvirt-provider` for this terraform version have a look on the [migration guide to v0.13](https://github.com/dmacvicar/terraform-provider-libvirt/blob/master/docs/migration-13.md)
+
    You will need to have a working libvirt/kvm setup for using the libvirt-provider. (refer to upstream doc of [libvirt provider](https://github.com/dmacvicar/terraform-provider-libvirt))
 
 2. You need to fulfill the system requirements provided by SAP for each Application. At least 15 GB of free disk space and 512 MiB of free memory per node.

--- a/libvirt/infrastructure.tf
+++ b/libvirt/infrastructure.tf
@@ -2,6 +2,16 @@ provider "libvirt" {
   uri = var.qemu_uri
 }
 
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
+}
+
 locals {
   deployment_name       = var.deployment_name != "" ? var.deployment_name : terraform.workspace
   internal_network_name = var.network_name

--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
+}
+
 resource "libvirt_volume" "drbd_image_disk" {
   count            = var.drbd_count
   name             = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-main-disk"

--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
+}
+
 resource "libvirt_volume" "hana_image_disk" {
   count            = var.hana_count
   name             = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-main-disk"

--- a/libvirt/modules/iscsi_server/main.tf
+++ b/libvirt/modules/iscsi_server/main.tf
@@ -1,5 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
 }
 
 resource "libvirt_volume" "iscsi_image_disk" {

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -1,5 +1,11 @@
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
 }
 
 resource "libvirt_volume" "monitoring_image_disk" {

--- a/libvirt/modules/netweaver_node/main.tf
+++ b/libvirt/modules/netweaver_node/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
+}
+
 locals {
   vm_count = var.xscs_server_count + var.app_server_count
 }

--- a/libvirt/modules/shared_disk/main.tf
+++ b/libvirt/modules/shared_disk/main.tf
@@ -1,3 +1,13 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.2"
+    }
+  }
+}
+
 resource "libvirt_volume" "shared_disk" {
   name  = "${var.common_variables["deployment_name"]}-${var.name}.raw"
   pool  = var.pool

--- a/libvirt/versions.tf
+++ b/libvirt/versions.tf
@@ -1,4 +1,0 @@
-
-terraform {
-  required_version = ">= 0.12"
-}


### PR DESCRIPTION
Adapt the project to use terraform 0.13.4. This version will be shipped in blue-horizon images.

Besides that, I have updated the providers versions to match with versions shipped in sle"
- `azurerm` - `2.32.0` https://build.suse.de/request/show/228891
- `aws` -  `3.11.0` https://build.suse.de/request/show/228890
- `google`- `3.43.0` https://build.suse.de/request/show/228893

**Now, to use the libvirt provider, some manual steps are needed until it is released as `rpm`**. Explained in the `libvirt` README file