### PR TITLE
"unicast: True" in libvirt pillars

### DIFF
--- a/pillar_examples/automatic/hana/cluster.sls
+++ b/pillar_examples/automatic/hana/cluster.sls
@@ -10,8 +10,8 @@ cluster:
   interface: eth1
   {% else %}
   interface: eth0
-  unicast: True
   {% endif %}
+  unicast: True
   join_timeout: 500
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -8,8 +8,8 @@ cluster:
   interface: eth1
   {%- else %}
   interface: eth0
-  unicast: True
   {%- endif %}
+  unicast: True
   {% if grains['fencing_mechanism'] == 'sbd' %}
   sbd:
     device: {{ grains['sbd_disk_device']|default('') }}

--- a/pillar_examples/libvirt/cost_optimized/cluster.sls
+++ b/pillar_examples/libvirt/cost_optimized/cluster.sls
@@ -2,6 +2,7 @@ cluster:
   name: 'hana_cluster'
   init: 'hana01'
   interface: 'eth1'
+  unicast: True
   watchdog:
     module: softdog
     device: /dev/watchdog

--- a/pillar_examples/libvirt/performance_optimized/cluster.sls
+++ b/pillar_examples/libvirt/performance_optimized/cluster.sls
@@ -2,6 +2,7 @@ cluster:
   name: 'hana_cluster'
   init: 'hana01'
   interface: 'eth1'
+  unicast: True
   watchdog:
     module: softdog
     device: /dev/watchdog


### PR DESCRIPTION
This sets `unicast: True` in the libvirt pillars.
This is the same value as in any other cloud provider.