### PR TITLE
Fix how the lvm is created in azure with multiple luns

### DIFF
--- a/salt/hana_node/mount/azure.sls
+++ b/salt/hana_node/mount/azure.sls
@@ -18,13 +18,14 @@ hana_lvm_vgcreate_{{ vg }}_azure:
       {%- endfor %}
 
 # Configure the logical volumes
+{%- set lun_count = luns|length %}
 {%- for lv_size in grains['hana_data_disks_configuration']['lv_sizes'].split('#')[vg_index].split(',') %}
 hana_lvm_lvcreate_{{ vg }}_{{ loop.index0 }}_azure:
   lvm.lv_present:
     - name: lv_hana_{{ vg }}_{{ loop.index0 }}
     - vgname: vg_hana_{{ vg }}
     - extents: {{ lv_size }}%FREE
-    - stripes: {{ loop.length }}
+    - stripes: {{ lun_count }}
 
 hana_format_lv_{{ vg }}_{{ loop.index0 }}_azure:
   cmd.run:


### PR DESCRIPTION
Fix how the LVM volumes are created in azure when multiple luns are involved.
This is needed for disk configuration such as:

```
hana_data_disks_configuration = {
  disks_type       = "Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS,Premium_LRS"
  disks_size       = "512,512,512,512,64,512"
  caching          = "ReadOnly,ReadOnly,ReadOnly,ReadOnly,ReadOnly,None"
  writeaccelerator = "false,false,false,false,false,false"
  luns             = "0,1,2#3#4#5"
  names            = "datalog#shared#usrsap#backup"
  lv_sizes         = "70,100#100#100#100"
  paths            = "/hana/data,/hana/log#/hana/shared#/usr/sap#/hana/backup"
}
```

Check how 2 LVMs are created for `datalog` (`/hana/data` which uses the 70% of disk size of luns `0,1,2` and `/hana/log` which uses the remaining empty space until 100% usage.

FYI: @petersatsuse