### PR TITLE
Implement bastion usage for GCP

### DIFF
--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -129,7 +129,8 @@ pre_deployment = true
 # Bastion (jumpbox) machine variables
 ##########################
 
-# Enable bastion usage. This option configures the deployment to only create a unique public ip address that is attached to the bastion machine
+# Enable bastion usage. If this option is enabled, it will create a unique public ip address that is attached to the bastion machine.
+# The rest of the machines won't have a public ip address and the SSH connection must be done through the bastion
 #bastion_enabled = true
 
 # Bastion SSH keys. If they are not set the public_key and private_key are used

--- a/doc/ip_autogeneration.md
+++ b/doc/ip_autogeneration.md
@@ -47,8 +47,9 @@ Example based on `10.0.0.0/24` VPC address range. The virtual addresses must be 
 | :---: | :---: | :----: | :---: |
 | Iscsi server | `iscsi_srv_ip` | `10.0.0.4` ||
 | Monitoring | `monitoring_srv_ip` | `10.0.0.5` ||
+| Bastion | - | `10.0.2.5` ||
 | Hana ips | `hana_ips` | `10.0.0.10`, `10.0.0.11` ||
-| Hana cluster vip | `hana_cluster_vip` | `10.0.2.12` | Only used if HA is enabled in HANA |
+| Hana cluster vip | `hana_cluster_vip` | `10.0.1.12` | Only used if HA is enabled in HANA |
 | Hana cluster vip secondary | `hana_cluster_vip_secondary` | `10.0.1.13` | Only used if the Active/Active setup is used |
 | DRBD ips | `drbd_ips` | `10.0.0.20`, `10.0.0.21` ||
 | DRBD cluster vip | `drbd_cluster_vip` | `10.0.1.22` ||

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -105,6 +105,7 @@ module "bastion" {
 
 # Create NAT service to provide external connection to the VMs without public ip address
 # This is just a basic NAT, more advanced configuration is possible
+# Based on: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-dm-deployment-sles#setting-up-a-nat-gateway
 resource "google_compute_router" "router" {
   count   = var.bastion_enabled ? 1 : 0
   name    = "${local.deployment_name}-router"

--- a/gcp/modules/bastion/main.tf
+++ b/gcp/modules/bastion/main.tf
@@ -1,0 +1,92 @@
+locals {
+  bastion_count      = var.common_variables["bastion_enabled"] ? 1 : 0
+  deployment_name    = var.common_variables["deployment_name"]
+  private_ip_address = cidrhost(var.snet_address_range, 5)
+  firewall_ports     = var.common_variables["monitoring_enabled"] ? ["22", "3000"] : ["22"]
+}
+
+# Bastion subnet
+resource "google_compute_subnetwork" "bastion_subnet" {
+  count         = local.bastion_count
+  name          = "${local.deployment_name}-bastion-subnet"
+  network       = var.network_link
+  region        = var.region
+  ip_cidr_range = var.snet_address_range
+}
+
+# Connection to the bastion
+resource "google_compute_firewall" "bastion_ingress_firewall" {
+  count              = local.bastion_count
+  name               = "${local.deployment_name}-bastion-ingress-firewall"
+  network            = var.network_link
+  target_tags        = ["bastion"]
+
+  allow {
+    protocol = "tcp"
+    ports    = local.firewall_ports
+  }
+}
+
+# Connection between bastion and other machines
+resource "google_compute_firewall" "bastion_egress_firewall" {
+  count         = local.bastion_count
+  name          = "${local.deployment_name}-bastion-egress-firewall"
+  network       = var.network_link
+  source_tags   = ["bastion"]
+
+  allow {
+    protocol = "tcp"
+    ports    = local.firewall_ports
+  }
+}
+
+resource "google_compute_instance" "bastion" {
+  count        = local.bastion_count
+  name         = "${var.common_variables["deployment_name"]}-bastion"
+  description  = "Bastion server"
+  machine_type = var.vm_size
+  zone         = element(var.compute_zones, 0)
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  network_interface {
+    subnetwork = google_compute_subnetwork.bastion_subnet.*.name[0]
+    network_ip = local.private_ip_address
+
+    access_config {
+      nat_ip = ""
+    }
+  }
+
+  scheduling {
+    automatic_restart   = true
+    on_host_maintenance = "MIGRATE"
+    preemptible         = false
+  }
+
+  boot_disk {
+    initialize_params {
+      image = var.os_image
+    }
+
+    auto_delete = true
+  }
+
+  metadata = {
+    sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["bastion_public_key"]}"
+  }
+
+  tags = ["bastion"]
+}
+
+module "bastion_on_destroy" {
+  source               = "../../../generic_modules/on_destroy"
+  node_count           = local.bastion_count
+  instance_ids         = google_compute_instance.bastion.*.id
+  user                 = var.common_variables["authorized_user"]
+  private_key          = var.common_variables["bastion_private_key"]
+  public_ips           = google_compute_instance.bastion.*.network_interface.0.access_config.0.nat_ip
+  dependencies         = var.on_destroy_dependencies
+}

--- a/gcp/modules/bastion/outputs.tf
+++ b/gcp/modules/bastion/outputs.tf
@@ -1,0 +1,3 @@
+output "public_ip" {
+  value = join("", google_compute_instance.bastion.*.network_interface.0.access_config.0.nat_ip)
+}

--- a/gcp/modules/bastion/salt_provisioner.tf
+++ b/gcp/modules/bastion/salt_provisioner.tf
@@ -1,0 +1,37 @@
+locals {
+  node_count = var.common_variables["provisioner"] == "salt" ? local.bastion_count : 0
+}
+
+resource "null_resource" "bastion_provisioner" {
+  count = local.node_count
+
+  triggers = {
+    bastion_id = join(",", google_compute_instance.bastion.*.id)
+  }
+
+  connection {
+    host        = element(google_compute_instance.bastion.*.network_interface.0.access_config.0.nat_ip, count.index)
+    type        = "ssh"
+    user        = var.common_variables["authorized_user"]
+    private_key = var.common_variables["bastion_private_key"]
+  }
+
+  provisioner "file" {
+    content = <<EOF
+role: bastion
+${var.common_variables["grains_output"]}
+EOF
+    destination = "/tmp/grains"
+}
+}
+
+module "bastion_provision" {
+  source               = "../../../generic_modules/salt_provisioner"
+  node_count           = local.node_count
+  instance_ids         = null_resource.bastion_provisioner.*.id
+  user                 = var.common_variables["authorized_user"]
+  private_key          = var.common_variables["bastion_private_key"]
+  public_ips           = google_compute_instance.bastion.*.network_interface.0.access_config.0.nat_ip
+  background           = var.common_variables["background"]
+  reboot               = false
+}

--- a/gcp/modules/bastion/variables.tf
+++ b/gcp/modules/bastion/variables.tf
@@ -1,0 +1,40 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
+variable "region" {
+  description = "GCP region where the bastion subnet is deployed"
+  type        = string
+}
+
+variable "os_image" {
+  description = "Image used to create the machine"
+  type        = string
+}
+
+variable "vm_size" {
+  description = "Bastion machine vm size"
+  type        = string
+  default     = "custom-1-2048"
+}
+
+variable "compute_zones" {
+  description = "gcp compute zones data"
+  type        = list(string)
+}
+
+variable "network_link" {
+  description = "Network link"
+  type        = string
+}
+
+variable "snet_address_range" {
+  description = "Subnet address range of the bastion subnet"
+  type        = string
+}
+
+variable "on_destroy_dependencies" {
+  description = "Resources objects need in the on_destroy script (everything that allows ssh connection)"
+  type        = any
+  default     = []
+}

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -1,6 +1,11 @@
 # drbd deployment in GCP to host a HA NFS share for SAP Netweaver
 # disclaimer: only supports a single NW installation
 
+locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? google_compute_instance.drbd.*.network_interface.0.network_ip : google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+}
+
 resource "google_compute_disk" "data" {
   count = var.drbd_count
   name  = "${var.common_variables["deployment_name"]}-disk-drbd-${count.index}"
@@ -32,8 +37,12 @@ resource "google_compute_instance" "drbd" {
     subnetwork = var.network_subnet_name
     network_ip = element(var.host_ips, count.index)
 
-    access_config {
-      nat_ip = ""
+    # Set public IP address. Only if the bastion is not used
+    dynamic "access_config" {
+      for_each = local.bastion_enabled ? [] : [1]
+      content {
+        nat_ip = ""
+      }
     }
   }
 
@@ -58,7 +67,7 @@ resource "google_compute_instance" "drbd" {
   }
 
   metadata = {
-    sshKeys = "root:${var.common_variables["public_key"]}"
+    sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["public_key"]}"
   }
 
   service_account {
@@ -70,8 +79,10 @@ module "drbd_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.drbd_count
   instance_ids         = google_compute_instance.drbd.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   dependencies         = var.on_destroy_dependencies
 }

--- a/gcp/modules/drbd_node/outputs.tf
+++ b/gcp/modules/drbd_node/outputs.tf
@@ -3,7 +3,7 @@ output "drbd_ip" {
 }
 
 output "drbd_public_ip" {
-  value = google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  value = local.bastion_enabled ? [] : google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "drbd_name" {

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -6,13 +6,14 @@ resource "null_resource" "drbd_provisioner" {
   }
 
   connection {
-    host = element(
-      google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip,
-      count.index,
-    )
+    host = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "root"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -51,8 +52,10 @@ module "drbd_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
   instance_ids         = null_resource.drbd_provisioner.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]
 }

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "machine_type" {
   type    = string
   default = "n1-standard-4"

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -1,7 +1,9 @@
 # HANA deployment in GCP
 
 locals {
-  create_ha_infra = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  create_ha_infra        = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? google_compute_instance.clusternodes.*.network_interface.0.network_ip : google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
 }
 
 # HANA disks configuration information: https://cloud.google.com/solutions/sap/docs/sap-hana-planning-guide#storage_configuration
@@ -63,8 +65,12 @@ resource "google_compute_instance" "clusternodes" {
     subnetwork = var.network_subnet_name
     network_ip = element(var.host_ips, count.index)
 
-    access_config {
-      nat_ip = ""
+    # Set public IP address. Only if the bastion is not used
+    dynamic "access_config" {
+      for_each = local.bastion_enabled ? [] : [1]
+      content {
+        nat_ip = ""
+      }
     }
   }
 
@@ -101,7 +107,7 @@ resource "google_compute_instance" "clusternodes" {
   }
 
   metadata = {
-    sshKeys = "root:${var.common_variables["public_key"]}"
+    sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["public_key"]}"
   }
 
   service_account {
@@ -113,8 +119,10 @@ module "hana_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.hana_count
   instance_ids         = google_compute_instance.clusternodes.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   dependencies         = var.on_destroy_dependencies
 }

--- a/gcp/modules/hana_node/outputs.tf
+++ b/gcp/modules/hana_node/outputs.tf
@@ -3,7 +3,7 @@ output "cluster_nodes_ip" {
 }
 
 output "cluster_nodes_public_ip" {
-  value = google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
+  value = local.bastion_enabled ? [] : google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "cluster_nodes_name" {

--- a/gcp/modules/hana_node/salt_provisioner.tf
+++ b/gcp/modules/hana_node/salt_provisioner.tf
@@ -10,13 +10,14 @@ resource "null_resource" "hana_node_provisioner" {
   }
 
   connection {
-    host = element(
-      google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip,
-      count.index,
-    )
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "root"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -53,8 +54,10 @@ module "hana_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
   instance_ids         = null_resource.hana_node_provisioner.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]
 }

--- a/gcp/modules/hana_node/variables.tf
+++ b/gcp/modules/hana_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "hana_count" {
   type    = string
   default = "2"

--- a/gcp/modules/iscsi_server/main.tf
+++ b/gcp/modules/iscsi_server/main.tf
@@ -1,3 +1,8 @@
+locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? google_compute_instance.iscsisrv.*.network_interface.0.network_ip : google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
+}
+
 resource "google_compute_disk" "iscsi_data" {
   count = var.iscsi_count
   name  = "${var.common_variables["deployment_name"]}-iscsi-data-${count.index + 1}"
@@ -21,8 +26,12 @@ resource "google_compute_instance" "iscsisrv" {
     subnetwork = var.network_subnet_name
     network_ip = element(var.host_ips, count.index)
 
-    access_config {
-      nat_ip = ""
+    # Set public IP address. Only if the bastion is not used
+    dynamic "access_config" {
+      for_each = local.bastion_enabled ? [] : [1]
+      content {
+        nat_ip = ""
+      }
     }
   }
 
@@ -47,7 +56,7 @@ resource "google_compute_instance" "iscsisrv" {
   }
 
   metadata = {
-    sshKeys = "root:${var.common_variables["public_key"]}"
+    sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["public_key"]}"
   }
 }
 
@@ -55,8 +64,10 @@ module "iscsi_on_destroy" {
   source               = "../../../generic_modules/on_destroy"
   node_count           = var.iscsi_count
   instance_ids         = google_compute_instance.iscsisrv.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   dependencies         = var.on_destroy_dependencies
 }

--- a/gcp/modules/iscsi_server/outputs.tf
+++ b/gcp/modules/iscsi_server/outputs.tf
@@ -3,7 +3,7 @@ output "iscsisrv_ip" {
 }
 
 output "iscsisrv_public_ip" {
-  value = join("", google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip)
+  value = local.bastion_enabled ? "" : join("", google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip)
 }
 
 output "iscsisrv_name" {

--- a/gcp/modules/iscsi_server/variables.tf
+++ b/gcp/modules/iscsi_server/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "machine_type" {
   type    = string
   default = "custom-1-2048"

--- a/gcp/modules/monitoring/outputs.tf
+++ b/gcp/modules/monitoring/outputs.tf
@@ -3,7 +3,7 @@ output "monitoring_ip" {
 }
 
 output "monitoring_public_ip" {
-  value = join("", google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip)
+  value = local.bastion_enabled ? "" : join("", google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip)
 }
 
 output "monitoring_name" {

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool

--- a/gcp/modules/netweaver_node/outputs.tf
+++ b/gcp/modules/netweaver_node/outputs.tf
@@ -3,7 +3,7 @@ output "netweaver_ip" {
 }
 
 output "netweaver_public_ip" {
-  value = google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
+  value = local.bastion_enabled ? [] : google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
 }
 
 output "netweaver_name" {

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -10,13 +10,14 @@ resource "null_resource" "netweaver_provisioner" {
   }
 
   connection {
-    host = element(
-      google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip,
-      count.index,
-    )
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "root"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -55,8 +56,10 @@ module "netweaver_provision" {
   source               = "../../../generic_modules/salt_provisioner"
   node_count           = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
   instance_ids         = null_resource.netweaver_provisioner.*.id
-  user                 = "root"
+  user                 = var.common_variables["authorized_user"]
   private_key          = var.common_variables["private_key"]
-  public_ips           = google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
+  bastion_host         = var.bastion_host
+  bastion_private_key  = var.common_variables["bastion_private_key"]
+  public_ips           = local.provisioning_addresses
   background           = var.common_variables["background"]
 }

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "machine_type" {
   type    = string
   default = "n1-standard-4"

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -93,3 +93,9 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
+
+# bastion
+
+output "bastion_public_ip" {
+  value = module.bastion.public_ip
+}

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -124,6 +124,21 @@ pre_deployment = true
 # true or false (default)
 #hwcct = false
 
+##########################
+# Bastion (jumpbox) machine variables
+##########################
+
+# Enable bastion usage. This option configures the deployment to only create a unique public ip address that is attached to the bastion machine
+#bastion_enabled = true
+
+# Bastion SSH keys. If they are not set the public_key and private_key are used
+#bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
+#bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
+
+# Bastion machine os image. If it is not provided, the os_image variable data is used
+# BYOS example
+# bastion_os_image = ""suse-byos-cloud/sles-15-sp2-sap-byos"
+
 #########################
 # HANA machines variables
 #########################

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -128,7 +128,8 @@ pre_deployment = true
 # Bastion (jumpbox) machine variables
 ##########################
 
-# Enable bastion usage. This option configures the deployment to only create a unique public ip address that is attached to the bastion machine
+# Enable bastion usage. If this option is enabled, it will create a unique public ip address that is attached to the bastion machine.
+# The rest of the machines won't have a public ip address and the SSH connection must be done through the bastion
 #bastion_enabled = true
 
 # Bastion SSH keys. If they are not set the public_key and private_key are used

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -55,6 +55,30 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "bastion_enabled" {
+  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_os_image" {
+  description = "sles4sap image used to create the bastion machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_public_key" {
+  description = "Content of a SSH public key or path to an already existing SSH public key to the bastion. If it's not set the key provided in public_key will be used"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Content of a SSH private key or path to an already existing SSH private key to the bastion. If it's not set the key provided in private_key will be used"
+  type        = string
+  default     = ""
+}
+
 # Deployment variables
 
 variable "deployment_name" {


### PR DESCRIPTION
Implementation of a bastion usage for GCP. Includes:
- Bastion machine implementation
- Use the correct firewall settings
- Create NAT resources to allow internet connectivity on VMs without public ip
- Change the other modules to use the bastion data

Based on: https://cloud.google.com/solutions/sap/docs/sap-hana-ha-dm-deployment-sles

https://github.com/SUSE/ha-sap-terraform-deployments/issues/644
FYI: @ab-mohamed