### PR TITLE
Set higher priority to the devel repo

### DIFF
--- a/salt/os_setup/repos.sls
+++ b/salt/os_setup/repos.sls
@@ -17,6 +17,12 @@ ha_sap_deployments_repo:
   pkgrepo.managed:
     - name: ha_sap_deployments
     - baseurl: {{ repository }}
+
+set_priority_ha_sap_deployments_repo:
+  cmd.run:
+    - name: zypper mr -p 90 ha_sap_deployments
+    - require:
+      - ha_sap_deployments_repo
 {% endif %}
 
 refresh_repos_after_registration:


### PR DESCRIPTION
Set higher priority to the devel repo if it's used (90, 99 is the default value).

This aims for:
- Use all the packages from the devel repository if this is added

Drawback:
- Now, we cannot have the combination of: the project uses the packages from SLE if found and from the devel project otherwise (in this case the higher version would win). I would say that this functionality is not good, but this is how it was working (and being used by now). This requires having all the involved packages in SLE to use the `non devel repo` option (which potentailly threatens the option to have the monitoring solution in SLE12, with supported deployment packages)