### PR TITLE
Remove wait_for_initialization from cluster pillar files

### DIFF
--- a/pillar_examples/automatic/drbd/cluster.sls
+++ b/pillar_examples/automatic/drbd/cluster.sls
@@ -8,7 +8,6 @@ cluster:
   interface: eth0
   {% endif %}
   unicast: True
-  wait_for_initialization: 120
   join_timeout: 180
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:

--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -12,7 +12,6 @@ cluster:
   interface: eth0
   unicast: True
   {% endif %}
-  wait_for_initialization: 120
   join_timeout: 500
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -17,7 +17,6 @@ cluster:
     module: softdog
     device: /dev/watchdog
   {% endif %}
-  wait_for_initialization: 120
   {%- if grains['app_server_count']|default(2) == 0 %}
   # join_timeout must be large as the 1st machine where the cluster is started will host
   # the DB and PAS installation, taking a long time


### PR DESCRIPTION
Remove wait_for_initialization from cluster pillar files as the parameter has been removed from `habootstrap-formula`

Based on: https://github.com/SUSE/habootstrap-formula/pull/76