### PR TITLE
libvirt: Draft/shared storage architecture for Hana scaleout and Netweaver 

### DIFF
--- a/libvirt/modules/nfs_server/main.tf
+++ b/libvirt/modules/nfs_server/main.tf
@@ -1,0 +1,100 @@
+terraform {
+  required_version = ">= 0.13"
+  required_providers {
+    libvirt = {
+      source  = "dmacvicar/libvirt"
+      version = "0.6.3"
+    }
+  }
+}
+
+resource "libvirt_volume" "nfs_server_image_disk" {
+  count            = var.nfs_server_count
+  name             = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-main-disk"
+  source           = var.source_image
+  base_volume_name = var.volume_name
+  pool             = var.storage_pool
+}
+
+resource "libvirt_volume" "nfs_server_data_disk" {
+  name  = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-nfs-disk"
+  pool  = var.storage_pool
+  count = var.nfs_server_count
+  size  = var.nfs_server_disk_size
+}
+
+resource "libvirt_domain" "nfs_server_domain" {
+  name       = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}"
+  memory     = var.memory
+  vcpu       = var.vcpu
+  count      = var.nfs_server_count
+  qemu_agent = true
+  dynamic "disk" {
+    for_each = [
+      {
+        "vol_id" = element(libvirt_volume.nfs_server_image_disk.*.id, count.index)
+      },
+      {
+        "vol_id" = element(libvirt_volume.nfs_server_data_disk.*.id, count.index)
+      },
+    ]
+    content {
+      volume_id = disk.value.vol_id
+    }
+  }
+
+  network_interface {
+    wait_for_lease = true
+    network_name   = var.network_name
+    bridge         = var.bridge
+    mac            = var.mac
+  }
+
+  network_interface {
+    wait_for_lease = false
+    network_name   = var.isolated_network_name
+    network_id     = var.isolated_network_id
+    addresses      = [element(var.host_ips, count.index)]
+  }
+
+  console {
+    type        = "pty"
+    target_port = "0"
+    target_type = "serial"
+  }
+
+  console {
+    type        = "pty"
+    target_type = "virtio"
+    target_port = "1"
+  }
+
+  graphics {
+    type        = "spice"
+    listen_type = "address"
+    autoport    = true
+  }
+
+  cpu = {
+    mode = "host-passthrough"
+  }
+}
+
+output "output_data" {
+  value = {
+    id                = libvirt_domain.nfs_server_domain.*.id
+    name              = libvirt_domain.nfs_server_domain.*.name
+    private_addresses = var.host_ips
+    addresses         = libvirt_domain.nfs_server_domain.*.network_interface.0.addresses.0
+  }
+}
+
+module "nfs_server_on_destroy" {
+  source       = "../../../generic_modules/on_destroy"
+  node_count   = var.nfs_server_count
+  instance_ids = libvirt_domain.nfs_server_domain.*.id
+  user         = "root"
+  password     = "linux"
+  public_ips   = libvirt_domain.nfs_server_domain.*.network_interface.0.addresses.0
+  dependencies = [libvirt_domain.nfs_server_domain]
+}

