### PR TITLE
Run bastion provision without monitoring

### DIFF
--- a/azure/modules/bastion/outputs.tf
+++ b/azure/modules/bastion/outputs.tf
@@ -1,5 +1,5 @@
 data "azurerm_public_ip" "bastion" {
-  count               = local.bastion_enabled
+  count               = local.bastion_count
   name                = azurerm_public_ip.bastion[0].name
   resource_group_name = azurerm_virtual_machine.bastion[0].resource_group_name
   # depends_on is included to avoid the issue with `resource_group was not found`. Find an example in: https://github.com/terraform-providers/terraform-provider-azurerm/issues/8476

--- a/azure/modules/bastion/salt_provisioner.tf
+++ b/azure/modules/bastion/salt_provisioner.tf
@@ -1,10 +1,9 @@
 locals {
-  salt_enabled      = var.common_variables["provisioner"] == "salt" ? local.bastion_enabled : 0
-  provision_enabled = var.common_variables["monitoring_enabled"] ? local.salt_enabled : 0
+  node_count = var.common_variables["provisioner"] == "salt" ? local.bastion_count : 0
 }
 
 resource "null_resource" "bastion_provisioner" {
-  count = local.provision_enabled
+  count = local.node_count
 
   triggers = {
     bastion_id = join(",", azurerm_virtual_machine.bastion.*.id)
@@ -28,7 +27,7 @@ EOF
 
 module "bastion_provision" {
   source               = "../../../generic_modules/salt_provisioner"
-  node_count           = local.provision_enabled
+  node_count           = local.node_count
   instance_ids         = null_resource.bastion_provisioner.*.id
   user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["bastion_private_key"]

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -48,6 +48,6 @@ predeployment:
     - default
     - monitoring_srv
 
-  'role:bastion':
-    - match: grain
+  'G@role:bastion and G@monitoring_enabled:true':
+    - match: compound
     - bastion


### PR DESCRIPTION
The bastion provisioning was not done if the monitoring machine was not created. This creates issues as some other important states (update machine, authorize ssh keys, etc) are not executed.

Now, `os_setup` is always executed, and states in `bastion` will be only executed if `monitoring` is enabled as we only setup nginx there to proxy grafana dashboards to the bastion machine.

I took advantage and renamed the internal variable `bastion_enabled` to `bastion_count` as it is more meaningful