### PR TITLE
Fix network restart on SLE15-SP3

### DIFF
--- a/salt/bastion/nginx.sls
+++ b/salt/bastion/nginx.sls
@@ -16,7 +16,6 @@ nginx_service:
   service.running:
     - name: nginx
     - enable: True
-    - restart: True
     - require:
       - pkg: nginx
       - file: nginx_config_file

--- a/salt/cluster_node/ha/network.sls
+++ b/salt/cluster_node/ha/network.sls
@@ -18,9 +18,11 @@ cloud-netconfig-azure:
   file.replace:
     - pattern: '^CLOUD_NETCONFIG_MANAGE.*'
     - repl: "CLOUD_NETCONFIG_MANAGE='no'"
+    {% if grains['provider'] != 'libvirt' %}
+    - append_if_not_found: True
+    {% endif %}
 
 network:
   service.running:
-    - enable: True
     - watch:
       - file: /etc/sysconfig/network/ifcfg-eth0

--- a/salt/cluster_node/monitoring.sls
+++ b/salt/cluster_node/monitoring.sls
@@ -6,7 +6,6 @@ node_exporter_service:
   service.running:
     - name: prometheus-node_exporter
     - enable: True
-    - restart: True
     - require:
       - pkg: prometheus_node_exporter
       - file: activate_node_exporter_systemd_collector
@@ -46,7 +45,6 @@ promtail_service:
   service.running:
     - name: promtail
     - enable: True
-    - restart: True
     - require:
       - pkg: loki
       - file: promtail_config

--- a/salt/monitoring_srv/grafana.sls
+++ b/salt/monitoring_srv/grafana.sls
@@ -36,7 +36,6 @@ grafana_service:
   service.running:
     - name: grafana-server
     - enable: True
-    - restart: True
     - require:
       - pkg: grafana
       - pkg: grafana_dashboards

--- a/salt/monitoring_srv/loki.sls
+++ b/salt/monitoring_srv/loki.sls
@@ -9,6 +9,5 @@ loki_service:
   service.running:
     - name: loki
     - enable: True
-    - restart: True
     - require:
       - pkg: loki


### PR DESCRIPTION
Current code tries to enable the network service which lead to an error on SLE15-SP3 because service is already enabled.
In fact, it's not really needed to enable this service, so better to remove this `Enable:` option.

This PR also force-adds the `CLOUD_NETCONFIG_MANAGE` option, to ensure that there will be no issues if `cloud-init` is used.

Tested on 15-SP2 and 15-SP3 images.