### PR TITLE
bsc#1179529 - Support use different backing device per node

### DIFF
--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -27,6 +27,7 @@ host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 drbd_disk_device: ${format("%s%s","/dev/disk/by-id/google-", element(google_compute_instance.drbd.*.attached_disk.0.device_name, count.index))}
+drbd_disk_device_list: [${join(", ", formatlist("'/dev/disk/by-id/google-%s'", google_compute_instance.drbd.*.attached_disk.0.device_name))}]
 drbd_cluster_vip: ${var.drbd_cluster_vip}
 fencing_mechanism: ${var.fencing_mechanism}
 sbd_storage_type: ${var.sbd_storage_type}

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -64,7 +64,9 @@ drbd:
   resource:
     - name: "sapdata"
       device: "/dev/drbd1"
+      {% if grains['provider'] != 'gcp' %}
       disk: {{ drbd_disk_device }}1
+      {% endif %}
 
       file_system: "xfs"
       mount_point: "{{ grains['nfs_mounting_point'] }}/{{ grains['nfs_export_name'] }}"
@@ -73,9 +75,15 @@ drbd:
       nodes:
         - name: {{ grains['name_prefix'] }}01
           ip: {{ grains['host_ips'][0] }}
+          {% if grains['provider'] == 'gcp' %}
+          disk: {{ grains['drbd_disk_device_list'][0] }}-part1
+          {% endif %}
           port: 7990
           id: 1
         - name: {{ grains['name_prefix'] }}02
           ip: {{ grains['host_ips'][1] }}
+          {% if grains['provider'] == 'gcp' %}
+          disk: {{ grains['drbd_disk_device_list'][1] }}-part1
+          {% endif %}
           port: 7990
           id: 2


### PR DESCRIPTION
DRBD have to use different backing device in GCP to support multiple google disks attached.
Use "by-id: /dev/disk/by-id/google-*" as backing device.

In GCP, it is like /dev/disk/by-id/google--disk-drbd--part1
Need to align pillar file to use the template res_single_vol_v9.j2

Need to align with corresponding pull request of drbd-formula(0.4.1) SUSE/drbd-formula#19