### PR TITLE
Fix hana_cluster_vip_secondary grain usage in pillar file

### DIFF
--- a/pillar_examples/automatic/hana/hana.sls
+++ b/pillar_examples/automatic/hana/hana.sls
@@ -78,7 +78,7 @@ hana:
         remote_host: {{ grains['name_prefix'] }}01
         remote_instance: "00"
         replication_mode: sync
-        {% if grains['hana_cluster_vip_secondary'] != '' %}
+        {% if grains['hana_cluster_vip_secondary'] %}
         operation_mode: logreplay_readaccess
         {% else %}
         operation_mode: logreplay


### PR DESCRIPTION
Fix for: https://github.com/SUSE/ha-sap-terraform-deployments/issues/626

The pillar file was incorrectly checking for the content. We introduced some change during the course of the development that is normalizing the `/etc/salt/grain` file content. This means, that the entries with empty value are changed to `null` value.

Initially the pillar was designed for:
```
hana_cluster_vip_secondary:
```
But now the file is changed to:
```
hana_cluster_vip_secondary: null
```

So, the if statement fails. With the new comparison the operation mode is properly set based in `hana_active_active` parameters.

Tested in libvirt and gcp.