### PR TITLE
ci: ignore www.linux-ha.org links as site is down since days

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,8 +66,7 @@ test-mlc:
 			./terraform.tvars.example \
 			../pillar/*/* \
 			https://github.com/SUSE/ha-sap-terraform-deployments/actions \
-			https://github.com/SUSE/ha-sap-terraform-deployments/workflows/CI%20tests/badge.svg \
-			http://www.linux-ha.org/wiki/SBD_Fencing
+			https://github.com/SUSE/ha-sap-terraform-deployments/workflows/CI%20tests/badge.svg
 
 # test-salt-lint: @ Run linting on all salt files
 test-salt-lint:

--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,8 @@ test-mlc:
 			./terraform.tvars.example \
 			../pillar/*/* \
 			https://github.com/SUSE/ha-sap-terraform-deployments/actions \
-			https://github.com/SUSE/ha-sap-terraform-deployments/workflows/CI%20tests/badge.svg
+			https://github.com/SUSE/ha-sap-terraform-deployments/workflows/CI%20tests/badge.svg \
+			http://www.linux-ha.org/wiki/SBD_Fencing
 
 # test-salt-lint: @ Run linting on all salt files
 test-salt-lint:

--- a/doc/fencing.md
+++ b/doc/fencing.md
@@ -14,7 +14,6 @@ SBD (Storage Based Death) uses a shared disk among the nodes to halt the nodes.
 
 Find more information in:
 - https://wiki.clusterlabs.org/wiki/Using_SBD_with_Pacemaker
-- http://www.linux-ha.org/wiki/SBD_Fencing
 
 The next options are available to use SBD as the cluster fencing mechanism.
 


### PR DESCRIPTION
This fixes the failing "Ci tests / markup link checker" tests.