--- a/libvirt/modules/nfs_server/salt_provisioner.tf
+++ b/libvirt/modules/nfs_server/salt_provisioner.tf
@@ -1,0 +1,47 @@
+# This file contains the salt provisioning logic.
+# It will be executed if 'provisioner' is set to 'salt' (default option) and the
+# libvirt_domain.domain (netweaver_node) resources are created (check triggers option).
+
+resource "null_resource" "netweaver_node_provisioner" {
+  count = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
+  triggers = {
+    netweaver_ids = libvirt_domain.netweaver_domain[count.index].id
+  }
+
+  connection {
+    host     = libvirt_domain.netweaver_domain[count.index].network_interface.0.addresses.0
+    user     = "root"
+    password = "linux"
+  }
+
+  provisioner "file" {
+    content     = <<EOF
+role: netweaver_node
+${var.common_variables["grains_output"]}
+${var.common_variables["netweaver_grains_output"]}
+name_prefix: ${var.name}
+hostname: ${var.name}0${count.index + 1}
+network_domain: ${var.network_domain}
+timezone: ${var.timezone}
+host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
+virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
+host_ip: ${element(var.host_ips, count.index)}
+app_server_count: ${var.app_server_count}
+netweaver_inst_media: ${var.netweaver_inst_media}
+sbd_disk_device: "${var.common_variables["netweaver"]["sbd_storage_type"] == "shared-disk" ? "/dev/vdb1" : ""}"
+sbd_lun_index: 1
+iscsi_srv_ip: ${var.iscsi_srv_ip}
+EOF
+    destination = "/tmp/grains"
+  }
+}
+
+module "netweaver_provision" {
+  source       = "../../../generic_modules/salt_provisioner"
+  node_count   = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
+  instance_ids = null_resource.netweaver_node_provisioner.*.id
+  user         = "root"
+  password     = "linux"
+  public_ips   = libvirt_domain.netweaver_domain.*.network_interface.0.addresses.0
+  background   = var.common_variables["background"]
+}

--- a/libvirt/modules/nfs_server/variables.tf
+++ b/libvirt/modules/nfs_server/variables.tf
@@ -1,0 +1,38 @@
+resource "null_resource" "nfs_provisioner" {
+  count = var.common_variables["provisioner"] == "salt" ? var.nfs_pool_count : 0
+  triggers = {
+    nfs_pool_ids = libvirt_domain.nfs_server_domain[count.index].id
+  }
+
+  connection {
+    host     = libvirt_domain.nfs_server_domain[count.index].network_interface.0.addresses.0
+    user     = "root"
+    password = "linux"
+  }
+
+  provisioner "file" {
+    content     = <<EOF
+role: nfs_pool
+${var.common_variables["grains_output"]}
+name_prefix: ${var.common_variables["deployment_name"]}-${var.name}
+hostname: ${var.common_variables["deployment_name"]}-${var.name}
+timezone: ${var.timezone}
+network_domain: ${var.network_domain}
+host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
+host_ip: ${element(var.host_ips, count.index)}
+nfs_mounting_point: ${var.nfs_mounting_point}
+nfs_export_name: ${var.nfs_export_name}
+EOF
+    destination = "/tmp/grains"
+  }
+}
+
+module "nfs_provision" {
+  source       = "../../../generic_modules/salt_provisioner"
+  node_count   = var.common_variables["provisioner"] == "salt" ? var.nfs_pool_count : 0
+  instance_ids = null_resource.nfs_provisioner.*.id
+  user         = "root"
+  password     = "linux"
+  public_ips   = libvirt_domain.nfs_server_domain.*.network_interface.0.addresses.0
+  background   = var.common_variables["background"]
+}

--- a/libvirt/modules/shared_storage/main.tf
+++ b/libvirt/modules/shared_storage/main.tf
@@ -1,0 +1,29 @@
+locals {
+
+  # Check if shared storage type is "drbd"
+  drbd_enabled = var.shared_storage_enabled && shared_storage_type == "drbd"
+}
+
+module "drbd_node" {
+  source                = "./drbd_node"
+  common_variables      = module.common_variables.configuration
+  name                  = "drbd"
+  source_image          = var.drbd_source_image
+  volume_name           = var.drbd_source_image != "" ? "" : (var.drbd_volume_name != "" ? var.drbd_volume_name : local.generic_volume_name)
+  drbd_count            = local.drbd_enabled == true ? 2 : 0
+  vcpu                  = var.drbd_node_vcpu
+  memory                = var.drbd_node_memory
+  bridge                = "br0"
+  host_ips              = var.drbd_ips
+  drbd_cluster_vip      = var.drbd_cluster_vip
+  drbd_disk_size        = var.drbd_disk_size
+  fencing_mechanism     = var.drbd_cluster_fencing_mechanism
+  sbd_storage_type      = var.sbd_storage_type
+  sbd_disk_id           = module.drbd_sbd_disk.id
+  iscsi_srv_ip          = module.iscsi_server.output_data.private_addresses.0
+  isolated_network_id   = var.internal_network_id
+  isolated_network_name = var.internal_network_name
+  storage_pool          = var.storage_pool
+  nfs_mounting_point    = var.drbd_nfs_mounting_point
+  nfs_export_name       = var.nfs_export_name
+}

