### PR TITLE
make Netweaver PAS/AAS virtual IPs reachable on public cloud setups

### DIFF
--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -37,7 +37,7 @@ resource "aws_route" "nw-ers-route" {
   instance_id            = aws_instance.netweaver.1.id
 }
 
-# deploy if only PAS
+# deploy if PAS on same machine as ASCS
 resource "aws_route" "nw-pas-route" {
   count                  = var.app_server_count == 0 ? 1 : 0
   route_table_id         = var.route_table_id
@@ -45,7 +45,7 @@ resource "aws_route" "nw-pas-route" {
   instance_id            = aws_instance.netweaver.0.id
 }
 
-# deploy if PAS and AAS
+# deploy if PAS and AAS on seperate hosts
 resource "aws_route" "nw-app-route" {
   count                  = var.app_server_count
   route_table_id         = var.route_table_id

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -1,6 +1,7 @@
 locals {
   vm_count        = var.xscs_server_count + var.app_server_count
   create_ha_infra = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
+  app_start_index = local.create_ha_infra == 1 ? 2 : 1
 }
 
 # Network resources: subnets, routes, etc
@@ -22,18 +23,34 @@ resource "aws_route_table_association" "netweaver-subnet-route-association" {
   route_table_id = var.route_table_id
 }
 
-resource "aws_route" "ascs-cluster-vip" {
-  count                  = local.create_ha_infra
+resource "aws_route" "nw-ascs-route" {
+  count                  = local.vm_count > 0 ? 1 : 0
   route_table_id         = var.route_table_id
   destination_cidr_block = "${element(var.virtual_host_ips, 0)}/32"
   instance_id            = aws_instance.netweaver.0.id
 }
 
-resource "aws_route" "ers-cluster-vip" {
+resource "aws_route" "nw-ers-route" {
   count                  = local.create_ha_infra
   route_table_id         = var.route_table_id
   destination_cidr_block = "${element(var.virtual_host_ips, 1)}/32"
   instance_id            = aws_instance.netweaver.1.id
+}
+
+# deploy if only PAS
+resource "aws_route" "nw-pas-route" {
+  count                  = var.app_server_count == 0 ? 1 : 0
+  route_table_id         = var.route_table_id
+  destination_cidr_block = "${element(var.virtual_host_ips, local.app_start_index)}/32"
+  instance_id            = aws_instance.netweaver.0.id
+}
+
+# deploy if PAS and AAS
+resource "aws_route" "nw-app-route" {
+  count                  = var.app_server_count
+  route_table_id         = var.route_table_id
+  destination_cidr_block = "${element(var.virtual_host_ips, local.app_start_index + count.index)}/32"
+  instance_id            = aws_instance.netweaver[local.app_start_index + count.index].id
 }
 
 resource "aws_efs_mount_target" "netweaver-efs-mount-target" {

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -5,6 +5,7 @@ locals {
   vm_count               = var.xscs_server_count + var.app_server_count
   bastion_enabled        = var.common_variables["bastion_enabled"]
   create_ha_infra        = var.xscs_server_count > 0 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
+  app_start_index        = local.create_ha_infra == 1 ? 2 : 1
   additional_lun_number  = "0"
   provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.netweaver.*.private_ip_address : data.azurerm_public_ip.netweaver.*.ip_address
   ascs_lb_rules_ports    = local.create_ha_infra == 1 ? toset([
@@ -210,10 +211,46 @@ resource "azurerm_network_interface" "netweaver" {
 
   ip_configuration {
     name                          = "ipconf-primary"
+    primary                       = true
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
     private_ip_address            = element(var.host_ips, count.index)
     public_ip_address_id          = local.bastion_enabled ? null : element(azurerm_public_ip.netweaver.*.id, count.index)
+  }
+
+  # deploy if non-HA AS
+  dynamic "ip_configuration" {
+    for_each = local.create_ha_infra == 0 && count.index == 0 ? [0] : []
+    content {
+      name                          = "ipconf-vip-as-${format("%02d", count.index + 1)}"
+      subnet_id                     = var.network_subnet_id
+      private_ip_address_allocation = "static"
+      private_ip_address            = element(var.virtual_host_ips, count.index)
+    }
+  }
+
+  # deploy if only PAS
+  dynamic "ip_configuration" {
+    # if no additional app servers and first node
+    for_each = var.app_server_count == 0 && count.index == 0 ? [0] : []
+    content {
+      name                          = "ipconf-vip-pas-${format("%02d", count.index + 1)}"
+      subnet_id                     = var.network_subnet_id
+      private_ip_address_allocation = "static"
+      private_ip_address            = element(var.virtual_host_ips, count.index + local.app_start_index)
+    }
+  }
+
+  # deploy if PAS and AAS
+  dynamic "ip_configuration" {
+    # if additional app servers
+    for_each = var.app_server_count > 0 && count.index >= local.app_start_index ? [0] : []
+    content {
+      name                          = "ipconf-vip-app-${format("%02d", count.index + 1)}"
+      subnet_id                     = var.network_subnet_id
+      private_ip_address_allocation = "static"
+      private_ip_address            = element(var.virtual_host_ips, count.index)
+    }
   }
 
   tags = {

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -218,7 +218,7 @@ resource "azurerm_network_interface" "netweaver" {
     public_ip_address_id          = local.bastion_enabled ? null : element(azurerm_public_ip.netweaver.*.id, count.index)
   }
 
-  # deploy if non-HA AS
+  # deploy if ASCS is non-HA
   dynamic "ip_configuration" {
     for_each = local.create_ha_infra == 0 && count.index == 0 ? [0] : []
     content {
@@ -229,7 +229,7 @@ resource "azurerm_network_interface" "netweaver" {
     }
   }
 
-  # deploy if only PAS
+  # deploy if PAS on same machine as ASCS
   dynamic "ip_configuration" {
     # if no additional app servers and first node
     for_each = var.app_server_count == 0 && count.index == 0 ? [0] : []
@@ -241,7 +241,7 @@ resource "azurerm_network_interface" "netweaver" {
     }
   }
 
-  # deploy if PAS and AAS
+  # deploy if PAS and AAS on seperate hosts
   dynamic "ip_configuration" {
     # if additional app servers
     for_each = var.app_server_count > 0 && count.index >= local.app_start_index ? [0] : []

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -3,7 +3,8 @@
 
 locals {
   vm_count        = var.xscs_server_count + var.app_server_count
-  create_ha_infra = local.vm_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  create_ha_infra = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
+  app_start_index = local.create_ha_infra == 1 ? 2 : 1
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.netweaver.*.network_interface.0.network_ip : google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
 }
@@ -18,8 +19,8 @@ resource "google_compute_disk" "netweaver-software" {
 
 # Don't remove the routes! Even though the RA gcp-vpc-move-route creates them, if they are not created here, the terraform destroy cannot work as it will find new route names
 resource "google_compute_route" "nw-ascs-route" {
-  name                   = "${var.common_variables["deployment_name"]}-nw-ascs-route"
-  count                  = local.create_ha_infra
+  name                   = "${var.common_variables["deployment_name"]}-nw-ascs-route-${format("%02d", 1)}"
+  count                  = local.vm_count > 0 ? 1 : 0
   dest_range             = "${element(var.virtual_host_ips, 0)}/32"
   network                = var.network_name
   next_hop_instance      = google_compute_instance.netweaver.0.name
@@ -28,12 +29,34 @@ resource "google_compute_route" "nw-ascs-route" {
 }
 
 resource "google_compute_route" "nw-ers-route" {
-  name                   = "${var.common_variables["deployment_name"]}-nw-ers-route"
+  name                   = "${var.common_variables["deployment_name"]}-nw-ers-route-${format("%02d", 2)}"
   count                  = local.create_ha_infra
   dest_range             = "${element(var.virtual_host_ips, 1)}/32"
   network                = var.network_name
   next_hop_instance      = google_compute_instance.netweaver.1.name
   next_hop_instance_zone = element(var.compute_zones, 1)
+  priority               = 1000
+}
+
+# deploy if only PAS
+resource "google_compute_route" "nw-pas-route" {
+  name                   = "${var.common_variables["deployment_name"]}-nw-pas-route-${format("%02d", 1)}"
+  count                  = var.app_server_count == 0 ? 1 : 0
+  dest_range             = "${element(var.virtual_host_ips, local.app_start_index)}/32"
+  network                = var.network_name
+  next_hop_instance      = google_compute_instance.netweaver.0.name
+  next_hop_instance_zone = element(var.compute_zones, 0)
+  priority               = 1000
+}
+
+# deploy if PAS and AAS
+resource "google_compute_route" "nw-app-route" {
+  name                   = "${var.common_variables["deployment_name"]}-nw-appoute-${format("%02d", local.app_start_index + count.index + 1)}"
+  count                  = var.app_server_count
+  dest_range             = "${element(var.virtual_host_ips, local.app_start_index + count.index)}/32"
+  network                = var.network_name
+  next_hop_instance      = google_compute_instance.netweaver[local.app_start_index + count.index].name
+  next_hop_instance_zone = element(var.compute_zones, local.app_start_index + count.index)
   priority               = 1000
 }
 

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -38,7 +38,7 @@ resource "google_compute_route" "nw-ers-route" {
   priority               = 1000
 }
 
-# deploy if only PAS
+# deploy if PAS on same machine as ASCS
 resource "google_compute_route" "nw-pas-route" {
   name                   = "${var.common_variables["deployment_name"]}-nw-pas-route-${format("%02d", 1)}"
   count                  = var.app_server_count == 0 ? 1 : 0
@@ -49,7 +49,7 @@ resource "google_compute_route" "nw-pas-route" {
   priority               = 1000
 }
 
-# deploy if PAS and AAS
+# deploy if PAS and AAS on seperate hosts
 resource "google_compute_route" "nw-app-route" {
   name                   = "${var.common_variables["deployment_name"]}-nw-appoute-${format("%02d", local.app_start_index + count.index + 1)}"
   count                  = var.app_server_count

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -51,7 +51,7 @@ resource "google_compute_route" "nw-pas-route" {
 
 # deploy if PAS and AAS on seperate hosts
 resource "google_compute_route" "nw-app-route" {
-  name                   = "${var.common_variables["deployment_name"]}-nw-appoute-${format("%02d", local.app_start_index + count.index + 1)}"
+  name                   = "${var.common_variables["deployment_name"]}-nw-app-route-${format("%02d", local.app_start_index + count.index + 1)}"
   count                  = var.app_server_count
   dest_range             = "${element(var.virtual_host_ips, local.app_start_index + count.index)}/32"
   network                = var.network_name


### PR DESCRIPTION
The Netweaver virtual IPs for AS/ERS are reachable via different mechanism for public clouds:
- azure -> load-balancer
- gcp -> route to VM (changed by cluster)
- aws -> route to VM (changed by cluster)

For the Netweaver virtual IPs for PAS/AAS there is currently no mechanism implemented to make them reachable to other nodes.
Therefore the current monitoring setup #740 is also broken.

This PR makes these PAS/AAS virtual IPs reachable via these mechanisms:
- azure -> vIP on network interface on VMs
  - load-balancer setup would also be possible in theory but is way more complex (e.g. create rules per node)
- gcp -> route to VM (static)
- aws -> route to VM (static)

In addition to that there are fixes included to not only deploy AS routes in HA scenarios.
```
count = local.create_ha_infra
vs.
count = local.vm_count > 0 ? 1 : 0
```