### PR TITLE
master: Fix 'pkg_requirements' empty variable

### DIFF
--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -13,7 +13,7 @@ locals {
   bastion_public_key  = var.bastion_public_key != "" ? (fileexists(var.bastion_public_key) ? file(var.bastion_public_key) : var.bastion_public_key) : local.public_key
 
   requirements_file = "${path.module}/../../requirements.yml"
-  requirements      = fileexists(local.requirements_file) ? yamlencode({pkg_requirements: yamldecode(trimspace(file(local.requirements_file)))}) : ""
+  requirements      = fileexists(local.requirements_file) ? yamlencode({pkg_requirements: yamldecode(trimspace(file(local.requirements_file)))}) : yamlencode({pkg_requirements: null})
 }
 
 output "configuration" {


### PR DESCRIPTION
Variable `pkg_requirements` can be uninitialized if `requirements.yml` file is delete. As this file is optional, the variable needs to be initialized with an empty value.