### PR TITLE
Feature/manage sapmnt folder

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -113,6 +113,7 @@ module "common_variables" {
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : "${join("", aws_efs_file_system.netweaver-efs.*.dns_name)}:"
+  netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -189,11 +189,11 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
 # The following SAP HANA Client variables are needed only when you are using a HANA database SAR archive for HANA installation.
-# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used 
+# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used
 # You can provide HANA Client in one of the two options below:
 # 1. Path to already extracted hana client folder, relative to hana_inst_master mounting point
 #hana_client_folder = "SAP_HANA_CLIENT"
-# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe 
+# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe
 # It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
 #hana_client_archive_file = "IMDB_CLIENT20_003_144-80002090.SAR"
 #hana_client_extract_dir = "/sapmedia_extract/HANA_CLIENT"
@@ -349,6 +349,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 
 # Example:
 #netweaver_product_id = "NW750.HDB.ABAPHA"
+
+# Path where netweaver sapmnt data is stored.
+#netweaver_sapmnt_path = "/sapmnt"
 
 # Preparing the Netweaver download basket. Check `doc/sap_software.md` for more information
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -609,6 +609,12 @@ variable "netweaver_cluster_fencing_mechanism" {
   default     = "native"
 }
 
+variable "netweaver_sapmnt_path" {
+  description = "Path where sapmnt folder is stored"
+  type        = string
+  default     = "/sapmnt"
+}
+
 variable "netweaver_product_id" {
   description = "Netweaver installation product. Even though the module is about Netweaver, it can be used to install other SAP instances like S4/HANA"
   type        = string

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -111,6 +111,7 @@ module "common_variables" {
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
+  netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -219,11 +219,11 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
 # The following SAP HANA Client variables are needed only when you are using a HANA database SAR archive for HANA installation.
-# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used 
+# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used
 # You can provide HANA Client in one of the two options below:
 # 1. Path to already extracted hana client folder, relative to hana_inst_master mounting point
 #hana_client_folder = "SAP_HANA_CLIENT"
-# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe 
+# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe
 # It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
 #hana_client_archive_file = "IMDB_CLIENT20_003_144-80002090.SAR"
 #hana_client_extract_dir = "/sapmedia_extract/HANA_CLIENT"
@@ -368,6 +368,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 
 # Example:
 #netweaver_product_id = "NW750.HDB.ABAPHA"
+
+# NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
+#netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
 # Preparing the Netweaver download basket. Check `doc/sap_software.md` for more information
 

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -372,6 +372,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
 #netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
+# Path where netweaver sapmnt data is stored.
+#netweaver_sapmnt_path = "/sapmnt"
+
 # Preparing the Netweaver download basket. Check `doc/sap_software.md` for more information
 
 # Azure storage account where all the Netweaver software is available. The next paths are relative to this folder.

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -643,7 +643,7 @@ variable "netweaver_cluster_fencing_mechanism" {
 }
 
 variable "netweaver_nfs_share" {
-  description = "NFS share used to store shared netweaver files. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project"
+  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
   type        = string
   default     = ""
 }

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -648,6 +648,12 @@ variable "netweaver_nfs_share" {
   default     = ""
 }
 
+variable "netweaver_sapmnt_path" {
+  description = "Path where sapmnt folder is stored"
+  type        = string
+  default     = "/sapmnt"
+}
+
 variable "netweaver_storage_account_name" {
   description = "Azure storage account where SAP Netweaver installation files are stored"
   type        = string

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -107,7 +107,7 @@ module "common_variables" {
   netweaver_swpm_sar                  = var.netweaver_swpm_sar
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
-  netweaver_nfs_share                 = "${local.drbd_cluster_vip}:/${var.netweaver_sid}"
+  netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -108,6 +108,7 @@ module "common_variables" {
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
+  netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -200,11 +200,11 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
 # The following SAP HANA Client variables are needed only when you are using a HANA database SAR archive for HANA installation.
-# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used 
+# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used
 # You can provide HANA Client in one of the two options below:
 # 1. Path to already extracted hana client folder, relative to hana_inst_master mounting point
 #hana_client_folder = "SAP_HANA_CLIENT"
-# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe 
+# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe
 # It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
 #hana_client_archive_file = "IMDB_CLIENT20_003_144-80002090.SAR"
 #hana_client_extract_dir = "/sapmedia_extract/HANA_CLIENT"
@@ -322,6 +322,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 # Example:
 #netweaver_product_id = "NW750.HDB.ABAPHA"
+
+# NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
+#netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
 # Preparing the Netweaver download basket. Check `doc/sap_software.md` for more information
 

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -326,6 +326,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
 #netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
+# Path where netweaver sapmnt data is stored.
+#netweaver_sapmnt_path = "/sapmnt"
+
 # Preparing the Netweaver download basket. Check `doc/sap_software.md` for more information
 
 # GCP storage where all the Netweaver software is available. The next paths are relative to this folder.

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -541,6 +541,12 @@ variable "netweaver_nfs_share" {
   default     = ""
 }
 
+variable "netweaver_sapmnt_path" {
+  description = "Path where sapmnt folder is stored"
+  type        = string
+  default     = "/sapmnt"
+}
+
 variable "netweaver_product_id" {
   description = "Netweaver installation product. Even though the module is about Netweaver, it can be used to install other SAP instances like S4/HANA"
   type        = string

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -535,6 +535,12 @@ variable "netweaver_cluster_fencing_mechanism" {
   default     = "native"
 }
 
+variable "netweaver_nfs_share" {
+  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
+  type        = string
+  default     = ""
+}
+
 variable "netweaver_product_id" {
   description = "Netweaver installation product. Even though the module is about Netweaver, it can be used to install other SAP instances like S4/HANA"
   type        = string

--- a/generic_modules/common_variables/netweaver_variables.tf
+++ b/generic_modules/common_variables/netweaver_variables.tf
@@ -83,6 +83,11 @@ variable "netweaver_nfs_share" {
   type        = string
 }
 
+variable "netweaver_sapmnt_path" {
+  description = "Path where sapmnt folder is stored"
+  type        = string
+}
+
 variable "netweaver_hana_ip" {
   description = "IP address of the HANA database. If the database is clustered, use the cluster virtual ip address"
   type        = string

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -80,6 +80,7 @@ output "configuration" {
       sapexe_folder        = var.netweaver_sapexe_folder
       additional_dvds      = var.netweaver_additional_dvds
       nfs_share            = var.netweaver_nfs_share
+      sapmnt_path          = var.netweaver_sapmnt_path
       hana_ip              = var.netweaver_hana_ip
       hana_sid             = var.netweaver_hana_sid
       hana_instance_number = var.netweaver_hana_instance_number
@@ -145,6 +146,7 @@ netweaver_swpm_sar: ${var.netweaver_swpm_sar}
 netweaver_sapexe_folder: ${var.netweaver_sapexe_folder}
 netweaver_additional_dvds: [${join(", ", formatlist("'%s'", var.netweaver_additional_dvds))}]
 netweaver_nfs_share: "${var.netweaver_nfs_share}"
+netweaver_sapmnt_path: ${var.netweaver_sapmnt_path}
 hana_ip: ${var.netweaver_hana_ip}
 hana_sid: ${var.netweaver_hana_sid}
 hana_instance_number: ${var.netweaver_hana_instance_number}

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -99,6 +99,7 @@ module "common_variables" {
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
   netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
+  netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
   netweaver_hana_instance_number      = var.hana_instance_number

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -257,6 +257,9 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 # NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
 #netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
+# Path where netweaver sapmnt data is stored.
+#netweaver_sapmnt_path = "/sapmnt"
+
 # Netweaver installation required folders
 # SAP SWPM installation folder, relative to the netweaver_inst_media mounting point
 #netweaver_swpm_folder     =  "your_swpm"

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -137,11 +137,11 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 #hana_extract_dir = "/sapmedia_extract/HANA"
 
 # The following SAP HANA Client variables are needed only when you are using a HANA database SAR archive for HANA installation.
-# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used 
+# HANA Client is used by monitoring & cost-optimized scenario and it is already included in HANA platform media unless a HANA database SAR archive is used
 # You can provide HANA Client in one of the two options below:
 # 1. Path to already extracted hana client folder, relative to hana_inst_master mounting point
 #hana_client_folder = "SAP_HANA_CLIENT"
-# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe 
+# 2. Or specify the path to the hana client SAR archive file, relative to the 'hana_inst_master'. To extract the SAR archive, you need to also provide compatible version of sapcar executable in variable hana_sapcar_exe
 # It will be extracted to hana_client_extract_dir path (optional, by default /sapmedia_extract/HANA_CLIENT)
 #hana_client_archive_file = "IMDB_CLIENT20_003_144-80002090.SAR"
 #hana_client_extract_dir = "/sapmedia_extract/HANA_CLIENT"
@@ -254,7 +254,7 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 
 # This share must contain the next software (select the version you want to install of course)
 
-# NFS share to store the Netweaver shared files
+# NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
 #netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 
 # Netweaver installation required folders

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -487,7 +487,7 @@ variable "netweaver_cluster_fencing_mechanism" {
 }
 
 variable "netweaver_nfs_share" {
-  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders"
+  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
   type        = string
   default     = ""
 }

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -492,6 +492,12 @@ variable "netweaver_nfs_share" {
   default     = ""
 }
 
+variable "netweaver_sapmnt_path" {
+  description = "Path where sapmnt folder is stored"
+  type        = string
+  default     = "/sapmnt"
+}
+
 variable "netweaver_product_id" {
   description = "Netweaver installation product. Even though the module is about Netweaver, it can be used to install other SAP instances like S4/HANA"
   type        = string

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -79,3 +79,4 @@ cluster:
         vpc_network_name: {{ grains['vpc_network_name'] }}
         {%- endif %}
         native_fencing: {{ grains['fencing_mechanism'] == 'native' }}
+        sapmnt_path: {{ grains['netweaver_sapmnt_path'] }}

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -42,6 +42,7 @@ netweaver:
   sap_adm_password: {{ grains['netweaver_master_password'] }}
   master_password: {{ grains['netweaver_master_password'] }}
   sapmnt_inst_media: "{{ grains['netweaver_nfs_share'] }}"
+  sapmnt_path: {{ grains['netweaver_sapmnt_path'] }}
   {%- if grains.get('netweaver_swpm_folder', False) %}
   swpm_folder: {{ grains['netweaver_inst_folder'] }}/{{ grains['netweaver_swpm_folder'] }}
   {%- endif %}

--- a/salt/netweaver_node/nfs.sls
+++ b/salt/netweaver_node/nfs.sls
@@ -17,6 +17,7 @@ netcat-openbsd:
       attempts: 3
       interval: 15
 
+{% if grains['netweaver_nfs_share'] %}
 {% set nfs_server_ip = grains['netweaver_nfs_share'].split(':')[0] %}
 wait_until_nfs_is_ready:
   cmd.run:
@@ -97,4 +98,5 @@ unmount_sapmnt:
 remove_tmp_folder:
   file.absent:
     - name: /tmp/sapmnt
+{% endif %}
 {% endif %}


### PR DESCRIPTION
Implementation based on https://github.com/SUSE/sapnwbootstrap-formula/pull/79

This implementation enables:
- The usage of a local `sapmnt` folder. Set `netweaver_nfs_share` with empty value for that (if drbd is not enabled, in this case a HA NFS is used always). **Disclaimer**: This is not implemented for AWS as it uses a EFS storage and I didn't want to make big changes
- Make `sapmnt` folder configurable. Usually it is stored in `/sapmnt`, but this value is configurable in the NW installation, so I have added here this option