### PR TITLE
install nginx only if monitoring enabled - move condition into bastion/init.sls

### DIFF
--- a/salt/bastion/init.sls
+++ b/salt/bastion/init.sls
@@ -1,2 +1,7 @@
+{% if grains.get('monitoring_enabled', False) %}
 include:
   - bastion.nginx
+{% else %}
+default_nop:
+  test.nop: []
+{% endif %}

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -48,6 +48,6 @@ predeployment:
     - default
     - monitoring_srv
 
-  'G@role:bastion and G@monitoring_enabled:true':
-    - match: compound
+  'role:bastion':
+    - match: grain
     - bastion


### PR DESCRIPTION
Currently if you don't have monitoring enabled the bastion role fails with:

```
local:
----------
          ID: states
    Function: no.None
      Result: False
     Comment: No Top file or master_tops data matches found. Please see master log for details.
     Changes:   

Summary for local
------------
Succeeded: 0
Failed:    1
------------
Total states run:     1
Total run time:   0.000 ms
```