### PR TITLE
Output hana virtual ip

### DIFF
--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -58,6 +58,10 @@ output "cluster_nodes_public_name" {
   value = module.hana_node.cluster_nodes_public_name
 }
 
+output "hana_ip" {
+  value = var.hana_ha_enabled ? local.hana_cluster_vip : local.hana_ips[0]
+}
+
 # drbd
 
 output "drbd_ip" {


### PR DESCRIPTION
This value is consumed by blue-horizon to format the correct grafana iframe urls.

Here an example:
http://%{bastion_ip}:3000/d/EcC4JDFWz2/sap-hana?orgId=1&var-DS_PROMETHEUS=Prometheus&var-node_name=hana01&var-node_ip=%{hana_ip}&var-sid=%{sid}&var-instance_number=00&var-database_name=%{sid}&kiosk

**bastion_ip and sid can be already retrieved**