### PR TITLE
Avoid loki installation and usage in SLE12 in client side

### DIFF
--- a/salt/cluster_node/monitoring.sls
+++ b/salt/cluster_node/monitoring.sls
@@ -19,6 +19,7 @@ activate_node_exporter_systemd_collector:
     - contents: |
         ARGS="--collector.systemd --no-collector.mdadm"
 
+{%- if grains['osmajorrelease'] > 12 %}
 loki:
   pkg.installed:
     - name: loki
@@ -49,3 +50,4 @@ promtail_service:
       - pkg: loki
       - file: promtail_config
       - group: loki_systemd_journal_member
+{%- endif %}


### PR DESCRIPTION
As `loki` won't be supported nor used in SLE12 code streams we need to remove the installation and usage, to avoid false errors when `loki` installation fails.

**This only affects to the client side. The whole monitoring server is only supported in SLE15**