### PR TITLE
S/4HANA Master Password

### DIFF
--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -359,7 +359,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# Netweaver master password. It must follow the SAP Password policies such as having 8 characters at least combining upper and lower case characters and numbers. It cannot start with special characters.
+# Netweaver or S/4HANA master password. 
+# It must follow the SAP Password policies such as having 8 characters at least for NetWeaver or 10 characters at least for S/4HANA combining upper and lower case characters and numbers.
+# It cannot start with special characters.
 #netweaver_master_password = "SuSE1234"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers


### PR DESCRIPTION
S/4HANA master password must be 10 characters at least. 
Refer to `https://github.com/SUSE/ha-sap-terraform-deployments/issues/683#issuecomment-826701299`

