### PR TITLE
Switch to using IBM Cloud Object Storage

### DIFF
--- a/powervs/modules/hana_node/salt_provisioner.tf
+++ b/powervs/modules/hana_node/salt_provisioner.tf
@@ -30,6 +30,7 @@ hana_data_disks_wwn: {${join(", ", [for i in range(0, var.hana_count): format("'
 sbd_disk_device: "${var.common_variables["hana"]["sbd_storage_type"] == "shared-disk" ? format("/dev/disk/by-id/wwn-0x%s", lower(var.sbd_disk_wwn)) : ""}"
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
+ibmcloud_api_key: ${var.ibmcloud_api_key}
 EOF
     destination = "/tmp/grains"
   }

--- a/powervs/terraform.tfvars.example
+++ b/powervs/terraform.tfvars.example
@@ -195,14 +195,14 @@ hana_data_disks_configuration = {
 # hana_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
 
 # The next variables define how the HANA installation software is obtained.
-# The installation software must be located in a IBM Cloud storage account
+# The installation software must be located in IBM Cloud Object Storage
 
 # IBM Cloud storage account name
 #storage_account_name = "YOUR_STORAGE_ACCOUNT_NAME"
 # IBM Cloud storage account secret key (key1 or key2)
 #storage_account_key = "YOUR_STORAGE_ACCOUNT_KEY"
 
-# 'hana_inst_master' is a IBM Cloud Storage account share where HANA installation files (extracted or not) are stored
+# 'hana_inst_master' is a IBM Cloud Object Storage location where HANA installation files (extracted or not) are stored
 # `hana_inst_master` must be used always! It is used as the reference path to the other variables
 
 # Local folder where HANA installation master will be mounted
@@ -212,7 +212,7 @@ hana_inst_folder = "/sapmedia/HANA"
 # 1. Use an already extracted HANA Platform folder structure.
 # The last numbered folder is the HANA Platform folder with the extracted files with
 # something like `HDB:HANA:2.0:LINUX_X86_64:SAP HANA PLATFORM EDITION 2.0::XXXXXX` in the LABEL.ASC file
-hana_inst_master = "192.168.139.2:/sapmedia"
+hana_inst_master = "https://s3.eu-gb.cloud-object-storage.appdomain.cloud/hana-media"
 
 # 2. Combine the `hana_inst_master` with `hana_platform_folder` variable.
 #hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sap_inst_media"

--- a/powervs/variables.tf
+++ b/powervs/variables.tf
@@ -160,6 +160,11 @@ variable "reg_additional_modules" {
   default     = {}
 }
 
+variable "additional_packages" {
+  description = "Extra packages to be installed"
+  default     = []
+}
+
 # Repository url used to install development versions of HA/SAP deployment packages
 # The latest RPM packages can be found at:
 # https://download.opensuse.org/repositories/network:ha-clustering:sap-deployments:devel/{YOUR SLE VERSION}
@@ -168,11 +173,6 @@ variable "ha_sap_deployment_repo" {
   description = "Repository url used to install development versions of HA/SAP deployment packages. If the SLE version is not present in the URL, it will be automatically detected"
   type        = string
   default     = ""
-}
-
-variable "additional_packages" {
-  description = "Extra packages to be installed"
-  default     = []
 }
 
 variable "provisioner" {

--- a/salt/hana_node/hana_inst_media.sls
+++ b/salt/hana_node/hana_inst_media.sls
@@ -9,7 +9,7 @@ hana_inst_directory:
     - name: {{ grains['hana_inst_folder'] }}
     - mode: "0755"
     - makedirs: True
-  {% if (grains['provider'] == 'libvirt') or (grains['provider'] == 'powervs') %}
+  {% if (grains['provider'] == 'libvirt') %}
   mount.mounted:
     - name: {{ grains['hana_inst_folder'] }}
     - device: {{ grains['hana_inst_master'] }}

--- a/salt/hana_node/init.sls
+++ b/salt/hana_node/init.sls
@@ -1,5 +1,5 @@
 include:
-  {% if grains['provider'] in ('aws', 'gcp',) %}
+  {% if grains['provider'] in ('aws', 'gcp', 'powervs') %}
   - hana_node.download_hana_inst
   {% else %}
   - hana_node.hana_inst_media


### PR DESCRIPTION
Installing SAP HANA from an NFS server was used for testing prior to this pull request.  This pull request uses the more cost effective method which downloads SAP media from IBM Cloud Object Storage.