### PR TITLE
Target the correct hana machines with the saptune exporter

### DIFF
--- a/salt/monitoring_srv/prometheus/prometheus.yml.j2
+++ b/salt/monitoring_srv/prometheus/prometheus.yml.j2
@@ -27,9 +27,9 @@ scrape_configs:
         {%- for ip in grains['hana_targets'][0:2] %}
         - "{{ ip }}:9100" # node_exporter
         - "{{ ip }}:9664" # ha_cluster_exporter
+        - "{{ ip }}:9758" # saptune_exporter
         {%- endfor %}
         - "{{ grains['hana_targets'][-1] }}:9668" # hanadb_exporter
-        - "{{ grains['hana_targets'][-1] }}:9758" # saptune_exporter
   {%- endif %}
 
   {%- if grains.get('drbd_targets', [])|length > 0 %}


### PR DESCRIPTION
The saptune exporter is executed in all the HANA nodes (all of the HANA nodes must have the solution applied), so it must be targeted there, and not using the virtual ip address (which actually, should go in the Load balancer in this case to redirect the port, otherwise it wouldn't work).

The change just fixes the target to query the individual HANA nodes