### PR TITLE
blue horizon tuning dashboard and exporter setup

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -216,10 +216,23 @@ resource "azurerm_network_security_group" "mysecgroup" {
     source_address_prefix      = "*"
     destination_address_prefix = "*"
   }
+  security_rule {
+    name                       = "saptuneExporter"
+    priority                   = 1009
+    direction                  = "Inbound"
+    access                     = "Allow"
+    protocol                   = "*"
+    source_port_range          = "*"
+    destination_port_range     = "9758"
+    source_address_prefix      = "*"
+    destination_address_prefix = "*"
+  }
+
+
 
   security_rule {
     name                       = "prometheus"
-    priority                   = 1008
+    priority                   = 1010
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "*"
@@ -231,7 +244,7 @@ resource "azurerm_network_security_group" "mysecgroup" {
 
   security_rule {
     name                       = "grafana"
-    priority                   = 1009
+    priority                   = 1011
     direction                  = "Inbound"
     access                     = "Allow"
     protocol                   = "*"

--- a/salt/hana_node/init.sls
+++ b/salt/hana_node/init.sls
@@ -6,3 +6,4 @@ include:
   {% endif %}
   - hana_node.mount
   - hana_node.hana_packages
+  - hana_node.saptune_exporter

--- a/salt/hana_node/saptune_exporter.sls
+++ b/salt/hana_node/saptune_exporter.sls
@@ -1,0 +1,11 @@
+prometheus_ha_cluster_exporter:
+  pkg.installed:
+    - name: prometheus-saptune_exporter
+
+saptune_exporter_service:
+  service.running:
+    - name: prometheus-saptune_exporter
+    - enable: True
+    - restart: True
+    - require:
+      - pkg: prometheus-saptune_exporter

--- a/salt/hana_node/saptune_exporter.sls
+++ b/salt/hana_node/saptune_exporter.sls
@@ -6,6 +6,5 @@ saptune_exporter_service:
   service.running:
     - name: prometheus-saptune_exporter
     - enable: True
-    - restart: True
     - require:
       - pkg: prometheus-saptune_exporter

--- a/salt/hana_node/saptune_exporter.sls
+++ b/salt/hana_node/saptune_exporter.sls
@@ -1,4 +1,4 @@
-prometheus_ha_cluster_exporter:
+prometheus_saptune_exporter:
   pkg.installed:
     - name: prometheus-saptune_exporter
 

--- a/salt/monitoring_srv/grafana.sls
+++ b/salt/monitoring_srv/grafana.sls
@@ -25,7 +25,7 @@ grafana_allow_embedding:
     - require:
       - pkg: grafana
 
-# change default_them to light for better matching blue-horizon colors ;default_theme = dark
+# change theme to light for better matching blue-horizon colors ;default_theme = dark
 grafana_default_color:
   file.line:
     - name: /etc/grafana/grafana.ini

--- a/salt/monitoring_srv/grafana.sls
+++ b/salt/monitoring_srv/grafana.sls
@@ -14,6 +14,17 @@ grafana_anonymous_login_configuration:
     - require:
       - pkg: grafana
 
+# by default grafana will instruct browsers to not allow rendering Grafana in a <iframe>, set value to true
+# this is needed in the blue-horizon static pages
+grafana__allow_embedding:
+  file.line:
+    - name: /etc/grafana/grafana.ini
+    - mode: ensure
+    - after: \[security\]
+    - content: allow_embedding = true
+    - require:
+      - pkg: grafana
+
 grafana_provisioning_datasources:
   file.managed:
     - name:  /etc/grafana/provisioning/datasources/datasources.yml

--- a/salt/monitoring_srv/grafana.sls
+++ b/salt/monitoring_srv/grafana.sls
@@ -16,12 +16,22 @@ grafana_anonymous_login_configuration:
 
 # by default grafana will instruct browsers to not allow rendering Grafana in a <iframe>, set value to true
 # this is needed in the blue-horizon static pages
-grafana__allow_embedding:
+grafana_allow_embedding:
   file.line:
     - name: /etc/grafana/grafana.ini
     - mode: ensure
     - after: \[security\]
     - content: allow_embedding = true
+    - require:
+      - pkg: grafana
+
+# change default_them to light for better matching blue-horizon colors ;default_theme = dark
+grafana_default_color:
+  file.line:
+    - name: /etc/grafana/grafana.ini
+    - mode: ensure
+    - after: \[users\]
+    - content: default_theme = light
     - require:
       - pkg: grafana
 

--- a/salt/monitoring_srv/grafana.sls
+++ b/salt/monitoring_srv/grafana.sls
@@ -32,6 +32,16 @@ grafana_dashboards:
       - grafana-sap-hana-dashboards
       - grafana-sap-netweaver-dashboards
 
+tuning_dashboard:
+  file.managed:
+    - name:  /var/lib/grafana/dashboards/sles4sap/tuning.json
+    - source: salt://monitoring_srv/grafana/dashboards/tuning.json
+    - user: grafana
+    - group: grafana
+    - require:
+      - pkg: grafana
+
+
 grafana_service:
   service.running:
     - name: grafana-server

--- a/salt/monitoring_srv/grafana/dashboards/tuning.json
+++ b/salt/monitoring_srv/grafana/dashboards/tuning.json
@@ -1,0 +1,382 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "id": 6,
+  "iteration": 1603633104064,
+  "links": [],
+  "panels": [
+    {
+      "datasource": null,
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "percentage",
+            "steps": [
+              {
+                "color": "dark-green",
+                "value": null
+              },
+              {
+                "color": "dark-blue",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 11,
+        "x": 0,
+        "y": 0
+      },
+      "id": 6,
+      "links": [
+        {
+          "targetBlank": true,
+          "title": "SAP NOTES",
+          "url": "https://support.sap.com/en/index.html"
+        }
+      ],
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "Enabled"
+          }
+        ]
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "expr": "saptune_note_enabled",
+          "interval": "",
+          "legendFormat": "{{ noteName }}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Saptune notes enabled",
+      "transformations": [
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "last"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Field": "Saptune note  ID ",
+              "Last": "Enabled"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-blue",
+                "value": 0
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 11,
+        "w": 13,
+        "x": 11,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.1.5",
+      "targets": [
+        {
+          "expr": "saptune_solution_bobj{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "BOBJ",
+          "refId": "C"
+        },
+        {
+          "expr": "saptune_solution_hana{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "format": "time_series",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "HANA",
+          "refId": "A"
+        },
+        {
+          "expr": "saptune_solution_maxdb{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "format": "time_series",
+          "interval": "",
+          "legendFormat": "MAXDB",
+          "refId": "B"
+        },
+        {
+          "expr": "saptune_solution_netweaver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "NETWEAVER",
+          "refId": "D"
+        },
+        {
+          "expr": "saptune_solution_netweaver_hana{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "NETWEAVER-HANA",
+          "refId": "E"
+        },
+        {
+          "expr": "saptune_solution_s4hana_app_db{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "S4HANA-APP+DB",
+          "refId": "G"
+        },
+        {
+          "expr": "saptune_solution_s4hana_appserver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "S4HANA-APPSERVER",
+          "refId": "H"
+        },
+        {
+          "expr": "saptune_solution_s4hana_dbserver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "S4HANA-DBSERVER",
+          "refId": "I"
+        },
+        {
+          "expr": "saptune_solution_sap_ase{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "interval": "",
+          "legendFormat": "SAP-ASE",
+          "refId": "F"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Saptune solution enabled",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": []
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Field": "Node",
+              "Last (not null)": "Active"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background"
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 0,
+              "text": "",
+              "to": "",
+              "type": 1
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-green",
+                "value": 2
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Value"
+            },
+            "properties": [
+              {
+                "id": "custom.width",
+                "value": 929
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 16,
+        "x": 3,
+        "y": 11
+      },
+      "id": 2,
+      "options": {
+        "showHeader": true,
+        "sortBy": [
+          {
+            "desc": false,
+            "displayName": "instance"
+          }
+        ]
+      },
+      "pluginVersion": "7.1.5",
+      "repeat": "node",
+      "repeatDirection": "v",
+      "targets": [
+        {
+          "expr": "saptune_misc_version{instance=\"192.168.23.12:9758\",job=\"hana\"}",
+          "format": "table",
+          "instant": true,
+          "interval": "",
+          "legendFormat": "{{ instance }]",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "saptune version",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": [
+                "Value",
+                "instance"
+              ]
+            }
+          }
+        }
+      ],
+      "type": "table"
+    }
+  ],
+  "schemaVersion": 26,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": [
+      {
+        "current": {
+          "selected": false,
+          "text": "Prometheus",
+          "value": "Prometheus"
+        },
+        "hide": 2,
+        "includeAll": false,
+        "label": "Data Source",
+        "multi": false,
+        "name": "DS_PROMETHEUS",
+        "options": [],
+        "query": "prometheus",
+        "queryValue": "",
+        "refresh": 1,
+        "regex": "",
+        "skipUrlSync": false,
+        "type": "datasource"
+      }
+    ]
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ]
+  },
+  "timezone": "",
+  "title": "Tuning",
+  "uid": "HzFepKtMz",
+  "version": 9
+}

