### PR TITLE
GCP - Increase the NAT mininum nuamber of ports for the bastion - Monitoring PAYG fixed

### DIFF
--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -127,5 +127,5 @@ resource "google_compute_router_nat" "nat" {
     source_ip_ranges_to_nat = ["ALL_IP_RANGES"]
   }
 
-  min_ports_per_vm = 160
+  min_ports_per_vm = var.bastion_nat_min_ports_per_vm
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -164,7 +164,8 @@ module "drbd_node" {
   nfs_mounting_point   = var.drbd_nfs_mounting_point
   nfs_export_name      = var.netweaver_sid
   on_destroy_dependencies = [
-    google_compute_firewall.ha_firewall_allow_tcp
+    google_compute_firewall.ha_firewall_allow_tcp,
+    module.bastion
   ]
 }
 
@@ -188,7 +189,8 @@ module "netweaver_node" {
   netweaver_software_bucket = var.netweaver_software_bucket
   virtual_host_ips          = local.netweaver_virtual_ips
   on_destroy_dependencies = [
-    google_compute_firewall.ha_firewall_allow_tcp
+    google_compute_firewall.ha_firewall_allow_tcp,
+    module.bastion
   ]
 }
 
@@ -213,7 +215,8 @@ module "hana_node" {
   cluster_ssh_key       = var.cluster_ssh_key
   on_destroy_dependencies = [
     google_compute_firewall.ha_firewall_allow_tcp,
-    google_compute_router_nat.nat
+    google_compute_router_nat.nat,
+    module.bastion
   ]
 }
 
@@ -231,7 +234,8 @@ module "monitoring" {
   netweaver_targets   = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   on_destroy_dependencies = [
     google_compute_firewall.ha_firewall_allow_tcp,
-    google_compute_router_nat.nat
+    google_compute_router_nat.nat,
+    module.bastion
   ]
 }
 
@@ -248,6 +252,7 @@ module "iscsi_server" {
   lun_count           = var.iscsi_lun_count
   iscsi_disk_size     = var.iscsi_disk_size
   on_destroy_dependencies = [
-    google_compute_firewall.ha_firewall_allow_tcp
+    google_compute_firewall.ha_firewall_allow_tcp,
+    module.bastion
   ]
 }

--- a/gcp/modules/bastion/main.tf
+++ b/gcp/modules/bastion/main.tf
@@ -47,10 +47,6 @@ resource "google_compute_instance" "bastion" {
   machine_type = var.vm_size
   zone         = element(var.compute_zones, 0)
 
-  lifecycle {
-    create_before_destroy = true
-  }
-
   network_interface {
     subnetwork = google_compute_subnetwork.bastion_subnet.*.name[0]
     network_ip = local.private_ip_address

--- a/gcp/modules/iscsi_server/main.tf
+++ b/gcp/modules/iscsi_server/main.tf
@@ -18,9 +18,7 @@ resource "google_compute_instance" "iscsisrv" {
   machine_type = var.machine_type
   zone         = element(var.compute_zones, 0)
 
-  lifecycle {
-    create_before_destroy = true
-  }
+  can_ip_forward = true
 
   network_interface {
     subnetwork = var.network_subnet_name
@@ -57,6 +55,10 @@ resource "google_compute_instance" "iscsisrv" {
 
   metadata = {
     sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["public_key"]}"
+  }
+
+  service_account {
+    scopes = ["compute-rw", "storage-rw", "logging-write", "monitoring-write", "service-control", "service-management"]
   }
 }
 

--- a/gcp/modules/monitoring/main.tf
+++ b/gcp/modules/monitoring/main.tf
@@ -21,9 +21,7 @@ resource "google_compute_instance" "monitoring" {
   machine_type = "custom-1-2048"
   zone         = element(var.compute_zones, 0)
 
-  lifecycle {
-    create_before_destroy = true
-  }
+  can_ip_forward = true
 
   network_interface {
     subnetwork = var.network_subnet_name
@@ -60,6 +58,10 @@ resource "google_compute_instance" "monitoring" {
 
   metadata = {
     sshKeys = "${var.common_variables["authorized_user"]}:${var.common_variables["public_key"]}"
+  }
+
+  service_account {
+    scopes = ["compute-rw", "storage-rw", "logging-write", "monitoring-write", "service-control", "service-management"]
   }
 }
 

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -140,6 +140,11 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # BYOS example
 # bastion_os_image = """suse-byos-cloud/sles-15-sp2-sap-byos""
 
+# Minimum ports per VM instance for the NAT router. Decreasing this value can compromise the deployment and make it fail
+# This value is a number between 1 and 1024
+# Find more information at: https://cloud.google.com/nat/docs/ports-and-addresses#port-reservation-procedure
+#bastion_nat_min_ports_per_vm = 1204
+
 #########################
 # HANA machines variables
 #########################

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -85,6 +85,12 @@ variable "bastion_private_key" {
   default     = ""
 }
 
+variable "bastion_nat_min_ports_per_vm" {
+  description = "Minimum ports per VM instance for the NAT router. Decreasing this value can compromise the deployment and make it fail"
+  type        = number
+  default     = 1024
+}
+
 # Deployment variables
 
 variable "deployment_name" {


### PR DESCRIPTION
If you PAYG images are used, the deployment fails due the lack of connection ports to get the packages from SCC. This is due the low number of `minimum ports per VM` of the NAT resource. Increasing this value fixes the issue.

Now the value is configurable.

Fix for:https://github.com/SUSE/ha-sap-terraform-deployments/issues/693

FYI: @ab-mohamed

**Edit**: The 2nd commit (https://github.com/SUSE/ha-sap-terraform-deployments/pull/694/commits/c9e8a124c4c9dcc443a0be6ca0e6a9a0a0e21c44) fixes the Monitoring and iSCSI machines deployment when the bastion host is used and the other machines are using PAYG images