### PR TITLE
Freeze deployment automation package versions

### DIFF
--- a/salt/os_setup/packages.sls
+++ b/salt/os_setup/packages.sls
@@ -2,17 +2,20 @@
 install-salt-formulas:
   pkg.installed:
     - pkgs:
+      - salt-shaptools: 0.3.11+git.1605797958.ae2f08a-3.6.1
       {%- if grains['role'] == 'iscsi_srv' %}
-      - iscsi-formula
+      - iscsi-formula: 1.1.1-1.6.1
       {%- elif grains['role'] == 'drbd_node' %}
-      - drbd-formula
-      - habootstrap-formula
+      - drbd-formula: 0.4.0+git.1611073587.55c0dfd-3.3.2
+      - habootstrap-formula: 0.4.1+git.1611775401.451718e-3.12.1
       {%- elif grains['role'] == 'hana_node' %}
-      - saphanabootstrap-formula
-      - habootstrap-formula
+      - python3-shaptools: 0.3.11+git.1605798399.b036435-3.6.1
+      - saphanabootstrap-formula: 0.7.0+git.1611071677.5443549-3.8.2
+      - habootstrap-formula: 0.4.1+git.1611775401.451718e-3.12.1
       {%- elif grains['role'] == 'netweaver_node' %}
-      - sapnwbootstrap-formula
-      - habootstrap-formula
+      - python3-shaptools: 0.3.11+git.1605798399.b036435-3.6.1
+      - sapnwbootstrap-formula: 0.6.0+git.1611071663.f186586-3.8.2
+      - habootstrap-formula: 0.4.1+git.1611775401.451718e-3.12.1
       {%- endif %}
     - retry:
         attempts: 3


### PR DESCRIPTION
Freeze the packages version involved in the deployment automation. This is needed to avoid errors if non backward compatible changes are introduced, specially in the formulas (which is quite common by now).

Some context:
As we don't expect to continue adding new features to this 1st version of the console project, having frozen packages is the best option. This will avoid unexpected errors in the future.
I have noticed that all the versions are stored in our SCC channels, so it gives the option to specify versions.
It is a pretty straightforward change and doesn't imply major consequences as we want to always stay in these versions.

The used versions are the current latest versions in the SLES4SAP product (all the testing has been done with them). When new versions are submitted, the same older versions are used.