### PR TITLE
do not use virtual IPs on netweaver PAS/AAS and use node IP instead

### DIFF
--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -322,7 +322,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #AWS efs performance mode used by netweaver nfs share, if efs storage is used
 #netweaver_efs_performance_mode = "generalPurpose"
 #netweaver_ips = ["10.0.2.7", "10.0.3.8", "10.0.2.9", "10.0.3.10"]
-#netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
+#netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21"]
 
 # Netweaver installation configuration
 # Netweaver system identifier. It's composed of 3 characters string

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -357,7 +357,7 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 
 # If the addresses are not set they will be auto generated from the provided vnet address range
 #netweaver_ips = ["10.74.1.30", "10.74.1.31", "10.74.1.32", "10.74.1.33"]
-#netweaver_virtual_ips = ["10.74.1.35", "10.74.1.36", "10.74.1.37", "10.74.1.38"]
+#netweaver_virtual_ips = ["10.74.1.35", "10.74.1.36"]
 
 # Netweaver installation configuration
 # Netweaver system identifier. It's composed of 3 characters string

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -13,7 +13,7 @@ module "local_execution" {
 # DRBD ips: 10.0.0.20, 10.0.0.21
 # DRBD cluster vip: 10.0.1.22
 # Netweaver ips: 10.0.0.30, 10.0.0.31, 10.0.0.32, 10.0.0.33
-# Netweaver virtual ips: 10.0.1.34, 10.0.1.35, 10.0.1.36, 10.0.1.37
+# Netweaver virtual ips: 10.0.1.34, 10.0.1.35 (no vips for PAS/AAS)
 # If the addresses are provided by the user they will always have preference
 locals {
   iscsi_srv_ip      = var.iscsi_srv_ip != "" ? var.iscsi_srv_ip : cidrhost(local.subnet_address_range, 4)
@@ -41,11 +41,12 @@ locals {
 
   netweaver_xscs_server_count = var.netweaver_enabled ? (var.netweaver_ha_enabled ? 2 : 1) : 0
   netweaver_count             = var.netweaver_enabled ? local.netweaver_xscs_server_count + var.netweaver_app_server_count : 0
-  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? max(local.netweaver_count, 3) : max(local.netweaver_count, 2) # We need at least 2 virtual ips, if ASCS and PAS are in the same machine
+  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? 2 : 1 # We need 2 virtual ips if ERS is enabled. Otherwise only ASCS gets 1 virtual ip.
 
   netweaver_ip_start    = 30
   netweaver_ips         = length(var.netweaver_ips) != 0 ? var.netweaver_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_count) : cidrhost(local.subnet_address_range, ip_index)]
-  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(cidrsubnet(local.subnet_address_range, -8, 0), 256 + ip_index + 4)]
+  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(cidrsubnet(local.subnet_address_range, -8, 0), 256 + ip_index + 4)] # virtual IPs (not for PAS/AAS)
+  netweaver_app_ips     = [for ip_index in range(local.netweaver_ip_start + local.netweaver_xscs_server_count, local.netweaver_ip_start + local.netweaver_xscs_server_count + var.netweaver_app_server_count) : cidrhost(local.subnet_address_range, ip_index)]                              # IPs of PAS/AAS
 
   # Check if iscsi server has to be created
   use_sbd       = var.hana_cluster_fencing_mechanism == "sbd" || var.drbd_cluster_fencing_mechanism == "sbd" || var.netweaver_cluster_fencing_mechanism == "sbd"
