### PR TITLE
Kernel default base remove

### DIFF
--- a/salt/os_setup/packages.sls
+++ b/salt/os_setup/packages.sls
@@ -8,17 +8,20 @@ iscsi-formula:
 {%- endif %}
 
 # iscsi kernel modules are not available in kernel-default-base
-kernel-default-base:
-  pkg.removed:
-  - retry:
-      attempts: 3
-      interval: 15
+# There is not reliable way to switch kernels directly with salt as dependency resolution is not yet implemented.
+kernel-default-install:
+  cmd.run:
+    - name: zypper -n install --force-resolution kernel-default
+    # install kernel-default if kernel-default-base is installed, do not touch otherwise
+    - only_if:
+      - rpm -q kernel-default-base
 
-kernel-default:
-  pkg.installed:
-  - retry:
-      attempts: 3
-      interval: 15
-  # install kernel-default if kernel-default-base is installed, do not touch otherwise
-  - require:
-    - pkg: kernel-default-base
+kernel-default-base-remove:
+  pkg.removed:
+    - name: kernel-default-base
+    - retry:
+        attempts: 3
+        interval: 15
+    - require:
+      - cmd: kernel-default-install
+

--- a/salt/os_setup/packages.sls
+++ b/salt/os_setup/packages.sls
@@ -5,6 +5,7 @@ iscsi-formula:
     - retry:
         attempts: 3
         interval: 15
+{%- endif %}
 
 # iscsi kernel modules are not available in kernel-default-base
 kernel-default-base:
@@ -21,4 +22,3 @@ kernel-default:
   # install kernel-default if kernel-default-base is installed, do not touch otherwise
   - require:
     - pkg: kernel-default-base
-{%- endif %}


### PR DESCRIPTION
In #731 the `kernel-default-base` removal code was changed to only run on the iscsi target server.
This PR reverts to the old behavior it and adds a more reliable way to switch kernels.

Without the new way of switching kernels, I get the following error messages:
```
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): ----------
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):           ID: kernel-default-base
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):     Function: pkg.removed
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):       Result: True
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Comment: All targeted packages were removed.
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Started: 12:08:58.633929
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):     Duration: 5946.026 ms
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Changes:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               ----------
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               kernel-default-base:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   ----------
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   new:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   old:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                       5.3.18-22.2.7.9,5.3.18-24.83.2.9.38.3
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): ----------
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):           ID: kernel-default
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):     Function: pkg.installed
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):       Result: False
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Comment: Attempt 1: Returned a result of "False", with the following comment: "An exception occurred in this state: Traceback (most recent call last):
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/state.py", line 1987, in call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   # correctly calculate further down the chain
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2030, in wrapper
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   if not virtual:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1690, in installed
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   pkgs, refresh = _resolve_capabilities(pkgs, refresh=refresh, **kwargs)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1004, in _resolve_capabilities
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   ret = __salt__["pkg.resolve_capabilities"](pkgs, refresh=refresh, **kwargs)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 3130, in resolve_capabilities
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   refresh_db(root)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 1440, in refresh_db
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   out = __zypper__(root=root).refreshable.call(*refresh_opts)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 381, in __call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   self.__call_result = __salt__["cmd.run_all"](cmd, **kwargs)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1268, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   _generate_module("{}.ext.{}".format(self.loaded_base_name, tag))
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/utils/lazy.py", line 108, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   raise KeyError(key)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               KeyError: 'cmd.run_all'
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               "
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               Attempt 2: Returned a result of "False", with the following comment: "An exception occurred in this state: Traceback (most recent call last):
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/state.py", line 1987, in call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   # correctly calculate further down the chain
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2030, in wrapper
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   if not virtual:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1877, in installed
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   **kwargs
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 1723, in install
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   .call(*cmd)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 381, in __call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   self.__call_result = __salt__["cmd.run_all"](cmd, **kwargs)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1268, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   _generate_module("{}.ext.{}".format(self.loaded_base_name, tag))
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/utils/lazy.py", line 108, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   raise KeyError(key)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               KeyError: 'cmd.run_all'
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               "
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               An exception occurred in this state: Traceback (most recent call last):
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/state.py", line 1987, in call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   # correctly calculate further down the chain
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 2030, in wrapper
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   if not virtual:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/states/pkg.py", line 1877, in installed
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   **kwargs
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 1723, in install
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   .call(*cmd)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/modules/zypperpkg.py", line 381, in __call
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   self.__call_result = __salt__["cmd.run_all"](cmd, **kwargs)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/loader.py", line 1268, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   _generate_module("{}.ext.{}".format(self.loaded_base_name, tag))
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                 File "/usr/lib/python3.6/site-packages/salt/utils/lazy.py", line 108, in __getitem__
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):                   raise KeyError(key)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):               KeyError: 'cmd.run_all'
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Started: 12:09:12.132478
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):     Duration: 30145.648999999998 ms
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):      Changes:
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec):
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): Summary for local
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): -------------
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): Succeeded: 18 (changed=14)
module.bastion.module.bastion_provision.null_resource.provision[0] (remote-exec): Failed:     1
```
Something in salt seems to break after the running `kernel-default-base` is removed.