--- a/libvirt/modules/shared_storage/variables.tf
+++ b/libvirt/modules/shared_storage/variables.tf
@@ -1,0 +1,103 @@
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
+variable "timezone" {
+  description = "Timezone setting for all VMs"
+  default     = "Europe/Berlin"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  default     = "majoritymaker"
+}
+
+variable "common_variables" {
+  description = "Output of the common_variables module"
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+
+variable "drbd_count" {
+  description = "number of hosts like this one"
+  default     = 2
+}
+
+variable "drbd_disk_size" {
+  description = "drbd partition disk size"
+  default     = "1024000000" # 1GB
+}
+
+variable "drbd_ips" {
+  description = "ip addresses to set to the nodes"
+  type        = list(string)
+}
+
+variable "drbd_cluster_vip" {
+  description = "IP address used to configure the drbd cluster floating IP. It must be in other subnet than the machines!"
+  type        = string
+}
+
+variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+}
+
+variable "nfs_export_name" {
+  description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
+  type        = string
+}
+
+
+// Provider-specific variables
+
+variable "source_image" {
+  description = "Source image used to boot the machines (qcow2 format). It's possible to specify the path to a local (relative to the machine running the terraform command) image or a remote one. Remote images have to be specified using HTTP(S) urls for now."
+  type        = string
+  default     = ""
+}
+
+variable "volume_name" {
+  description = "Already existing volume name used to boot the machines. It must be in the same storage pool. It's only used if source_image is not provided"
+  type        = string
+  default     = ""
+}
+
+variable "memory" {
+  description = "RAM memory in MiB"
+  default     = 4096
+}
+
+variable "vcpu" {
+  description = "Number of virtual CPUs"
+  default     = 1
+}
+
+variable "mac" {
+  description = "a MAC address in the form AA:BB:CC:11:22:22"
+  default     = ""
+}
+
+variable "cpu_model" {
+  description = "Define what CPU model the guest is getting (host-model, host-passthrough or the default)."
+  default     = ""
+}
+
+variable "isolated_network_id" {
+  description = "Network id, internally created by terraform"
+  type        = string
+}
+
+variable "isolated_network_name" {
+  description = "Network name to attach the isolated network interface"
+  type        = string
+}
+
+variable "storage_pool" {
+  description = "libvirt storage pool name for VM disks"
+  default     = "default"
+}

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -205,13 +205,16 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 #monitoring_srv_ip = "192.168.XXX.Y+7"
 
 ########################
-# DRBD related variables
+# Storage related variables
 ########################
 
-# Enable the DRBD cluster for nfs
-#drbd_enabled = true
+# Enable the shared storage system which is required for storing part of the data in SAP applications. This can be a NFS server or DRBD provided NFS storage
+#shared_storage_enabled = true
 
-# IP of DRBD cluster
+# Select the type of storage. Current options are drbd or nfs
+#shared_storage_type = "drbd"
+
+# IP of DRBD cluster, if using drbd for storage
 #drbd_ips = ["192.168.XXX.Y+8", "192.168.XXX.Y+9"]
 
 # NFS share mounting point and export. Warning: Since cloud images are using cloud-init, /mnt folder cannot be used as standard mounting point folder

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -554,7 +554,7 @@ variable "netweaver_cluster_fencing_mechanism" {
 }
 
 variable "netweaver_nfs_share" {
-  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
+  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd is used for storage, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
   type        = string
   default     = ""
 }
@@ -625,14 +625,26 @@ variable "netweaver_ha_enabled" {
   default     = true
 }
 
