### PR TITLE
docs(#491): removes references to `shared_storage_type`

### DIFF
--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -36,7 +36,6 @@ fencing_mechanism: ${var.fencing_mechanism}
 drbd_disk_device: /dev/xvdd
 drbd_cluster_vip: ${var.drbd_cluster_vip}
 route_table: ${var.route_table_id}
-shared_storage_type: iscsi
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}

--- a/doc/deployment-templates.md
+++ b/doc/deployment-templates.md
@@ -33,7 +33,6 @@ reg_email = "MY_EMAIL"
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
 # Specific SLE version used in all the created machines
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-shared_storage_type = "shared-disk"
 storage_pool           = "terraform"
 ```
 
@@ -59,7 +58,6 @@ reg_email = "MY_EMAIL"
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
 # Specific SLE version used in all the created machines
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-shared_storage_type = "shared-disk"
 storage_pool           = "terraform"
 ```
 
@@ -78,7 +76,6 @@ reg_email = "MY_EMAIL"
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
 # Specific SLE version used in all the created machines
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-shared_storage_type = "iscsi"
 iscsi_srv_ip = "192.168.110.31"
 iscsi_image = "SLE15 IMAGE"
 storage_pool           = "terraform"
@@ -101,13 +98,11 @@ reg_email = "MY_EMAIL"
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/"
 # Specific SLE version used in all the created machines
 ha_sap_deployment_repo = "http://download.opensuse.org/repositories/network:/ha-clustering:/Factory/SLE_15/"
-shared_storage_type = "shared-disk"
 storage_pool           = "terraform"
 netweaver_inst_media = "PATH INST MEDIA"
 netweaver_nfs_share      = "192.168.110.201:/HA1"
 netweaver_enabled        = true
 drbd_enabled           = true
-drbd_shared_storage_type = "shared-disk"
 drbd_ips               = ["192.168.110.23", "192.168.110.22"]
 nw_ips                 = ["192.168.110.24", "192.168.110.25", "192.168.110.26", "192.168.110.27"]
 nw_virtual_ips          = ["192.168.110.31", "192.168.110.30", "192.168.110.29", "192.168.119.28"]

--- a/doc/drbd.md
+++ b/doc/drbd.md
@@ -20,8 +20,6 @@ In order to deploy a DRBD environment for NFS, some changes must be executed in 
 
 ### Additional options
 
-- Choose the `drbd_shared_storage_type` to use different type of storage to *sbd* for HA cluster (azure only uses the `iscsi` option).
-
 - Choose the `drbd_cluster_vip` to be used as the drbd cluster floating ip address. This address must be outside of the subnet ip range (gcp only).
 
 - Configure the `drbd_disk_size` for the size of attached DRBD backing device. Modify the `partitions` grain in [salt_provisioner.tf](../libvirt/modules/drbd_node/salt_provisioner.tf) for the layout of the disk for DRBD resouce.

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -386,7 +386,7 @@ variable "iscsi_volume_name" {
 }
 
 variable "iscsi_srv_ip" {
-  description = "iSCSI server address (only used if shared_storage_type is iscsi)"
+  description = "iSCSI server address"
   type        = string
   default     = ""
   validation {


### PR DESCRIPTION
... as well as `drbd_shared_storage_type`. I can't find it reused anywhere.