### PR TITLE
fix(ci)

### DIFF
--- a/generic_modules/common_variables/variables.tf
+++ b/generic_modules/common_variables/variables.tf
@@ -3,9 +3,9 @@ variable "provider_type" {
   type        = string
   validation {
     condition = (
-      can(regex("^(aws|azure|gcp|libvirt)$", var.provider_type))
+      can(regex("^(aws|azure|gcp|libvirt|openstack)$", var.provider_type))
     )
-    error_message = "Invalid provider type. Options: aws|azure|gcp|libvirt ."
+    error_message = "Invalid provider type. Options: aws|azure|gcp|libvirt|openstack ."
   }
 }
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -129,6 +129,7 @@ module "common_variables" {
   hana_client_archive_file            = var.hana_client_archive_file
   hana_client_extract_dir             = var.hana_client_extract_dir
   hana_scenario_type                  = var.scenario_type
+  hana_cluster_vip_mechanism          = ""
   hana_cluster_vip                    = local.hana_cluster_vip
   hana_cluster_vip_secondary          = var.hana_active_active ? local.hana_cluster_vip_secondary : ""
   hana_ha_enabled                     = var.hana_ha_enabled


### PR DESCRIPTION
Having submitted another PR, I see the tests are failing with something like:

```
Error: Missing required argument
  on main.tf line 89, in module "common_variables":
  89: module "common_variables" {
The argument "hana_cluster_vip_mechanism" is required, but no definition was
found.
```

Might be related to a previous merge: https://github.com/SUSE/ha-sap-terraform-deployments/commit/4e4014e50842445e40baa7684d76f677406b0c10#diff-4c1d93077429e7e054503aad146fb57c858ccbddbf7661b79833d0df000fb582R89

Searching for `hana_cluster_vip_mechanism` in that repository, I would end up here: https://github.com/SUSE/ha-sap-terraform-deployments/pull/659/files#diff-66519e86321302d0740fac251bcd1fba3787deca61a68133fb8a0270f2b0d12dR34

Sounds like it's been introduced dealing with some GCP specific, which may not make sense in OSP.
In doubt, checking what's been done with another provider:

https://github.com/SUSE/ha-sap-terraform-deployments/pull/659/files#diff-afcb3ab4d99298cacacab676e53e1ef05f8159f8e7087a0a3f2cbe9ca32c7b7fR95

Let's do the same with OSP, see how that goes ...