+
+#
+# Shared Storage variables
+#
+
+variable "shared_storage_enabled" {
+  description = "Enable the shared storage system which is required for storing part of the data in SAP applications"
+  type        = bool
+  default     = true
+}
+
+variable "shared_storage_type" {
+  description = "Select the type of storage. Current options: drbd or nfs"
+  type        = string
+  default     = ""
+}
+
 #
 # DRBD related variables
 #
-variable "drbd_enabled" {
-  description = "Enable the drbd cluster for nfs"
-  type        = bool
-  default     = false
-}
 
 variable "drbd_source_image" {
   description = "Source image used to bot the drbd machines (qcow2 format). It's possible to specify the path to a local (relative to the machine running the terraform command) image or a remote one. Remote images have to be specified using HTTP(S) urls for now."
@@ -695,6 +707,52 @@ variable "drbd_cluster_fencing_mechanism" {
 }
 
 variable "drbd_nfs_mounting_point" {
+  description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
+  type        = string
+  default     = "/mnt_permanent/sapdata"
+}
+
+#
+# NFS server variables
+#
+
+variable "nfs_server_enabled" {
+  description = "Enable the drbd cluster for nfs"
+  type        = bool
+  default     = false
+}
+
+variable "nfs_server_source_image" {
+  description = "Source image used to boot the nfs server machine (qcow2 format). It's possible to specify the path to a local (relative to the machine running the terraform command) image or a remote one. Remote images have to be specified using HTTP(S) urls for now."
+  type        = string
+  default     = ""
+}
+
+variable "nfs_server_volume_name" {
+  description = "Already existing volume name boot to create the nfs server machine. It must be in the same storage pool. It's only used if nfs_server_source_image is not provided"
+  type        = string
+  default     = ""
+}
+
+variable "nfs_server_vcpu" {
+  description = "Number of CPUs for the nfs server machine"
+  type        = number
+  default     = 1
+}
+
+variable "nfs_server_memory" {
+  description = "Memory (in MBs) for the nfs server machine"
+  type        = number
+  default     = 1024
+}
+
+variable "nfs_server_disk_size" {
+  description = "Disk size (in bytes) for the nfs server machine"
+  type        = number
+  default     = 10737418240
+}
+
+variable "nfs_mounting_point" {
   description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
   type        = string
   default     = "/mnt_permanent/sapdata"

--- a/salt/nfs_srv/init.sls
+++ b/salt/nfs_srv/init.sls
@@ -1,0 +1,3 @@
+include:
+  - nfs_pool.nfs_server
+  - nfs_pool.nfs_packages

--- a/salt/nfs_srv/nfs_packages.sls
+++ b/salt/nfs_srv/nfs_packages.sls
@@ -1,0 +1,13 @@
+parted_package:
+  pkg.installed:
+    - name: parted
+    - retry:
+        attempts: 3
+        interval: 15
+
+nfs_packages:
+  pkg.installed:
+    - name: nfs-kernel-server
+    - retry:
+        attempts: 3
+        interval: 15

--- a/salt/nfs_srv/nfs_server.sls
+++ b/salt/nfs_srv/nfs_server.sls
@@ -1,0 +1,19 @@
+create_nfs_folder:
+  file.directory:
+    - name: {{ grains['nfs_mounting_point'] }}
+    - user: root
+    - mode: "0755"
+    - makedirs: True
+
+
+configure_nfs:
+  nfs_export.present:
+    - name: {{ grains['nfs_mounting_point'] }}
+    - hosts: '*'
+    - options:
+      - rw
+      - no_root_squash
+      - fsid=0
+      - no_subtree_check
+    - require:
+      - create_nfs_folder


### PR DESCRIPTION
The motivation behind this architecture change is to have one terraform module for providing shared storage to all type of deployments. Depending on the type of deployed application(SAP Hana scaleout, NW etc) user can choose the type of needed shared storage, and at the same time configure the storage parameters like disk, cpu resources etc. This configuration is needed as resources will be different on type of deployed application. 
Currently the project supports NFS and Drbd provided storage options.
The changes are not complete and I create this draft for time being while testing new additional changes