### PR TITLE
powervs: Add bastion host info to connection details

### DIFF
--- a/generic_modules/salt_provisioner/main.tf
+++ b/generic_modules/salt_provisioner/main.tf
@@ -46,6 +46,10 @@ resource "null_resource" "provision" {
     user        = var.user
     password    = var.password
     private_key = var.private_key != "" ? var.private_key : ""
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.user
+    bastion_private_key = var.bastion_private_key != "" ? var.bastion_private_key : ""
   }
 
   provisioner "file" {


### PR DESCRIPTION
Missed adding this change to PR [powervs: Enable bastion private network #727](https://github.com/SUSE/ha-sap-terraform-deployments/pull/727)