--- a/salt/monitoring_srv/grafana/dashboards/tuning.json
+++ b/salt/monitoring_srv/grafana/dashboards/tuning.json
@@ -16,7 +16,7 @@
   "gnetId": null,
   "graphTooltip": 0,
   "id": 6,
-  "iteration": 1603633104064,
+  "iteration": 1605698565793,
   "links": [],
   "panels": [
     {
@@ -25,7 +25,8 @@
         "defaults": {
           "custom": {
             "align": null,
-            "displayMode": "color-background"
+            "displayMode": "color-background",
+            "filterable": false
           },
           "mappings": [],
           "thresholds": {
@@ -45,8 +46,8 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 11,
+        "h": 12,
+        "w": 10,
         "x": 0,
         "y": 0
       },
@@ -67,7 +68,7 @@
           }
         ]
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.3.1",
       "targets": [
         {
           "expr": "saptune_note_enabled",
@@ -108,9 +109,19 @@
         "defaults": {
           "custom": {
             "align": null,
-            "displayMode": "color-background"
+            "displayMode": "color-background",
+            "filterable": false
           },
-          "mappings": [],
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Enabled",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            }
+          ],
           "thresholds": {
             "mode": "absolute",
             "steps": [
@@ -132,9 +143,9 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 11,
-        "w": 13,
-        "x": 11,
+        "h": 4,
+        "w": 14,
+        "x": 10,
         "y": 0
       },
       "id": 4,
@@ -143,64 +154,13 @@
         "showHeader": true,
         "sortBy": []
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.3.1",
       "targets": [
         {
-          "expr": "saptune_solution_bobj{instance=\"192.168.23.12:9758\", job=\"hana\"}",
+          "expr": "saptune_solution_enabled",
           "interval": "",
-          "legendFormat": "BOBJ",
+          "legendFormat": "{{ solutionName}}",
           "refId": "C"
-        },
-        {
-          "expr": "saptune_solution_hana{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "format": "time_series",
-          "instant": false,
-          "interval": "",
-          "legendFormat": "HANA",
-          "refId": "A"
-        },
-        {
-          "expr": "saptune_solution_maxdb{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "format": "time_series",
-          "interval": "",
-          "legendFormat": "MAXDB",
-          "refId": "B"
-        },
-        {
-          "expr": "saptune_solution_netweaver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "NETWEAVER",
-          "refId": "D"
-        },
-        {
-          "expr": "saptune_solution_netweaver_hana{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "NETWEAVER-HANA",
-          "refId": "E"
-        },
-        {
-          "expr": "saptune_solution_s4hana_app_db{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "S4HANA-APP+DB",
-          "refId": "G"
-        },
-        {
-          "expr": "saptune_solution_s4hana_appserver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "S4HANA-APPSERVER",
-          "refId": "H"
-        },
-        {
-          "expr": "saptune_solution_s4hana_dbserver{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "S4HANA-DBSERVER",
-          "refId": "I"
-        },
-        {
-          "expr": "saptune_solution_sap_ase{instance=\"192.168.23.12:9758\", job=\"hana\"}",
-          "interval": "",
-          "legendFormat": "SAP-ASE",
-          "refId": "F"
         }
       ],
       "timeFrom": null,
@@ -229,8 +189,8 @@
             "excludeByName": {},
             "indexByName": {},
             "renameByName": {
-              "Field": "Node",
-              "Last (not null)": "Active"
+              "Field": "Solution Name",
+              "Last (not null)": "Status"
             }
           }
         }
@@ -243,7 +203,102 @@
         "defaults": {
           "custom": {
             "align": null,
-            "displayMode": "color-background"
+            "displayMode": "color-background",
+            "filterable": false
+          },
+          "mappings": [
+            {
+              "from": "",
+              "id": 1,
+              "text": "Compliant",
+              "to": "",
+              "type": 1,
+              "value": "1"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "dark-blue",
+                "value": 0
+              },
+              {
+                "color": "dark-green",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 3,
+        "w": 14,
+        "x": 10,
+        "y": 4
+      },
+      "id": 9,
+      "options": {
+        "frameIndex": 0,
+        "showHeader": true,
+        "sortBy": []
+      },
+      "pluginVersion": "7.3.1",
+      "targets": [
+        {
+          "expr": "saptune_solution_compliant",
+          "interval": "",
+          "legendFormat": "{{ solutionName}}",
+          "refId": "A"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Saptune solution compliant",
+      "transformations": [
+        {
+          "id": "filterFieldsByName",
+          "options": {
+            "include": {
+              "names": []
+            }
+          }
+        },
+        {
+          "id": "reduce",
+          "options": {
+            "reducers": [
+              "lastNotNull"
+            ]
+          }
+        },
+        {
+          "id": "organize",
+          "options": {
+            "excludeByName": {},
+            "indexByName": {},
+            "renameByName": {
+              "Field": "Solution name",
+              "Last (not null)": "Compliant"
+            }
+          }
+        }
+      ],
+      "type": "table"
+    },
+    {
+      "datasource": "Prometheus",
+      "fieldConfig": {
+        "defaults": {
+          "custom": {
+            "align": null,
+            "displayMode": "color-background",
+            "filterable": false
           },
           "mappings": [
             {
@@ -284,10 +339,10 @@
         ]
       },
       "gridPos": {
-        "h": 3,
-        "w": 16,
-        "x": 3,
-        "y": 11
+        "h": 5,
+        "w": 14,
+        "x": 10,
+        "y": 7
       },
       "id": 2,
       "options": {
@@ -299,16 +354,16 @@
           }
         ]
       },
-      "pluginVersion": "7.1.5",
+      "pluginVersion": "7.3.1",
       "repeat": "node",
       "repeatDirection": "v",
       "targets": [
         {
-          "expr": "saptune_misc_version{instance=\"192.168.23.12:9758\",job=\"hana\"}",
+          "expr": "saptune_meta_version\n",
           "format": "table",
           "instant": true,
           "interval": "",
-          "legendFormat": "{{ instance }]",
+          "legendFormat": "",
           "refId": "A"
         }
       ],
@@ -342,6 +397,7 @@
           "text": "Prometheus",
           "value": "Prometheus"
         },
+        "error": null,
         "hide": 2,
         "includeAll": false,
         "label": "Data Source",
@@ -378,5 +434,5 @@
   "timezone": "",
   "title": "Tuning",
   "uid": "HzFepKtMz",
-  "version": 9
+  "version": 4
 }

--- a/salt/monitoring_srv/prometheus/prometheus.yml.j2
+++ b/salt/monitoring_srv/prometheus/prometheus.yml.j2
@@ -29,6 +29,7 @@ scrape_configs:
         - "{{ ip }}:9664" # ha_cluster_exporter
         {%- endfor %}
         - "{{ grains['hana_targets'][-1] }}:9668" # hanadb_exporter
+        - "{{ grains['hana_targets'][-1] }}:9758" # saptune_exporter
   {%- endif %}
 
   {%- if grains.get('drbd_targets', [])|length > 0 %}


### PR DESCRIPTION
# Note for reviewers:

review commit by commit so you have less files

# Description:

This pull-request add:

- the new `tuning.json` dashboard which is the saptune_exporter dashboard
- an option for grafana.ini to allow dashboards/panels to be embedded (by default this is disabled by grafana)
- add the saptune_exporter systemd-service activation on hana nodes