### PR TITLE
Define specific version for null provider

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -4,6 +4,10 @@ provider "azurerm" {
   features {}
 }
 
+provider "null" {
+  version = "3.0.0"
+}
+
 terraform {
   required_version = ">= 0.13"
 }


### PR DESCRIPTION
Define a specific version for the `null` provider.

This is required to avoid the download of the latest version, and as we ship this provider under SLE, we must use the provided version.