### PR TITLE
add minion.d files for each environment (base/predeployment)

### DIFF
--- a/salt/os_setup/minion_configuration.sls
+++ b/salt/os_setup/minion_configuration.sls
@@ -14,6 +14,12 @@
             - /srv/salt
             - /usr/share/salt-formulas/states
 
+# prevent "[WARNING ] top_file_merging_strategy is set to 'merge' and multiple top files were found."
+/etc/salt/minion.d/top_file_merging_strategy.conf:
+  file.managed:
+    - contents: |
+        top_file_merging_strategy: same
+
 backup_salt_configuration:
   file.copy:
     - name: /etc/salt/minion.backup

--- a/salt/os_setup/minion_configuration.sls
+++ b/salt/os_setup/minion_configuration.sls
@@ -20,18 +20,11 @@
     - contents: |
         top_file_merging_strategy: same
 
-backup_salt_configuration:
-  file.copy:
-    - name: /etc/salt/minion.backup
-    - source: /etc/salt/minion
-
-# Old module.run style will be deprecated after sodium release
-upgrade_module_run:
-  file.append:
-    - name: /etc/salt/minion
-    - text:
-      - 'use_superseded:'
-      - '- module.run'
+/etc/salt/minion.d/use_superseded.conf:
+  file.managed:
+    - contents: |
+        use_superseded:
+          - module.run
 
 minion_service:
   service.dead:

--- a/salt/os_setup/minion_configuration.sls
+++ b/salt/os_setup/minion_configuration.sls
@@ -1,19 +1,23 @@
-backup_salt_configuration:
-  file.copy:
-    - name: /etc/salt/minion.backup
-    - source: /etc/salt/minion
-
-configure_file_roots:
-  file.append:
-    - name: /etc/salt/minion
-    - text: |
+/etc/salt/minion.d/environment_base.conf:
+  file.managed:
+    - contents: |
         file_roots:
           base:
             - /srv/salt
             - /usr/share/salt-formulas/states
+
+/etc/salt/minion.d/environment_predeployment.conf:
+  file.managed:
+    - contents: |
+        file_roots:
           predeployment:
             - /srv/salt
             - /usr/share/salt-formulas/states
+
+backup_salt_configuration:
+  file.copy:
+    - name: /etc/salt/minion.backup
+    - source: /etc/salt/minion
 
 # Old module.run style will be deprecated after sodium release
 upgrade_module_run:


### PR DESCRIPTION
This fixes an issue which comes with the updated rpm `salt-standalone-formulas-configuration-3002.2-46.1` which introduces a new file `/etc/salt/minion.d/standalone-formulas-configuration.conf` that overwrites our `base/predeployment` environments in `/etc/salt/minion`.

This should be a permanent fix as long as there is no tampering with the environments by additional rpms.

All other minion settings are now in separate config files, too.