### PR TITLE
Set new configuration values for corosync for gcp

### DIFF
--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -31,6 +31,12 @@ cluster:
       join: 60
       consensus: 36000
       max_messages: 20
+  {% elif grains['provider'] == 'gcp' %}
+  corosync:
+    totem:
+      secauth: 'off'
+      token: 20000
+      consensus: 24000
   {% endif %}
   monitoring_enabled: {{ grains['monitoring_enabled']|default(False) }}
   configure:

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -45,6 +45,12 @@ cluster:
       join: 60
       consensus: 36000
       max_messages: 20
+  {% elif grains['provider'] == 'gcp' %}
+  corosync:
+    totem:
+      secauth: 'off'
+      token: 20000
+      consensus: 24000
   {% endif %}
   monitoring_enabled: {{ grains['monitoring_enabled']|default(False) }}
   configure:

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -33,6 +33,12 @@ cluster:
       join: 60
       consensus: 36000
       max_messages: 20
+  {% elif grains['provider'] == 'gcp' %}
+  corosync:
+    totem:
+      secauth: 'off'
+      token: 20000
+      consensus: 24000
   {% endif %}
   monitoring_enabled: {{ grains['monitoring_enabled']|default(False) }}
   configure:


### PR DESCRIPTION
Fix for: https://github.com/SUSE/ha-sap-terraform-deployments/issues/624
FYI: @ab-mohamed
Updated some values of corosync in GCP deployment. 
The new result is:
```
totem {
	version: 2
	secauth: off
	crypto_hash: sha1
	crypto_cipher: aes256
	cluster_name: hana_cluster
	clear_node_high_bit: yes
	token: 20000
	token_retransmits_before_loss_const: 10
	join: 60
	consensus: 24000
	max_messages: 20
	interface {
		ringnumber: 0
		mcastport: 5405
		ttl: 1
	}

	transport: udpu
}

logging {
	fileline: off
	to_stderr: no
	to_logfile: no
	logfile: /var/log/cluster/corosync.log
	to_syslog: yes
	debug: off
	timestamp: on
	logger_subsys {
		subsys: QUORUM
		debug: off
	}

}

nodelist {
	node {
		ring0_addr: 192.168.1.11
		nodeid: 1
	}

	node {
		ring0_addr: 192.168.1.12
		nodeid: 2
	}

}

quorum {
	provider: corosync_votequorum
	expected_votes: 2
	two_node: 1
}
```