### PR TITLE
fix(prometheus): corosync service not checked

### DIFF
--- a/salt/monitoring_srv/prometheus/rules.yml
+++ b/salt/monitoring_srv/prometheus/rules.yml
@@ -55,12 +55,12 @@ groups:
     annotations:
       summary: a drbd connection is an bad state inconsistent|outdated|dunknown|failed
 
-  - alert: drbd-sync-connections-percentage-lower-then-expected
+  - alert: drbd-sync-connections-percentage-lower-than-expected
     expr: ha_cluster_drbd_connections_sync < 90
     labels:
       severity: page
     annotations:
-      summary: a drbd disk sync is lower then 90 percent!
+      summary: a drbd disk sync is lower than 90 percent!
 
   - alert: drbd-resource-in-a-bad-state
     expr: count(ha_cluster_drbd_resources{peer_disk_state=~"inconsistent|outdated|dunknown|failed"}) > 0
@@ -90,7 +90,7 @@ groups:
       summary: Pacemaker service not running
 
   - alert: service-down-corosync
-    expr: node_systemd_unit_state{name="pacemaker.service", state="active"} == 0
+    expr: node_systemd_unit_state{name="corosync.service", state="active"} == 0
     labels:
       severity: page
     annotations:


### PR DESCRIPTION
The pacemaker unit is checked twice. Corosync however, is not checked.