### PR TITLE
Fix fencing on GCE with onoff method

### DIFF
--- a/salt/drbd_node/files/templates/drbd_cluster.j2
+++ b/salt/drbd_node/files/templates/drbd_cluster.j2
@@ -58,6 +58,8 @@ primitive rsc_socat_{{ res.name }}_nfs azure-lb \
 primitive rsc_gcp_stonith_{{ res.name }}_{{ grains['host'] }} stonith:fence_gce \
   params plug={{ grains['gcp_instance_name'] }} pcmk_host_map="{{ grains['host'] }}:{{ grains['gcp_instance_name'] }}" \
   meta target-role=Started
+
+location loc_stonith_{{ res.name }}_{{ grains['host'] }} rsc_gcp_stonith_{{ res.name }}_{{ grains['host'] }} -inf: {{ grains['host'] }}
 {%- endif %}
 
 primitive vip_{{ res.name }}_nfs ocf:heartbeat:gcp-vpc-move-route \


### PR DESCRIPTION
Add a location constraint for fence_gce stronith resource.

The resource must *NOT* run on the same node it has to managed!

Because the agent has to stop and start the node, so if it runs on the same node it cannot do the start command, and so the node cannot be restarted.

Manually tested.

Command used to test the fencing: `crm node fence <node>`, a sysrq command can also be used to simulate a crash on the node.

Related bug: https://bugzilla.suse.com/show_bug.cgi?id=1182701

*NOTE:* I forget to add that this issue happens in newer versions of `fence_gce` available in SLE 15-SP3, no issue until now on previous version.