### PR TITLE
Add provisioning_output_colored variable

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -69,6 +69,7 @@ module "common_variables" {
   authorized_user                     = "ec2-user"
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
+  provisioning_output_colored         = var.provisioning_output_colored
   background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_ip : ""

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -98,6 +98,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
+# Print colored output of the provisioning execution (true by default)
+#provisioning_output_colored = false
+
 # Enable pre deployment steps (disabled by default)
 pre_deployment = true
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -162,6 +162,12 @@ variable "background" {
   default     = false
 }
 
+variable "provisioning_output_colored" {
+  description = "Print colored output of the provisioning execution"
+  type        = bool
+  default     = true
+}
+
 # Hana related variables
 
 variable "name" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -67,6 +67,7 @@ module "common_variables" {
   bastion_private_key                 = var.bastion_private_key
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
+  provisioning_output_colored         = var.provisioning_output_colored
   background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_ip : ""

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -100,6 +100,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
+# Print colored output of the provisioning execution (true by default)
+#provisioning_output_colored = false
+
 # Enable pre deployment steps (disabled by default)
 pre_deployment = true
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -178,6 +178,12 @@ variable "background" {
   default     = false
 }
 
+variable "provisioning_output_colored" {
+  description = "Print colored output of the provisioning execution"
+  type        = bool
+  default     = true
+}
+
 # Hana related variables
 
 variable "name" {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -64,6 +64,7 @@ module "common_variables" {
   authorized_user                     = "root"
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
+  provisioning_output_colored         = var.provisioning_output_colored
   background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_srv_ip : ""

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -99,6 +99,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
+# Print colored output of the provisioning execution (true by default)
+#provisioning_output_colored = false
+
 # Enable pre deployment steps (disabled by default)
 pre_deployment = true
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -142,6 +142,12 @@ variable "background" {
   default     = false
 }
 
+variable "provisioning_output_colored" {
+  description = "Print colored output of the provisioning execution"
+  type        = bool
+  default     = true
+}
+
 # Hana related variables
 
 variable "hana_count" {

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -15,26 +15,27 @@ locals {
 
 output "configuration" {
   value = {
-    provider_type          = var.provider_type
-    deployment_name        = var.deployment_name
-    reg_code               = var.reg_code
-    reg_email              = var.reg_email
-    reg_additional_modules = var.reg_additional_modules
-    ha_sap_deployment_repo = var.ha_sap_deployment_repo
-    additional_packages    = var.additional_packages
-    public_key             = local.public_key
-    private_key            = local.private_key
-    authorized_keys        = var.authorized_keys
-    bastion_enabled        = var.bastion_enabled
-    bastion_public_key     = local.bastion_public_key
-    bastion_private_key    = local.bastion_private_key
-    authorized_user        = var.authorized_user
-    provisioner            = var.provisioner
-    provisioning_log_level = var.provisioning_log_level
-    background             = var.background
-    monitoring_enabled     = var.monitoring_enabled
-    monitoring_srv_ip      = var.monitoring_srv_ip
-    qa_mode                = var.qa_mode
+    provider_type               = var.provider_type
+    deployment_name             = var.deployment_name
+    reg_code                    = var.reg_code
+    reg_email                   = var.reg_email
+    reg_additional_modules      = var.reg_additional_modules
+    ha_sap_deployment_repo      = var.ha_sap_deployment_repo
+    additional_packages         = var.additional_packages
+    public_key                  = local.public_key
+    private_key                 = local.private_key
+    authorized_keys             = var.authorized_keys
+    bastion_enabled             = var.bastion_enabled
+    bastion_public_key          = local.bastion_public_key
+    bastion_private_key         = local.bastion_private_key
+    authorized_user             = var.authorized_user
+    provisioner                 = var.provisioner
+    provisioning_log_level      = var.provisioning_log_level
+    provisioning_output_colored = var.provisioning_output_colored
+    background                  = var.background
+    monitoring_enabled          = var.monitoring_enabled
+    monitoring_srv_ip           = var.monitoring_srv_ip
+    qa_mode                     = var.qa_mode
     hana = {
       sid                            = var.hana_sid
       instance_number                = var.hana_instance_number
@@ -94,6 +95,7 @@ monitoring_enabled: ${var.monitoring_enabled}
 monitoring_srv_ip: ${var.monitoring_srv_ip}
 qa_mode: ${var.qa_mode}
 provisioning_log_level: ${var.provisioning_log_level}
+provisioning_output_colored: ${var.provisioning_output_colored}
 EOF
     hana_grains_output      = <<EOF
 hana_sid: ${var.hana_sid}

--- a/generic_modules/common_variables/variables.tf
+++ b/generic_modules/common_variables/variables.tf
@@ -112,3 +112,9 @@ variable "qa_mode" {
   type        = bool
   default     = false
 }
+
+variable "provisioning_output_colored" {
+  description = "Print colored output of the provisioning execution"
+  type        = bool
+  default     = true
+}

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -55,6 +55,7 @@ module "common_variables" {
   authorized_user                     = "root"
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
+  provisioning_output_colored         = var.provisioning_output_colored
   background                          = var.background
   monitoring_enabled                  = var.monitoring_enabled
   monitoring_srv_ip                   = var.monitoring_enabled ? local.monitoring_srv_ip : ""

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -66,6 +66,9 @@ ha_sap_deployment_repo = ""
 # Provisioning log level (error by default)
 #provisioning_log_level = "info"
 
+# Print colored output of the provisioning execution (true by default)
+#provisioning_output_colored = false
+
 # Enable pre deployment steps (disabled by default)
 #pre_deployment = true
 

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -112,6 +112,12 @@ variable "background" {
   default     = false
 }
 
+variable "provisioning_output_colored" {
+  description = "Print colored output of the provisioning execution"
+  type        = bool
+  default     = true
+}
+
 #
 # Hana related variables
 

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -18,27 +18,37 @@ get_grain () {
 }
 
 log_ok () {
-    NODE=$(hostname)
-    TIMESTAMP=$(date -u)
-    GREEN='\033[0;32m'
-    NC='\033[0m' # No Color
-    echo -e "${GREEN}$TIMESTAMP::$NODE::[INFO] $1 ${NC}"
+    node=$(hostname)
+    timestamp=$(date -u)
+    message="$timestamp::$node::[INFO] $1"
+    if [[ "$(get_grain provisioning_output_colored)" == "true" ]]; then
+      green="\033[0;32m"
+      nc="\033[0m" # No Color
+      echo -e "$green$message $nc"
+    else
+      echo -e "$message"
+    fi
 }
 
 log_error () {
-    NODE=$(hostname)
-    TIMESTAMP=$(date -u)
-    RED='\033[0;31m'
-    NC='\033[0m' # No Color
-    echo -e "${RED}$TIMESTAMP::$NODE::[ERROR] $1 ${NC}"
+    node=$(hostname)
+    timestamp=$(date -u)
+    message="$timestamp::$node::[ERROR] $1"
+    if [[ "$(get_grain provisioning_output_colored)" == "true" ]]; then
+      red="\033[0;31m"
+      nc="\033[0m" # No Color
+      echo -e "$red$message $nc"
+    else
+      echo -e "$message"
+    fi
     exit 1
 }
 
-salt_output_colored () {
-    if [[ "$(get_grain qa_mode)" == "true" ]]; then
-        echo "--no-color"
-    else
+provisioning_output_colored () {
+    if [[ "$(get_grain provisioning_output_colored)" == "true" ]]; then
         echo "--force-color"
+    else
+        echo "--no-color"
     fi
 }
 
@@ -124,7 +134,7 @@ os_setup () {
         --log-file=/var/log/salt-os-setup.log \
         --log-file-level=debug \
         --retcode-passthrough \
-        $(salt_output_colored) \
+        $(provisioning_output_colored) \
         state.apply os_setup || log_error "os setup failed"
     log_ok "os setup done"
 }
@@ -138,7 +148,7 @@ predeploy () {
         --log-file=/var/log/salt-predeployment.log \
         --log-file-level=debug \
         --retcode-passthrough \
-        $(salt_output_colored) \
+        $(provisioning_output_colored) \
         state.highstate saltenv=predeployment || log_error "predeployment failed"
     log_ok "predeployment done"
 }
@@ -152,7 +162,7 @@ deploy () {
             --log-file=/var/log/salt-deployment.log \
             --log-file-level=debug \
             --retcode-passthrough \
-            $(salt_output_colored) \
+            $(provisioning_output_colored) \
             state.highstate saltenv=base || log_error "deployment failed"
         log_ok "deployment done"
     fi
@@ -172,7 +182,7 @@ run_tests () {
             --log-file=/var/log/salt-qa.log \
             --log-file-level=debug \
             --retcode-passthrough \
-            $(salt_output_colored) \
+            $(provisioning_output_colored) \
             state.apply qa_mode || log_error "tests failed"
         log_ok "tests done"
     fi

--- a/salt/provision.sh
+++ b/salt/provision.sh
@@ -44,7 +44,7 @@ log_error () {
     exit 1
 }
 
-provisioning_output_colored () {
+salt_color_flag () {
     if [[ "$(get_grain provisioning_output_colored)" == "true" ]]; then
         echo "--force-color"
     else
@@ -134,7 +134,7 @@ os_setup () {
         --log-file=/var/log/salt-os-setup.log \
         --log-file-level=debug \
         --retcode-passthrough \
-        $(provisioning_output_colored) \
+        $(salt_color_flag) \
         state.apply os_setup || log_error "os setup failed"
     log_ok "os setup done"
 }
@@ -148,7 +148,7 @@ predeploy () {
         --log-file=/var/log/salt-predeployment.log \
         --log-file-level=debug \
         --retcode-passthrough \
-        $(provisioning_output_colored) \
+        $(salt_color_flag) \
         state.highstate saltenv=predeployment || log_error "predeployment failed"
     log_ok "predeployment done"
 }
@@ -162,7 +162,7 @@ deploy () {
             --log-file=/var/log/salt-deployment.log \
             --log-file-level=debug \
             --retcode-passthrough \
-            $(provisioning_output_colored) \
+            $(salt_color_flag) \
             state.highstate saltenv=base || log_error "deployment failed"
         log_ok "deployment done"
     fi
@@ -182,7 +182,7 @@ run_tests () {
             --log-file=/var/log/salt-qa.log \
             --log-file-level=debug \
             --retcode-passthrough \
-            $(provisioning_output_colored) \
+            $(salt_color_flag) \
             state.apply qa_mode || log_error "tests failed"
         log_ok "tests done"
     fi


### PR DESCRIPTION
Implementation of a non colored provisioning output. 
It adds the `provisioning_output_colored` variable to decide whether the provisioning scripts output is colored or not.

Until now, this was done using the `qa_mode` option.

This feature is a good go have thing if the project is used in environments such as blue-horizon.
To use ansii output colors in html is not trivial, as you need to translate all the characters by html tags and span entries, and besides that, salt/terraform combo doesn't just put colors in individual lines, so it makes things really difficult. I think going colorless is the best by now.

**INFO: Unfortunately the `SUSEConnect` tool doesn't have the option to disable colors, so this command output always be colored...*