@@ -147,7 +148,7 @@ module "common_variables" {
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
-  monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
+  monitoring_netweaver_targets_app    = var.netweaver_enabled ? concat(local.netweaver_virtual_ips, local.netweaver_app_ips) : []
 }
 
 module "drbd_node" {

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -387,7 +387,7 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 #netweaver_ips = ["10.0.0.20", "10.0.0.21", "10.0.0.22", "10.0.0.23"]
 
-#netweaver_virtual_ips = ["10.0.1.25", "10.0.1.26", "10.0.0.27", "10.0.0.28"]
+#netweaver_virtual_ips = ["10.0.1.25", "10.0.1.26"]
 
 # Netweaver installation configuration
 # Netweaver system identifier. It's composed of 3 characters string

--- a/generic_modules/common_variables/monitoring_variables.tf
+++ b/generic_modules/common_variables/monitoring_variables.tf
@@ -46,8 +46,8 @@ variable "monitoring_netweaver_targets_ha" {
   default     = []
 }
 
-variable "monitoring_netweaver_targets_vip" {
-  description = "VIPs of Netweaver Instances you want to monitor."
+variable "monitoring_netweaver_targets_app" {
+  description = "App IPs of Netweaver Instances you want to monitor."
   type        = list(string)
   default     = []
 }

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -101,7 +101,7 @@ output "configuration" {
       drbd_targets_vip      = var.monitoring_drbd_targets_vip
       netweaver_targets     = var.monitoring_netweaver_targets
       netweaver_targets_ha  = var.monitoring_netweaver_targets_ha
-      netweaver_targets_vip = var.monitoring_netweaver_targets_vip
+      netweaver_targets_app = var.monitoring_netweaver_targets_app
     }
     grains_output           = <<EOF
 provider: ${var.provider_type}
@@ -181,7 +181,7 @@ drbd_targets_ha: [${join(", ", formatlist("'%s'", var.monitoring_drbd_targets_ha
 drbd_targets_ha_vip: [${join(", ", formatlist("'%s'", var.monitoring_drbd_targets_vip))}]
 netweaver_targets: [${join(", ", formatlist("'%s'", var.monitoring_netweaver_targets))}]
 netweaver_targets_ha: [${join(", ", formatlist("'%s'", var.monitoring_netweaver_targets_ha))}]
-netweaver_targets_vip: [${join(", ", formatlist("'%s'", var.monitoring_netweaver_targets_vip))}]
+netweaver_targets_app: [${join(", ", formatlist("'%s'", var.monitoring_netweaver_targets_app))}]
 EOF
   }
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -13,7 +13,7 @@ module "local_execution" {
 # DRBD ips: 192.168.135.20, 192.168.135.21
 # DRBD cluster vip: 192.168.135.22
 # Netweaver ips: 192.168.135.30, 192.168.135.31, 192.168.135.32, 192.168.135.33
-# Netweaver virtual ips: 192.168.135.34, 192.168.135.35, 192.168.135.36, 19.168.135.37
+# Netweaver virtual ips : 192.168.135.34, 192.168.135.35 (no vips for PAS/AAS)
 # If the addresses are provided by the user they will always have preference
 locals {
   iscsi_ip          = var.iscsi_srv_ip != "" ? var.iscsi_srv_ip : cidrhost(local.iprange, 4)
@@ -31,11 +31,12 @@ locals {
 
   netweaver_xscs_server_count = var.netweaver_enabled ? (var.netweaver_ha_enabled ? 2 : 1) : 0
   netweaver_count             = var.netweaver_enabled ? local.netweaver_xscs_server_count + var.netweaver_app_server_count : 0
-  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? max(local.netweaver_count, 3) : max(local.netweaver_count, 2) # We need at least 2 virtual ips, if ASCS and PAS are in the same machine
+  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? 2 : 1 # We need 2 virtual ips if ERS is enabled. Otherwise only ASCS gets 1 virtual ip.
 
   netweaver_ip_start    = 30
   netweaver_ips         = length(var.netweaver_ips) != 0 ? var.netweaver_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_count) : cidrhost(local.iprange, ip_index)]
-  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(local.iprange, ip_index + local.netweaver_virtual_ips_count)]
+  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(local.iprange, ip_index + local.netweaver_virtual_ips_count)] # virtual IPs (not for PAS/AAS)
+  netweaver_app_ips     = [for ip_index in range(local.netweaver_ip_start + local.netweaver_xscs_server_count, local.netweaver_ip_start + local.netweaver_xscs_server_count + var.netweaver_app_server_count) : cidrhost(local.iprange, ip_index)]                                     # IPs of PAS/AAS
 
   # Check if iscsi server has to be created
   use_sbd       = var.hana_cluster_fencing_mechanism == "sbd" || var.drbd_cluster_fencing_mechanism == "sbd" || var.netweaver_cluster_fencing_mechanism == "sbd"
@@ -123,7 +124,7 @@ module "common_variables" {
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
-  monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
+  monitoring_netweaver_targets_app    = var.netweaver_enabled ? concat(local.netweaver_virtual_ips, local.netweaver_app_ips) : []
 }
 
 module "iscsi_server" {

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -290,7 +290,7 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 
 # IP addresses of the machines hosting Netweaver instances
 #netweaver_ips = ["192.168.XXX.Y+2", "192.168.XXX.Y+3", "192.168.XXX.Y+4", "192.168.XXX.Y+5"]
-#netweaver_virtual_ips = ["192.168.XXX.Y+6", "192.168.XXX.Y+7", "192.168.XXX.Y+8", "192.168.XXX.Y+9"]
+#netweaver_virtual_ips = ["192.168.XXX.Y+6", "192.168.XXX.Y+7"]
 
 # Netweaver installation configuration
 # Netweaver system identifier. It's composed of 3 characters string

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -13,7 +13,7 @@ module "local_execution" {
 # DRBD ips: 10.0.0.20, 10.0.0.21
 # DRBD cluster vip: 10.0.0.22
 # Netweaver ips: 10.0.0.30, 10.0.0.31, 10.0.0.32, 10.0.0.33
-# Netweaver virtual ips: 10.0.0.34, 10.0.0.35, 10.0.0.36, 10.0.0.37
+# Netweaver virtual ips: 10.0.0.34, 10.0.0.35 (no vips for PAS/AAS)
 # If the addresses are provided by the user they will always have preference
 locals {
   bastion_srv_ip    = var.bastion_srv_ip != "" ? var.bastion_srv_ip : cidrhost(local.subnet_address_range, 3)
@@ -32,11 +32,12 @@ locals {
 
   netweaver_xscs_server_count = var.netweaver_enabled ? (var.netweaver_ha_enabled ? 2 : 1) : 0
   netweaver_count             = var.netweaver_enabled ? local.netweaver_xscs_server_count + var.netweaver_app_server_count : 0
-  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? max(local.netweaver_count, 3) : max(local.netweaver_count, 2) # We need at least 2 virtual ips, if ASCS and PAS are in the same machine
+  netweaver_virtual_ips_count = var.netweaver_ha_enabled ? 2 : 1 # We need 2 virtual ips if ERS is enabled. Otherwise only ASCS gets 1 virtual ip.
 
   netweaver_ip_start    = 30
   netweaver_ips         = length(var.netweaver_ips) != 0 ? var.netweaver_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_count) : cidrhost(local.subnet_address_range, ip_index)]
-  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(cidrsubnet(local.subnet_address_range, -8, 0), 256 + ip_index + 4)]
+  netweaver_virtual_ips = length(var.netweaver_virtual_ips) != 0 ? var.netweaver_virtual_ips : [for ip_index in range(local.netweaver_ip_start, local.netweaver_ip_start + local.netweaver_virtual_ips_count) : cidrhost(cidrsubnet(local.subnet_address_range, -8, 0), 256 + ip_index + 4)] # virtual IPs (not for PAS/AAS)
+  netweaver_app_ips     = [for ip_index in range(local.netweaver_ip_start + local.netweaver_xscs_server_count, local.netweaver_ip_start + local.netweaver_xscs_server_count + var.netweaver_app_server_count) : cidrhost(local.subnet_address_range, ip_index)]                              # IPs of PAS/AAS
 
   # Check if iscsi server has to be created
   use_sbd       = var.hana_cluster_fencing_mechanism == "sbd" || var.drbd_cluster_fencing_mechanism == "sbd" || var.netweaver_cluster_fencing_mechanism == "sbd"
@@ -172,7 +173,7 @@ module "common_variables" {
   monitoring_drbd_targets_vip         = var.drbd_enabled ? [local.drbd_cluster_vip] : []
   monitoring_netweaver_targets        = var.netweaver_enabled ? local.netweaver_ips : []
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
-  monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
+  monitoring_netweaver_targets_app    = var.netweaver_enabled ? concat(local.netweaver_virtual_ips, local.netweaver_app_ips) : []
 }
 
 module "drbd_node" {

--- a/openstack/terraform.tfvars.example
+++ b/openstack/terraform.tfvars.example
@@ -404,7 +404,7 @@ netweaver_flavor = "4C-8GB-40GB"
 #netweaver_additional_dvds = ["dvd1", "dvd2"]
 
 netweaver_ips         = ["10.0.0.30", "10.0.0.31", "10.0.0.32", "10.0.0.33"]
-netweaver_virtual_ips = ["10.0.0.34", "10.0.0.35", "10.0.0.36", "10.0.0.37"]
+netweaver_virtual_ips = ["10.0.0.34", "10.0.0.35"]
 
 # Netweaver installation configuration
 # Netweaver system identifier. It's composed of 3 characters string

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -25,14 +25,12 @@ netweaver:
   {%- endif %}
   virtual_addresses:
     {{ grains['virtual_host_ips'][0] }}: sap{{ sid_lower }}as
+    {{ grains['host_ips'][app_start_index] }}: sap{{ sid_lower }}pas
     {%- if grains['ha_enabled'] %}
     {{ grains['virtual_host_ips'][1] }}: sap{{ sid_lower }}er
-    {{ grains['virtual_host_ips'][2] }}: sap{{ sid_lower }}pas
-    {%- else %}
-    {{ grains['virtual_host_ips'][1] }}: sap{{ sid_lower }}pas
     {%- endif %}
     {%- for index in range(app_server_count-1) %}
-    {{ grains['virtual_host_ips'][loop.index+app_start_index] }}: sap{{ sid_lower }}aas{{ loop.index }}
+    {{ grains['host_ips'][loop.index+app_start_index] }}: sap{{ sid_lower }}aas{{ loop.index }}
     {%- endfor %}
 
   sidadm_user:

--- a/salt/monitoring_srv/prometheus/prometheus.yml.j2
+++ b/salt/monitoring_srv/prometheus/prometheus.yml.j2
@@ -57,7 +57,7 @@ scrape_configs:
         {%- for ip in grains['netweaver_targets_ha'] %}
         - "{{ ip }}:9664" # ha_cluster_exporter
         {%- endfor %}
-        {%- for ip in grains['netweaver_targets_vip'] %}
+        {%- for ip in grains['netweaver_targets_app'] %}
         - "{{ ip }}:9680" # sap_host_exporter
         {%- endfor %}
   {%- endif %}


### PR DESCRIPTION
This is a proposed fix for #740.
It removes the virtual IPs for the PAS/AAS nodes for all providers. PAS/AAS will be rachable via the node IPs instead.