### PR TITLE
fix monitoring and azure native fence default values

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -136,7 +136,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -136,7 +136,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -134,7 +134,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -134,7 +134,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -843,9 +843,11 @@ variable "pre_deployment" {
 variable "fence_agent_app_id" {
   description = "ID of the azure service principal / application that is used for native fencing."
   type        = string
+  default     = ""
 }
 
 variable "fence_agent_client_secret" {
   description = "Secret for the azure service principal / application that is used for native fencing."
   type        = string
+  default     = ""
 }

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -146,7 +146,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -146,7 +146,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -122,7 +122,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -122,7 +122,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -171,7 +171,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -171,7 +171,7 @@ module "common_variables" {
   monitoring_drbd_targets_ha          = var.drbd_enabled ? local.drbd_ips : []
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
-  monitoring_netweaver_targets_ha     = var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
+  monitoring_netweaver_targets_ha     = var.netweaver_enabled ? (var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []) : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
 }
 


### PR DESCRIPTION
This fixes:
 - a logic error in defining `monitoring_netweaver_targets_ha` #724.
 - set default values for azure native fencing variables