### PR TITLE
install terraform-provider-libvirt in travis

### DIFF
--- a/.ci/validate-terraform.sh
+++ b/.ci/validate-terraform.sh
@@ -23,7 +23,6 @@ for provider in $(find * -maxdepth 0 -type d | grep -Ev 'salt|pillar_examples|do
   echo "--------------------------"
   /tmp/terraform fmt -check ;
   rm -f remote-state.tf ;
-  if [[ "$provider" == "libvirt" ]]; then continue ; fi ;
   echo "--------------------------"
   echo "** PASSED ** "
   echo "--------------------------"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,11 @@ matrix:
         - unzip /tmp/terraform -d /tmp
         - chmod +x /tmp/terraform
         - /tmp/terraform -version
+        # install terraform-proivder-libvirt
+        - echo 'deb http://download.opensuse.org/repositories/systemsmanagement:/terraform/Ubuntu_20.04/ /' | sudo tee /etc/apt/sources.list.d/systemsmanagement:terraform.list
+        - curl -fsSL https://download.opensuse.org/repositories/systemsmanagement:terraform/Ubuntu_20.04/Release.key | gpg --dearmor | sudo tee /etc/apt/trusted.gpg.d/systemsmanagement_terraform.gpg > /dev/null
+        - sudo apt-get update
+        - sudo apt-get -y install terraform-provider-libvirt
       script:
         - .ci/validate-terraform.sh
         - shellcheck salt/provision.sh


### PR DESCRIPTION
This installs terraform-provider-libvirt in travis and enables checks on libvirt provider again.