### PR TITLE
make hostnames configurable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 **/.terraform
 **/terraform.tfstate*
+**/.terraform.tfstate*
 **/terraform*.tfvars
 azure/terraform/provision/node0_id_rsa
 azure/terraform/provision/node0_id_rsa.pub

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ azure/terraform/provision/node0_id_rsa
 azure/terraform/provision/node0_id_rsa.pub
 azure/terraform/provision/node1_id_rsa
 azure/terraform/provision/node1_id_rsa.pub
+gcp/*.json
 **/id_rsa*
 
 salt/sshkeys

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -64,6 +64,7 @@ module "common_variables" {
   source                              = "../generic_modules/common_variables"
   provider_type                       = "aws"
   deployment_name                     = local.deployment_name
+  deployment_name_in_hostname         = var.deployment_name_in_hostname
   reg_code                            = var.reg_code
   reg_email                           = var.reg_email
   reg_additional_modules              = var.reg_additional_modules
@@ -143,6 +144,8 @@ module "common_variables" {
 module "drbd_node" {
   source                = "./modules/drbd_node"
   common_variables      = module.common_variables.configuration
+  name                  = var.drbd_name
+  network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   drbd_count            = var.drbd_enabled == true ? 2 : 0
   instance_type         = var.drbd_instancetype
   aws_region            = var.aws_region
@@ -177,6 +180,8 @@ module "drbd_node" {
 module "iscsi_server" {
   source             = "./modules/iscsi_server"
   common_variables   = module.common_variables.configuration
+  name               = var.iscsi_name
+  network_domain     = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
   iscsi_count        = local.iscsi_enabled == true ? 1 : 0
   aws_region         = var.aws_region
   availability_zones = data.aws_availability_zones.available.names
@@ -200,10 +205,11 @@ module "iscsi_server" {
 module "netweaver_node" {
   source                = "./modules/netweaver_node"
   common_variables      = module.common_variables.configuration
+  name                  = var.netweaver_name
+  network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   xscs_server_count     = local.netweaver_xscs_server_count
   app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
   instance_type         = var.netweaver_instancetype
-  name                  = "netweaver"
   aws_region            = var.aws_region
   availability_zones    = data.aws_availability_zones.available.names
   os_image              = local.netweaver_os_image
@@ -234,9 +240,10 @@ module "netweaver_node" {
 module "hana_node" {
   source                = "./modules/hana_node"
   common_variables      = module.common_variables.configuration
+  name                  = var.hana_name
+  network_domain        = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   hana_count            = var.hana_count
   instance_type         = var.hana_instancetype
-  name                  = var.name
   aws_region            = var.aws_region
   availability_zones    = data.aws_availability_zones.available.names
   os_image              = local.hana_os_image
@@ -265,6 +272,8 @@ module "hana_node" {
 module "monitoring" {
   source             = "./modules/monitoring"
   common_variables   = module.common_variables.configuration
+  name               = var.monitoring_name
+  network_domain     = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   monitoring_enabled = var.monitoring_enabled
   instance_type      = var.monitor_instancetype
   key_name           = aws_key_pair.key-pair.key_name

--- a/aws/modules/drbd_node/main.tf
+++ b/aws/modules/drbd_node/main.tf
@@ -1,4 +1,7 @@
 # drbd resources
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
 
 resource "aws_subnet" "drbd-subnet" {
   count             = var.drbd_count
@@ -71,7 +74,7 @@ resource "aws_instance" "drbd" {
   }
 
   tags = {
-    Name                                                 = "${var.common_variables["deployment_name"]} - ${var.name}${format("%02d", count.index + 1)}"
+    Name                                                 = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
     Workspace                                            = var.common_variables["deployment_name"]
     "${var.common_variables["deployment_name"]}-cluster" = "${var.name}${format("%02d", count.index + 1)}"
   }

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -22,13 +22,13 @@ resource "null_resource" "drbd_provisioner" {
 role: drbd_node
 ${var.common_variables["grains_output"]}
 region: ${var.aws_region}
-name_prefix: ${var.name}
 aws_cluster_profile: Cluster
 aws_instance_tag: ${var.common_variables["deployment_name"]}-cluster
 aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/aws/modules/drbd_node/variables.tf
+++ b/aws/modules/drbd_node/variables.tf
@@ -5,7 +5,11 @@ variable "common_variables" {
 variable "name" {
   description = "hostname, without the domain part"
   type        = string
-  default     = "drbd"
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "drbd_count" {
@@ -93,11 +97,6 @@ variable "drbd_data_disk_type" {
   description = "Disk type of the disks used to store drbd content"
   type        = string
   default     = "gp2"
-}
-
-variable "network_domain" {
-  type    = string
-  default = "tf.local"
 }
 
 variable "cluster_ssh_pub" {

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -1,7 +1,7 @@
-
 locals {
   hana_disk_device = "/dev/xvdd"
   create_ha_infra  = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  hostname         = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 # Network resources: subnets, routes, etc
@@ -84,7 +84,7 @@ resource "aws_instance" "clusternodes" {
   }
 
   tags = {
-    Name                                                 = "${var.common_variables["deployment_name"]} - ${var.name}${format("%02d", count.index + 1)}"
+    Name                                                 = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
     Workspace                                            = var.common_variables["deployment_name"]
     "${var.common_variables["deployment_name"]}-cluster" = "${var.name}${format("%02d", count.index + 1)}"
   }

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -29,10 +29,10 @@ aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}
 route_table: ${var.route_table_id}
-name_prefix: ${var.name}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-network_domain: "tf.local"
 sbd_lun_index: 0
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 hana_disk_device: ${local.hana_disk_device}

--- a/aws/modules/hana_node/variables.tf
+++ b/aws/modules/hana_node/variables.tf
@@ -2,6 +2,16 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "hana_count" {
   type    = string
   default = "2"
@@ -10,12 +20,6 @@ variable "hana_count" {
 variable "instance_type" {
   type    = string
   default = "r3.8xlarge"
-}
-
-variable "name" {
-  description = "prefix of the machines names"
-  type        = string
-  default     = "hana"
 }
 
 variable "aws_region" {

--- a/aws/modules/iscsi_server/main.tf
+++ b/aws/modules/iscsi_server/main.tf
@@ -2,6 +2,7 @@
 
 locals {
   iscsi_device_name = "/dev/xvdd"
+  hostname          = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 module "get_os_image" {
@@ -33,11 +34,11 @@ resource "aws_instance" "iscsisrv" {
   }
 
   volume_tags = {
-    Name = "${var.common_variables["deployment_name"]}-iscsi-${count.index + 1}"
+    Name = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   }
 
   tags = {
-    Name      = "${var.common_variables["deployment_name"]} - iSCSI Server - ${count.index + 1}"
+    Name      = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
     Workspace = var.common_variables["deployment_name"]
   }
 }

--- a/aws/modules/iscsi_server/salt_provisioner.tf
+++ b/aws/modules/iscsi_server/salt_provisioner.tf
@@ -16,6 +16,9 @@ resource "null_resource" "iscsi_provisioner" {
     content = <<EOF
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 region: ${var.aws_region}
 iscsi_srv_ip: ${element(aws_instance.iscsisrv.*.private_ip, count.index)}
 iscsidev: ${local.iscsi_device_name}

--- a/aws/modules/iscsi_server/variables.tf
+++ b/aws/modules/iscsi_server/variables.tf
@@ -17,6 +17,16 @@ variable "subnet_ids" {
   description = "Subnet ids to attach the machines network interface"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "iscsi_count" {
   type        = number
   description = "Number of iscsi machines to deploy"

--- a/aws/modules/monitoring/main.tf
+++ b/aws/modules/monitoring/main.tf
@@ -1,3 +1,7 @@
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
+
 module "get_os_image" {
   source   = "../../modules/get_os_image"
   os_image = var.os_image
@@ -27,11 +31,11 @@ resource "aws_instance" "monitoring" {
   }
 
   volume_tags = {
-    Name = "${var.common_variables["deployment_name"]}-monitoring"
+    Name = "${var.common_variables["deployment_name"]}-${var.name}"
   }
 
   tags = {
-    Name      = "${var.common_variables["deployment_name"]} - Monitoring"
+    Name      = "${var.common_variables["deployment_name"]}-${var.name}"
     Workspace = var.common_variables["deployment_name"]
   }
 }

--- a/aws/modules/monitoring/salt_provisioner.tf
+++ b/aws/modules/monitoring/salt_provisioner.tf
@@ -18,12 +18,12 @@ role: monitoring_srv
 ${var.common_variables["grains_output"]}
 ${var.common_variables["monitoring_grains_output"]}
 region: ${var.aws_region}
-name_prefix: monitoring
-hostname: monitoring
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ip: ${var.monitoring_srv_ip}
 public_ip: ${aws_instance.monitoring[0].public_ip}
-network_domain: "tf.local"
 EOF
 
     destination = "/tmp/grains"

--- a/aws/modules/monitoring/variables.tf
+++ b/aws/modules/monitoring/variables.tf
@@ -14,6 +14,16 @@ variable "instance_type" {
   default     = "t3.micro"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "key_name" {
   type        = string
   description = "AWS key pair name"

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -2,6 +2,7 @@ locals {
   vm_count        = var.xscs_server_count + var.app_server_count
   create_ha_infra = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
   app_start_index = local.create_ha_infra == 1 ? 2 : 1
+  hostname        = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 # Network resources: subnets, routes, etc
@@ -106,7 +107,7 @@ resource "aws_instance" "netweaver" {
   }
 
   tags = {
-    Name                                                 = "${var.common_variables["deployment_name"]} - ${var.name}${format("%02d", count.index + 1)}"
+    Name                                                 = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
     Workspace                                            = var.common_variables["deployment_name"]
     "${var.common_variables["deployment_name"]}-cluster" = "${var.name}${format("%02d", count.index + 1)}"
   }

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -23,15 +23,15 @@ role: netweaver_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["netweaver_grains_output"]}
 region: ${var.aws_region}
-name_prefix: ${var.name}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 aws_cluster_profile: Cluster
 aws_instance_tag: ${var.common_variables["deployment_name"]}-cluster
 aws_credentials_file: /tmp/credentials
 aws_access_key_id: ${var.aws_access_key_id}
 aws_secret_access_key: ${var.aws_secret_access_key}
 route_table: ${var.route_table_id}
-network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -18,7 +18,12 @@ variable "instance_type" {
 }
 
 variable "name" {
-  description = "prefix of the machines names"
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 
@@ -83,11 +88,6 @@ variable "aws_secret_access_key" {
 variable "s3_bucket" {
   description = "S3 bucket where Netwaever installation files are stored"
   type        = string
-}
-
-variable "network_domain" {
-  type    = string
-  default = "tf.local"
 }
 
 variable "host_ips" {

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -29,6 +29,9 @@ aws_region = "eu-central-1"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Add the "deployment_name" as a prefix to the hostname.
+#deployment_name_in_hostname = true
+
 # aws-cli credentials data
 # access keys parameters have preference over the credentials file (they are self exclusive)
 aws_access_key_id = my-access-key-id
@@ -127,6 +130,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # HANA machines variables
 #########################
 
+# Hostname, without the domain part
+#hana_name = "vmhana"
+
 # Instance type to use for the hana cluster nodes
 #hana_instancetype = "r3.8xlarge"
 
@@ -147,9 +153,6 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 #hana_os_image = "ami-xxxxxxxxxxxx"
 # Custom owner for private AMI
 #hana_os_owner = "amazon"
-
-# Hostname, without the domain part
-#name = "hana"
 
 # Enable system replication and HA cluster
 #hana_ha_enabled = true
@@ -247,6 +250,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation _fencing_mechanism must be set to 'sbd' for any of the clusters
 
+# Hostname, without the domain part
+#iscsi_name = "vmiscsi"
+
 # iSCSI server image. By default, PAYG image is used. The usage is the same as the HANA images
 #iscsi_os_image = "suse-sles-sap-15-sp1-byos"
 #iscsi_os_owner = "amazon"
@@ -264,6 +270,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
+#
+# Hostname, without the domain part
+#monitoring_name = "vmmonitoring"
 
 # Monitoring server image. By default, PAYG image is used. The usage is the same as the HANA images
 #monitoring_os_image = "suse-sles-sap-15-sp1-byos"
@@ -279,6 +288,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # netweaver will use AWS efs for nfs share by default, unless drbd is enabled
 # Enable drbd cluster
 #drbd_enabled = false
+
+# Hostname, without the domain part
+#drbd_name = "vmdrbd"
 
 #drbd_instancetype = "t2.micro"
 
@@ -306,6 +318,9 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #############################
 
 #netweaver_enabled = true
+
+# Hostname, without the domain part
+#netweaver_name = "vmnetweaver"
 
 # Netweaver APP server count (PAS and AAS)
 # Set to 0 to install the PAS instance in the same instance as the ASCS. This means only 1 machine is installed in the deployment (2 if HA capabilities are enabled)

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -89,6 +89,18 @@ variable "deployment_name" {
   default     = ""
 }
 
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+  default     = true
+}
+
+variable "network_domain" {
+  description = "hostname's network domain for all hosts. Can be overwritten by modules."
+  type        = string
+  default     = "tf.local"
+}
+
 variable "os_image" {
   description = "Default OS image for all the machines. This value is not used if the specific nodes os_image is set (e.g. hana_os_image)"
   type        = string
@@ -182,9 +194,16 @@ variable "provisioning_output_colored" {
 
 # Hana related variables
 
-variable "name" {
+variable "hana_name" {
   description = "hostname, without the domain part"
   type        = string
+  default     = "vmhana"
+}
+
+variable "hana_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
 }
 
 variable "hana_count" {
@@ -408,6 +427,18 @@ variable "scenario_type" {
 
 # DRBD related variables
 
+variable "drbd_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmdrbd"
+}
+
+variable "drbd_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "drbd_enabled" {
   description = "Enable the DRBD cluster for nfs"
   type        = bool
@@ -511,6 +542,18 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
+variable "iscsi_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmiscsi"
+}
+
+variable "iscsi_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
@@ -554,6 +597,18 @@ variable "iscsi_disk_size" {
 
 # Monitoring related variables
 
+variable "monitoring_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmmonitoring"
+}
+
+variable "monitoring_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
   type        = string
@@ -591,6 +646,18 @@ variable "monitoring_enabled" {
 }
 
 # Netweaver related variables
+
+variable "netweaver_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmnetweaver"
+}
+
+variable "netweaver_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "netweaver_enabled" {
   description = "Enable SAP Netweaver cluster deployment"

--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -262,6 +262,8 @@ resource "azurerm_network_security_group" "mysecgroup" {
 module "bastion" {
   source              = "./modules/bastion"
   common_variables    = module.common_variables.configuration
+  name                = var.bastion_name
+  network_domain      = var.bastion_network_domain == "" ? var.network_domain : var.bastion_network_domain
   az_region           = var.az_region
   os_image            = local.bastion_os_image
   vm_size             = "Standard_B1s"

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -59,6 +59,7 @@ module "common_variables" {
   source                              = "../generic_modules/common_variables"
   provider_type                       = "azure"
   deployment_name                     = local.deployment_name
+  deployment_name_in_hostname         = var.deployment_name_in_hostname
   reg_code                            = var.reg_code
   reg_email                           = var.reg_email
   reg_additional_modules              = var.reg_additional_modules
@@ -141,6 +142,8 @@ module "common_variables" {
 module "drbd_node" {
   source              = "./modules/drbd_node"
   common_variables    = module.common_variables.configuration
+  name                = var.drbd_name
+  network_domain      = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   bastion_host        = module.bastion.public_ip
   az_region           = var.az_region
   drbd_count          = var.drbd_enabled == true ? 2 : 0
@@ -169,6 +172,8 @@ module "drbd_node" {
 module "netweaver_node" {
   source                      = "./modules/netweaver_node"
   common_variables            = module.common_variables.configuration
+  name                        = var.netweaver_name
+  network_domain              = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   bastion_host                = module.bastion.public_ip
   az_region                   = var.az_region
   xscs_server_count           = local.netweaver_xscs_server_count
@@ -206,6 +211,8 @@ module "netweaver_node" {
 module "hana_node" {
   source                        = "./modules/hana_node"
   common_variables              = module.common_variables.configuration
+  name                          = var.hana_name
+  network_domain                = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   bastion_host                  = module.bastion.public_ip
   az_region                     = var.az_region
   hana_count                    = var.hana_count
@@ -235,6 +242,8 @@ module "hana_node" {
 module "monitoring" {
   source              = "./modules/monitoring"
   common_variables    = module.common_variables.configuration
+  name                = var.monitoring_name
+  network_domain      = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   bastion_host        = module.bastion.public_ip
   monitoring_enabled  = var.monitoring_enabled
   az_region           = var.az_region
@@ -250,6 +259,8 @@ module "monitoring" {
 module "iscsi_server" {
   source              = "./modules/iscsi_server"
   common_variables    = module.common_variables.configuration
+  name                = var.iscsi_name
+  network_domain      = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
   bastion_host        = module.bastion.public_ip
   iscsi_count         = local.iscsi_enabled ? 1 : 0
   az_region           = var.az_region

--- a/azure/modules/bastion/main.tf
+++ b/azure/modules/bastion/main.tf
@@ -1,6 +1,7 @@
 locals {
   bastion_count      = var.common_variables["bastion_enabled"] ? 1 : 0
   private_ip_address = cidrhost(var.snet_address_range, 5)
+  hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 
@@ -103,7 +104,7 @@ module "os_image_reference" {
 
 resource "azurerm_virtual_machine" "bastion" {
   count                            = local.bastion_count
-  name                             = "vmbastion"
+  name                             = var.name
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [azurerm_network_interface.bastion[0].id]
@@ -126,7 +127,7 @@ resource "azurerm_virtual_machine" "bastion" {
   }
 
   os_profile {
-    computer_name  = "vmbastion"
+    computer_name  = local.hostname
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/bastion/salt_provisioner.tf
+++ b/azure/modules/bastion/salt_provisioner.tf
@@ -20,6 +20,9 @@ resource "null_resource" "bastion_provisioner" {
     content     = <<EOF
 role: bastion
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 EOF
     destination = "/tmp/grains"
   }

--- a/azure/modules/bastion/variables.tf
+++ b/azure/modules/bastion/variables.tf
@@ -13,10 +13,20 @@ variable "os_image" {
   type        = string
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "vm_size" {
   description = "Bastion machine vm size"
   type        = string
   default     = "Standard_B1s"
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "resource_group_name" {

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -5,6 +5,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.drbd.*.private_ip_address : data.azurerm_public_ip.drbd.*.ip_address
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "azurerm_availability_set" "drbd-availability-set" {
@@ -174,7 +175,7 @@ module "os_image_reference" {
 
 resource "azurerm_virtual_machine" "drbd" {
   count                            = var.drbd_count
-  name                             = "vm${var.name}${format("%02d", count.index + 1)}"
+  name                             = "${var.name}${format("%02d", count.index + 1)}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.drbd.*.id, count.index)]
@@ -208,7 +209,7 @@ resource "azurerm_virtual_machine" "drbd" {
   }
 
   os_profile {
-    computer_name  = "vmdrbd${format("%02d", count.index + 1)}"
+    computer_name  = "${local.hostname}${format("%02d", count.index + 1)}"
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -20,8 +20,8 @@ resource "null_resource" "drbd_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
-name_prefix: vm${var.name}
-hostname: vm${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -30,12 +30,6 @@ variable "drbd_count" {
   default = "2"
 }
 
-variable "name" {
-  description = "hostname, without the domain part"
-  type        = string
-  default     = "drbd"
-}
-
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)
@@ -52,14 +46,19 @@ variable "os_image" {
   type        = string
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "vm_size" {
   type    = string
   default = "Standard_D2s_v3"
 }
 
 variable "network_domain" {
-  type    = string
-  default = "tf.local"
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "fencing_mechanism" {

--- a/azure/modules/hana_node/main.tf
+++ b/azure/modules/hana_node/main.tf
@@ -17,6 +17,7 @@ locals {
   ]) : toset([])
 
   hana_lb_rules_ports_secondary = local.create_active_active_infra == 1 ? local.hana_lb_rules_ports : toset([])
+  hostname                      = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "azurerm_availability_set" "hana-availability-set" {
@@ -218,7 +219,7 @@ locals {
 
 resource "azurerm_virtual_machine" "hana" {
   count                            = var.hana_count
-  name                             = "vm${var.name}${format("%02d", count.index + 1)}"
+  name                             = "${var.name}${format("%02d", count.index + 1)}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.hana.*.id, count.index)]
@@ -256,7 +257,7 @@ resource "azurerm_virtual_machine" "hana" {
   }
 
   os_profile {
-    computer_name  = "vm${var.name}${format("%02d", count.index + 1)}"
+    computer_name  = "${local.hostname}${format("%02d", count.index + 1)}"
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/hana_node/salt_provisioner.tf
+++ b/azure/modules/hana_node/salt_provisioner.tf
@@ -21,10 +21,10 @@ resource "null_resource" "hana_node_provisioner" {
 role: hana_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["hana_grains_output"]}
-name_prefix: vm${var.name}
-hostname: vm${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-network_domain: "tf.local"
+network_domain: ${var.network_domain}
 hana_data_disks_configuration: {${join(", ", formatlist("'%s': '%s'", keys(var.hana_data_disks_configuration), values(var.hana_data_disks_configuration), ), )}}
 storage_account_name: ${var.storage_account_name}
 storage_account_key: ${var.storage_account_key}

--- a/azure/modules/hana_node/variables.tf
+++ b/azure/modules/hana_node/variables.tf
@@ -30,11 +30,6 @@ variable "hana_count" {
   default = "2"
 }
 
-variable "name" {
-  type    = string
-  default = "hana"
-}
-
 variable "fencing_mechanism" {
   description = "Choose the fencing mechanism for the cluster. Options: sbd, native"
   type        = string
@@ -74,9 +69,19 @@ variable "os_image" {
   type        = string
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "vm_size" {
   type    = string
   default = "Standard_E4s_v3"
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "iscsi_srv_ip" {

--- a/azure/modules/iscsi_server/main.tf
+++ b/azure/modules/iscsi_server/main.tf
@@ -3,6 +3,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.iscsisrv.*.private_ip_address : data.azurerm_public_ip.iscsisrv.*.ip_address
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "azurerm_network_interface" "iscsisrv" {
@@ -66,7 +67,7 @@ module "os_image_reference" {
 
 resource "azurerm_virtual_machine" "iscsisrv" {
   count                            = var.iscsi_count
-  name                             = "vmiscsisrv${format("%02d", count.index + 1)}"
+  name                             = "${var.name}${format("%02d", count.index + 1)}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.iscsisrv.*.id, count.index)]
@@ -99,7 +100,7 @@ resource "azurerm_virtual_machine" "iscsisrv" {
   }
 
   os_profile {
-    computer_name  = "vmiscsisrv"
+    computer_name  = "${local.hostname}${format("%02d", count.index + 1)}"
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/iscsi_server/salt_provisioner.tf
+++ b/azure/modules/iscsi_server/salt_provisioner.tf
@@ -20,6 +20,9 @@ resource "null_resource" "iscsi_provisioner" {
     content = <<EOF
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 iscsi_srv_ip: ${element(var.host_ips, count.index)}
 iscsidev: /dev/disk/azure/scsi1/lun0
 ${yamlencode(

--- a/azure/modules/iscsi_server/variables.tf
+++ b/azure/modules/iscsi_server/variables.tf
@@ -35,9 +35,19 @@ variable "iscsi_srv_uri" {
   default = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "vm_size" {
   type    = string
   default = "Standard_D2s_v3"
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "iscsi_count" {

--- a/azure/modules/monitoring/main.tf
+++ b/azure/modules/monitoring/main.tf
@@ -3,6 +3,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? data.azurerm_network_interface.monitoring.*.private_ip_address : data.azurerm_public_ip.monitoring.*.ip_address
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "azurerm_network_interface" "monitoring" {
@@ -65,7 +66,7 @@ module "os_image_reference" {
 }
 
 resource "azurerm_virtual_machine" "monitoring" {
-  name                             = "vmmonitoring"
+  name                             = var.name
   count                            = var.monitoring_enabled == true ? 1 : 0
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
@@ -99,7 +100,7 @@ resource "azurerm_virtual_machine" "monitoring" {
   }
 
   os_profile {
-    computer_name  = "vmmonitoring"
+    computer_name  = local.hostname
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/monitoring/salt_provisioner.tf
+++ b/azure/modules/monitoring/salt_provisioner.tf
@@ -21,12 +21,12 @@ resource "null_resource" "monitoring_provisioner" {
 role: monitoring_srv
 ${var.common_variables["grains_output"]}
 ${var.common_variables["monitoring_grains_output"]}
-name_prefix: vmmonitoring
-hostname: vmmonitoring
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ip: ${var.monitoring_srv_ip}
 public_ip: ${local.bastion_enabled ? data.azurerm_network_interface.monitoring.0.private_ip_address : data.azurerm_public_ip.monitoring.0.ip_address}
-network_domain: "tf.local"
 EOF
     destination = "/tmp/grains"
   }

--- a/azure/modules/monitoring/variables.tf
+++ b/azure/modules/monitoring/variables.tf
@@ -23,9 +23,19 @@ variable "resource_group_name" {
   type = string
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "vm_size" {
   type    = string
   default = "Standard_D2s_v3"
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "network_subnet_id" {

--- a/azure/modules/netweaver_node/main.tf
+++ b/azure/modules/netweaver_node/main.tf
@@ -26,6 +26,7 @@ locals {
     "5${var.ers_instance_number}16",
     "9680" # monitoring - sap_host_exporter
   ]) : toset([])
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "azurerm_availability_set" "netweaver-xscs-availability-set" {
@@ -307,7 +308,7 @@ module "os_image_reference" {
 
 resource "azurerm_virtual_machine" "netweaver" {
   count                            = local.vm_count
-  name                             = "vmnetweaver${format("%02d", count.index + 1)}"
+  name                             = "${var.name}${format("%02d", count.index + 1)}"
   location                         = var.az_region
   resource_group_name              = var.resource_group_name
   network_interface_ids            = [element(azurerm_network_interface.netweaver.*.id, count.index)]
@@ -332,7 +333,7 @@ resource "azurerm_virtual_machine" "netweaver" {
   }
 
   os_profile {
-    computer_name  = "vmnetweaver${format("%02d", count.index + 1)}"
+    computer_name  = "${local.hostname}${format("%02d", count.index + 1)}"
     admin_username = var.common_variables["authorized_user"]
   }
 

--- a/azure/modules/netweaver_node/salt_provisioner.tf
+++ b/azure/modules/netweaver_node/salt_provisioner.tf
@@ -21,8 +21,8 @@ resource "null_resource" "netweaver_provisioner" {
 role: netweaver_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["netweaver_grains_output"]}
-name_prefix: vmnetweaver
-hostname: vmnetweaver${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]

--- a/azure/modules/netweaver_node/variables.tf
+++ b/azure/modules/netweaver_node/variables.tf
@@ -26,8 +26,8 @@ variable "storage_account" {
 }
 
 variable "network_domain" {
-  type    = string
-  default = "tf.local"
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "fencing_mechanism" {
@@ -43,6 +43,11 @@ variable "xscs_server_count" {
 variable "app_server_count" {
   type    = number
   default = 2
+}
+
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
 }
 
 variable "xscs_vm_size" {

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -34,6 +34,9 @@ az_region = "westeurope"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Add the "deployment_name" as a prefix to the hostname.
+#deployment_name_in_hostname = false
+
 # Admin user for the created machines
 admin_user = "cloudadmin"
 
@@ -152,6 +155,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # HANA machines variables
 # This example shows the demo option values.Find more options in the README file
 #########################
+
+# Hostname, without the domain part
+#hana_name = "vmhana"
 
 # HANA configuration ()
 # VM size to use for the cluster nodes
@@ -283,6 +289,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # In order to enable SBD, an ISCSI server is needed as right now is the only option
 # All the clusters will use the same mechanism
 
+# Hostname, without the domain part
+#iscsi_name = "vmiscsi"
+
 # Custom iscsi server image
 #iscsi_srv_uri = "/path/to/your/iscsi/image"
 
@@ -309,6 +318,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
+# Hostname, without the domain part
+#monitoring_name = "vmmonitoring"
+
 # IP address of the machine where Prometheus and Grafana are running. If it's not set the address will be auto generated from the provided vnet address range
 #monitoring_srv_ip = "10.74.1.13"
 
@@ -316,14 +328,17 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 # DRBD related variables
 ########################
 
+# Enable drbd cluster
+#drbd_enabled = true
+
+# Hostname, without the domain part
+#drbd_name = "vmdrbd"
+
 # Custom drbd nodes image
 #drbd_image_uri = "/path/to/your/monitoring/image"
 
 # Public image usage for the DRBD machines. BYOS example
 #drbd_os_image = "SUSE:sles-sap-15-sp2-byos:gen2:latest"
-
-# Enable drbd cluster
-#drbd_enabled = true
 
 # Each drbd cluster host IP address (sequential order). If it's not set the addresses will be auto generated from the provided vnet address range
 #drbd_ips = ["10.74.1.21", "10.74.1.22"]
@@ -342,6 +357,9 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 #############################
 
 #netweaver_enabled = true
+
+# Hostname, without the domain part
+#netweaver_name = "vmnetweaver"
 
 # Netweaver APP server count (PAS and AAS)
 # Set to 0 to install the PAS instance in the same instance as the ASCS. This means only 1 machine is installed in the deployment (2 if HA capabilities are enabled)

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -79,6 +79,18 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "bastion_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmbastion"
+}
+
+variable "bastion_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_enabled" {
   description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
   type        = bool
@@ -109,6 +121,18 @@ variable "deployment_name" {
   description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
   type        = string
   default     = ""
+}
+
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+  default     = false
+}
+
+variable "network_domain" {
+  description = "hostname's network domain for all hosts. Can be overwritten by modules."
+  type        = string
+  default     = "tf.local"
 }
 
 variable "os_image" {
@@ -198,10 +222,16 @@ variable "provisioning_output_colored" {
 
 # Hana related variables
 
-variable "name" {
+variable "hana_name" {
   description = "hostname, without the domain part"
   type        = string
-  default     = "hana"
+  default     = "vmhana"
+}
+
+variable "hana_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
 }
 
 variable "hana_count" {
@@ -458,6 +488,18 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
+variable "iscsi_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmiscsi"
+}
+
+variable "iscsi_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_os_image" {
   description = "sles4sap image used to create the ISCSI machines. Composed by 'Publisher:Offer:Sku:Version' syntax. Example: SUSE:sles-sap-15-sp2:gen2:latest"
   type        = string
@@ -501,6 +543,18 @@ variable "iscsi_disk_size" {
 
 # Monitoring related variables
 
+variable "monitoring_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmmonitoring"
+}
+
+variable "monitoring_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "Enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool
@@ -538,6 +592,18 @@ variable "monitoring_srv_ip" {
 }
 
 # DRBD related variables
+
+variable "drbd_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmdrbd"
+}
+
+variable "drbd_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "drbd_enabled" {
   description = "Enable the DRBD cluster for nfs"
@@ -600,6 +666,18 @@ variable "drbd_nfs_mounting_point" {
 }
 
 # Netweaver related variables
+
+variable "netweaver_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmnetweaver"
+}
+
+variable "netweaver_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "netweaver_enabled" {
   description = "Enable SAP Netweaver cluster deployment"

--- a/gcp/infrastructure.tf
+++ b/gcp/infrastructure.tf
@@ -95,6 +95,8 @@ resource "google_compute_firewall" "ha_firewall_allow_tcp" {
 module "bastion" {
   source             = "./modules/bastion"
   common_variables   = module.common_variables.configuration
+  name               = var.bastion_name
+  network_domain     = var.bastion_network_domain == "" ? var.network_domain : var.bastion_network_domain
   region             = var.region
   os_image           = local.bastion_os_image
   vm_size            = "custom-1-2048"

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -71,6 +71,7 @@ module "common_variables" {
   provider_type                       = "gcp"
   region                              = var.region
   deployment_name                     = local.deployment_name
+  deployment_name_in_hostname         = var.deployment_name_in_hostname
   reg_code                            = var.reg_code
   reg_email                           = var.reg_email
   reg_additional_modules              = var.reg_additional_modules
@@ -153,6 +154,8 @@ module "common_variables" {
 module "drbd_node" {
   source               = "./modules/drbd_node"
   common_variables     = module.common_variables.configuration
+  name                 = var.drbd_name
+  network_domain       = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   bastion_host         = module.bastion.public_ip
   drbd_count           = var.drbd_enabled == true ? 2 : 0
   machine_type         = var.drbd_machine_type
@@ -164,7 +167,6 @@ module "drbd_node" {
   drbd_data_disk_type  = var.drbd_data_disk_type
   drbd_cluster_vip     = local.drbd_cluster_vip
   gcp_credentials_file = var.gcp_credentials_file
-  network_domain       = "tf.local"
   host_ips             = local.drbd_ips
   fencing_mechanism    = var.drbd_cluster_fencing_mechanism
   sbd_storage_type     = var.sbd_storage_type
@@ -182,6 +184,8 @@ module "drbd_node" {
 module "netweaver_node" {
   source                    = "./modules/netweaver_node"
   common_variables          = module.common_variables.configuration
+  name                      = var.netweaver_name
+  network_domain            = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   bastion_host              = module.bastion.public_ip
   xscs_server_count         = local.netweaver_xscs_server_count
   app_server_count          = var.netweaver_enabled ? var.netweaver_app_server_count : 0
@@ -191,7 +195,6 @@ module "netweaver_node" {
   network_subnet_name       = local.subnet_name
   os_image                  = local.netweaver_os_image
   gcp_credentials_file      = var.gcp_credentials_file
-  network_domain            = "tf.local"
   host_ips                  = local.netweaver_ips
   iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
@@ -207,6 +210,8 @@ module "netweaver_node" {
 module "hana_node" {
   source                = "./modules/hana_node"
   common_variables      = module.common_variables.configuration
+  name                  = var.hana_name
+  network_domain        = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   bastion_host          = module.bastion.public_ip
   hana_count            = var.hana_count
   machine_type          = var.machine_type
@@ -233,6 +238,8 @@ module "hana_node" {
 module "monitoring" {
   source              = "./modules/monitoring"
   common_variables    = module.common_variables.configuration
+  name                = var.monitoring_name
+  network_domain      = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   bastion_host        = module.bastion.public_ip
   monitoring_enabled  = var.monitoring_enabled
   compute_zones       = data.google_compute_zones.available.names
@@ -249,6 +256,8 @@ module "monitoring" {
 module "iscsi_server" {
   source              = "./modules/iscsi_server"
   common_variables    = module.common_variables.configuration
+  name                = var.iscsi_name
+  network_domain      = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
   bastion_host        = module.bastion.public_ip
   iscsi_count         = local.iscsi_enabled == true ? 1 : 0
   machine_type        = var.machine_type_iscsi_server

--- a/gcp/modules/bastion/main.tf
+++ b/gcp/modules/bastion/main.tf
@@ -3,6 +3,7 @@ locals {
   deployment_name    = var.common_variables["deployment_name"]
   private_ip_address = cidrhost(var.snet_address_range, 5)
   firewall_ports     = var.common_variables["monitoring_enabled"] ? ["22", "3000"] : ["22"]
+  hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 # Bastion subnet
@@ -42,7 +43,7 @@ resource "google_compute_firewall" "bastion_egress_firewall" {
 
 resource "google_compute_instance" "bastion" {
   count        = local.bastion_count
-  name         = "${var.common_variables["deployment_name"]}-bastion"
+  name         = "${local.deployment_name}-${var.name}"
   description  = "Bastion server"
   machine_type = var.vm_size
   zone         = element(var.compute_zones, 0)

--- a/gcp/modules/bastion/salt_provisioner.tf
+++ b/gcp/modules/bastion/salt_provisioner.tf
@@ -20,6 +20,9 @@ resource "null_resource" "bastion_provisioner" {
     content     = <<EOF
 role: bastion
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 EOF
     destination = "/tmp/grains"
   }

--- a/gcp/modules/bastion/variables.tf
+++ b/gcp/modules/bastion/variables.tf
@@ -7,8 +7,18 @@ variable "region" {
   type        = string
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "os_image" {
   description = "Image used to create the machine"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -4,6 +4,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.drbd.*.network_interface.0.network_ip : google_compute_instance.drbd.*.network_interface.0.access_config.0.nat_ip
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "google_compute_disk" "data" {
@@ -27,7 +28,7 @@ resource "google_compute_route" "drbd-route" {
 
 resource "google_compute_instance" "drbd" {
   machine_type = var.machine_type
-  name         = "${var.common_variables["deployment_name"]}-drbd${format("%02d", count.index + 1)}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   count        = var.drbd_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -20,8 +20,8 @@ resource "null_resource" "drbd_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-drbd
-hostname: ${var.common_variables["deployment_name"]}-drbd${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -8,6 +8,11 @@ variable "bastion_host" {
   default     = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "machine_type" {
   type    = string
   default = "n1-standard-4"
@@ -39,6 +44,11 @@ variable "os_image" {
   type        = string
 }
 
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "drbd_data_disk_size" {
   description = "drbd data disk size"
   type        = string
@@ -59,11 +69,6 @@ variable "drbd_cluster_vip" {
 variable "gcp_credentials_file" {
   description = "Path to your local gcp credentials file"
   type        = string
-}
-
-variable "network_domain" {
-  description = "hostname's network domain"
-  default     = "tf.local"
 }
 
 variable "host_ips" {

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -4,6 +4,7 @@ locals {
   create_ha_infra        = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.clusternodes.*.network_interface.0.network_ip : google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 # HANA disks configuration information: https://cloud.google.com/solutions/sap/docs/sap-hana-planning-guide#storage_configuration
@@ -98,7 +99,7 @@ module "hana-secondary-load-balancer" {
 
 resource "google_compute_instance" "clusternodes" {
   machine_type = var.machine_type
-  name         = "${var.common_variables["deployment_name"]}-hana${format("%02d", count.index + 1)}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   count        = var.hana_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/hana_node/salt_provisioner.tf
+++ b/gcp/modules/hana_node/salt_provisioner.tf
@@ -30,10 +30,10 @@ resource "null_resource" "hana_node_provisioner" {
 role: hana_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["hana_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-hana
-hostname: ${var.common_variables["deployment_name"]}-hana${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-network_domain: "tf.local"
+network_domain: ${var.network_domain}
 sbd_lun_index: 0
 hana_disk_device: ${format("%s%s", "/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.0.device_name, count.index))}
 hana_backup_device: ${format("%s%s", "/dev/disk/by-id/google-", element(google_compute_instance.clusternodes.*.attached_disk.1.device_name, count.index))}

--- a/gcp/modules/hana_node/variables.tf
+++ b/gcp/modules/hana_node/variables.tf
@@ -8,6 +8,11 @@ variable "bastion_host" {
   default     = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "hana_count" {
   type    = string
   default = "2"
@@ -35,6 +40,11 @@ variable "network_subnet_name" {
 
 variable "os_image" {
   description = "Image used to create the machine"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 

--- a/gcp/modules/iscsi_server/main.tf
+++ b/gcp/modules/iscsi_server/main.tf
@@ -1,6 +1,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.iscsisrv.*.network_interface.0.network_ip : google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "google_compute_disk" "iscsi_data" {
@@ -13,7 +14,7 @@ resource "google_compute_disk" "iscsi_data" {
 
 resource "google_compute_instance" "iscsisrv" {
   count        = var.iscsi_count
-  name         = "${var.common_variables["deployment_name"]}-iscsisrv-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   description  = "iSCSI server"
   machine_type = var.machine_type
   zone         = element(var.compute_zones, 0)

--- a/gcp/modules/iscsi_server/salt_provisioner.tf
+++ b/gcp/modules/iscsi_server/salt_provisioner.tf
@@ -20,6 +20,9 @@ resource "null_resource" "iscsi_provisioner" {
     content = <<EOF
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 iscsi_srv_ip: ${element(google_compute_instance.iscsisrv.*.network_interface.0.network_ip, count.index)}
 iscsidev: ${format("%s%s", "/dev/disk/by-id/google-", element(google_compute_instance.iscsisrv.*.attached_disk.0.device_name, count.index))}
 ${yamlencode(

--- a/gcp/modules/iscsi_server/variables.tf
+++ b/gcp/modules/iscsi_server/variables.tf
@@ -8,6 +8,11 @@ variable "bastion_host" {
   default     = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "machine_type" {
   type    = string
   default = "custom-1-2048"
@@ -25,6 +30,11 @@ variable "network_subnet_name" {
 
 variable "os_image" {
   description = "Image used to create the machine"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 

--- a/gcp/modules/monitoring/main.tf
+++ b/gcp/modules/monitoring/main.tf
@@ -4,6 +4,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.monitoring.*.network_interface.0.network_ip : google_compute_instance.monitoring.*.network_interface.0.access_config.0.nat_ip
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "google_compute_disk" "monitoring_data" {
@@ -16,7 +17,7 @@ resource "google_compute_disk" "monitoring_data" {
 
 resource "google_compute_instance" "monitoring" {
   count        = var.monitoring_enabled == true ? 1 : 0
-  name         = "${var.common_variables["deployment_name"]}-monitoring"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}"
   description  = "Monitoring server"
   machine_type = "custom-1-2048"
   zone         = element(var.compute_zones, 0)

--- a/gcp/modules/monitoring/salt_provisioner.tf
+++ b/gcp/modules/monitoring/salt_provisioner.tf
@@ -21,9 +21,9 @@ resource "null_resource" "monitoring_provisioner" {
 role: monitoring_srv
 ${var.common_variables["grains_output"]}
 ${var.common_variables["monitoring_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-monitoring
-hostname: ${var.common_variables["deployment_name"]}-monitoring
-network_domain: "tf.local"
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 host_ip: ${var.monitoring_srv_ip}
 public_ip: ${local.provisioning_addresses[0]}
 EOF

--- a/gcp/modules/monitoring/variables.tf
+++ b/gcp/modules/monitoring/variables.tf
@@ -8,6 +8,11 @@ variable "bastion_host" {
   default     = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool
@@ -26,6 +31,11 @@ variable "network_subnet_name" {
 
 variable "os_image" {
   description = "Image used to create the machine"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -7,6 +7,7 @@ locals {
   app_start_index        = local.create_ha_infra == 1 ? 2 : 1
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? google_compute_instance.netweaver.*.network_interface.0.network_ip : google_compute_instance.netweaver.*.network_interface.0.access_config.0.nat_ip
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "google_compute_disk" "netweaver-software" {
@@ -62,7 +63,7 @@ resource "google_compute_route" "nw-app-route" {
 
 resource "google_compute_instance" "netweaver" {
   machine_type = var.machine_type
-  name         = "${var.common_variables["deployment_name"]}-netweaver${format("%02d", count.index + 1)}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   count        = local.vm_count
   zone         = element(var.compute_zones, count.index)
 

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -30,8 +30,8 @@ resource "null_resource" "netweaver_provisioner" {
 role: netweaver_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["netweaver_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-netweaver
-hostname: ${var.common_variables["deployment_name"]}-netweaver${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]

--- a/gcp/modules/netweaver_node/variables.tf
+++ b/gcp/modules/netweaver_node/variables.tf
@@ -8,6 +8,11 @@ variable "bastion_host" {
   default     = ""
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "machine_type" {
   type    = string
   default = "n1-standard-4"
@@ -43,14 +48,14 @@ variable "os_image" {
   type        = string
 }
 
-variable "gcp_credentials_file" {
-  description = "Path to your local gcp credentials file"
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 
-variable "network_domain" {
-  type    = string
-  default = "tf.local"
+variable "gcp_credentials_file" {
+  description = "Path to your local gcp credentials file"
+  type        = string
 }
 
 variable "host_ips" {

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -35,6 +35,9 @@ region = "europe-west1"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Add the "deployment_name" as a prefix to the hostname.
+#deployment_name_in_hostname = true
+
 # If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
 # By default, all the images are PAYG, so these next parameters are not needed
 #reg_code = "<<REG_CODE>>"
@@ -148,6 +151,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 #########################
 # HANA machines variables
 #########################
+
+# Hostname, without the domain part
+#hana_name = "vmhana"
 
 # HANA machine type
 #machine_type = "n1-highmem-32"
@@ -276,6 +282,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation _fencing_mechanism must be set to 'sbd' for any of the clusters
 
+# Hostname, without the domain part
+#iscsi_name = "vmiscsi"
+
 # iSCSI server image. By default, PAYG image is used. The usage is the same as the HANA images
 #iscsi_os_image = "suse-byos-cloud/sles-15-sp2-sap-byos"
 
@@ -296,6 +305,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
+# Hostname, without the domain part
+#monitoring_name = "vmmonitoring"
+
 # Monitoring server image. By default, PAYG image is used. The usage is the same as the HANA images
 #monitoring_os_image = "suse-byos-cloud/sles-15-sp2-sap-byos"
 
@@ -308,6 +320,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 # Enable drbd cluster
 #drbd_enabled = true
+
+# Hostname, without the domain part
+#drbd_name = "vmdrbd"
 
 #drbd_machine_type = "n1-standard-4"
 
@@ -335,6 +350,9 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 
 # Enable netweaver cluster
 #netweaver_enabled = true
+
+# Hostname, without the domain part
+#netweaver_name = "vmnetweaver"
 
 # Netweaver APP server count (PAS and AAS)
 # Set to 0 to install the PAS instance in the same instance as the ASCS. This means only 1 machine is installed in the deployment (2 if HA capabilities are enabled)

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -61,6 +61,18 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "bastion_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmbastion"
+}
+
+variable "bastion_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_enabled" {
   description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
   type        = bool
@@ -97,6 +109,18 @@ variable "deployment_name" {
   description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
   type        = string
   default     = ""
+}
+
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+  default     = true
+}
+
+variable "network_domain" {
+  description = "hostname's network domain for all hosts. Can be overwritten by modules."
+  type        = string
+  default     = "tf.local"
 }
 
 variable "os_image" {
@@ -185,6 +209,18 @@ variable "provisioning_output_colored" {
 }
 
 # Hana related variables
+
+variable "hana_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmhana"
+}
+
+variable "hana_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "hana_count" {
   description = "Number of hana nodes"
@@ -418,6 +454,18 @@ variable "scenario_type" {
 }
 
 # Monitoring related variables
+variable "monitoring_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmmonitoring"
+}
+
+variable "monitoring_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_srv_ip" {
   description = "Monitoring server address"
   type        = string
@@ -461,6 +509,18 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
+variable "iscsi_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmiscsi"
+}
+
+variable "iscsi_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_os_image" {
   description = "The image used to create the iscsi machines"
   type        = string
@@ -497,6 +557,18 @@ variable "iscsi_disk_size" {
 }
 
 # DRBD related variables
+
+variable "drbd_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmdrbd"
+}
+
+variable "drbd_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "drbd_enabled" {
   description = "Enable the DRBD cluster for nfs"
@@ -571,6 +643,18 @@ variable "drbd_nfs_mounting_point" {
 }
 
 # Netweaver related variables
+
+variable "netweaver_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmnetweaver"
+}
+
+variable "netweaver_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "netweaver_enabled" {
   description = "Enable netweaver cluster creation"

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -21,6 +21,7 @@ output "configuration" {
     provider_type               = var.provider_type
     region                      = var.region
     deployment_name             = var.deployment_name
+    deployment_name_in_hostname = var.deployment_name_in_hostname
     reg_code                    = var.reg_code
     reg_email                   = var.reg_email
     reg_additional_modules      = var.reg_additional_modules

--- a/generic_modules/common_variables/variables.tf
+++ b/generic_modules/common_variables/variables.tf
@@ -21,6 +21,11 @@ variable "deployment_name" {
   default     = ""
 }
 
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   default     = ""

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -52,6 +52,7 @@ module "common_variables" {
   source                              = "../generic_modules/common_variables"
   provider_type                       = "libvirt"
   deployment_name                     = local.deployment_name
+  deployment_name_in_hostname         = var.deployment_name_in_hostname
   reg_code                            = var.reg_code
   reg_email                           = var.reg_email
   reg_additional_modules              = var.reg_additional_modules
@@ -129,6 +130,8 @@ module "common_variables" {
 module "iscsi_server" {
   source                = "./modules/iscsi_server"
   common_variables      = module.common_variables.configuration
+  name                  = var.iscsi_name
+  network_domain        = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
   iscsi_count           = local.iscsi_enabled == true ? 1 : 0
   source_image          = var.iscsi_source_image
   volume_name           = var.iscsi_source_image != "" ? "" : (var.iscsi_volume_name != "" ? var.iscsi_volume_name : local.generic_volume_name)
@@ -146,7 +149,8 @@ module "iscsi_server" {
 module "hana_node" {
   source                = "./modules/hana_node"
   common_variables      = module.common_variables.configuration
-  name                  = "hana"
+  name                  = var.hana_name
+  network_domain        = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   source_image          = var.hana_source_image
   volume_name           = var.hana_source_image != "" ? "" : (var.hana_volume_name != "" ? var.hana_volume_name : local.generic_volume_name)
   hana_count            = var.hana_count
@@ -165,7 +169,8 @@ module "hana_node" {
 module "drbd_node" {
   source                = "./modules/drbd_node"
   common_variables      = module.common_variables.configuration
-  name                  = "drbd"
+  name                  = var.drbd_name
+  network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   source_image          = var.drbd_source_image
   volume_name           = var.drbd_source_image != "" ? "" : (var.drbd_volume_name != "" ? var.drbd_volume_name : local.generic_volume_name)
   drbd_count            = var.drbd_enabled == true ? 2 : 0
@@ -189,7 +194,8 @@ module "drbd_node" {
 module "monitoring" {
   source                = "./modules/monitoring"
   common_variables      = module.common_variables.configuration
-  name                  = "monitoring"
+  name                  = var.monitoring_name
+  network_domain        = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   monitoring_enabled    = var.monitoring_enabled
   source_image          = var.monitoring_source_image
   volume_name           = var.monitoring_source_image != "" ? "" : (var.monitoring_volume_name != "" ? var.monitoring_volume_name : local.generic_volume_name)
@@ -205,9 +211,10 @@ module "monitoring" {
 module "netweaver_node" {
   source                = "./modules/netweaver_node"
   common_variables      = module.common_variables.configuration
+  name                  = var.netweaver_name
+  network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   xscs_server_count     = local.netweaver_xscs_server_count
   app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
-  name                  = "netweaver"
   source_image          = var.netweaver_source_image
   volume_name           = var.netweaver_source_image != "" ? "" : (var.netweaver_volume_name != "" ? var.netweaver_volume_name : local.generic_volume_name)
   vcpu                  = var.netweaver_node_vcpu

--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -8,6 +8,10 @@ terraform {
   }
 }
 
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
+
 resource "libvirt_volume" "drbd_image_disk" {
   count            = var.drbd_count
   name             = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-main-disk"
@@ -24,7 +28,7 @@ resource "libvirt_volume" "drbd_data_disk" {
 }
 
 resource "libvirt_domain" "drbd_domain" {
-  name       = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}"
+  name       = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.drbd_count

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -18,8 +18,8 @@ resource "null_resource" "drbd_node_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
-name_prefix: ${var.name}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -14,7 +14,7 @@ variable "timezone" {
 
 variable "network_domain" {
   description = "hostname's network domain"
-  default     = "tf.local"
+  type        = string
 }
 
 variable "drbd_count" {

--- a/libvirt/modules/hana_node/main.tf
+++ b/libvirt/modules/hana_node/main.tf
@@ -8,6 +8,10 @@ terraform {
   }
 }
 
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
+
 resource "libvirt_volume" "hana_image_disk" {
   count            = var.hana_count
   name             = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}-main-disk"
@@ -24,7 +28,7 @@ resource "libvirt_volume" "hana_data_disk" {
 }
 
 resource "libvirt_domain" "hana_domain" {
-  name       = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}"
+  name       = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.hana_count

--- a/libvirt/modules/hana_node/salt_provisioner.tf
+++ b/libvirt/modules/hana_node/salt_provisioner.tf
@@ -19,8 +19,8 @@ resource "null_resource" "hana_node_provisioner" {
 role: hana_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["hana_grains_output"]}
-name_prefix: ${var.name}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/libvirt/modules/hana_node/variables.tf
+++ b/libvirt/modules/hana_node/variables.tf
@@ -14,7 +14,7 @@ variable "timezone" {
 
 variable "network_domain" {
   description = "hostname's network domain"
-  default     = "tf.local"
+  type        = string
 }
 
 variable "hana_count" {

--- a/libvirt/modules/iscsi_server/main.tf
+++ b/libvirt/modules/iscsi_server/main.tf
@@ -8,6 +8,10 @@ terraform {
   }
 }
 
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
+
 resource "libvirt_volume" "iscsi_image_disk" {
   count            = var.iscsi_count
   name             = format("%s-iscsi-disk-%s", var.common_variables["deployment_name"], count.index + 1)
@@ -24,7 +28,7 @@ resource "libvirt_volume" "iscsi_dev_disk" {
 }
 
 resource "libvirt_domain" "iscsisrv" {
-  name       = format("%s-iscsi-%s", var.common_variables["deployment_name"], count.index + 1)
+  name       = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = var.iscsi_count

--- a/libvirt/modules/iscsi_server/salt_provisioner.tf
+++ b/libvirt/modules/iscsi_server/salt_provisioner.tf
@@ -15,6 +15,8 @@ resource "null_resource" "iscsi_provisioner" {
     content = <<EOF
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 host_ip: ${element(var.host_ips, count.index)}
 iscsi_srv_ip: ${element(var.host_ips, count.index)}
 iscsidev: /dev/vdb

--- a/libvirt/modules/iscsi_server/variables.tf
+++ b/libvirt/modules/iscsi_server/variables.tf
@@ -2,9 +2,19 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "host_ips" {
   description = "List of ip addresses to set to the machines"
   type        = list(string)
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
 }
 
 variable "lun_count" {

--- a/libvirt/modules/monitoring/main.tf
+++ b/libvirt/modules/monitoring/main.tf
@@ -8,6 +8,10 @@ terraform {
   }
 }
 
+locals {
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+}
+
 resource "libvirt_volume" "monitoring_image_disk" {
   count            = var.monitoring_enabled == true ? 1 : 0
   name             = format("%s-monitoring-disk", var.common_variables["deployment_name"])

--- a/libvirt/modules/monitoring/salt_provisioner.tf
+++ b/libvirt/modules/monitoring/salt_provisioner.tf
@@ -15,8 +15,8 @@ resource "null_resource" "monitoring_provisioner" {
 role: monitoring_srv
 ${var.common_variables["grains_output"]}
 ${var.common_variables["monitoring_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-${var.name}
-hostname: ${var.common_variables["deployment_name"]}-${var.name}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
 timezone: ${var.timezone}
 network_domain: ${var.network_domain}
 host_ip: ${var.monitoring_srv_ip}

--- a/libvirt/modules/monitoring/variables.tf
+++ b/libvirt/modules/monitoring/variables.tf
@@ -2,6 +2,11 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "monitoring_image" {
   description = "monitoring server base image"
   type        = string
@@ -13,14 +18,9 @@ variable "timezone" {
   default     = "Europe/Berlin"
 }
 
-variable "name" {
-  description = "hostname, without the domain part"
-  default     = "grafana"
-}
-
 variable "network_domain" {
   description = "hostname's network domain"
-  default     = "tf.local"
+  type        = string
 }
 
 variable "network_name" {

--- a/libvirt/modules/netweaver_node/main.tf
+++ b/libvirt/modules/netweaver_node/main.tf
@@ -10,6 +10,7 @@ terraform {
 
 locals {
   vm_count = var.xscs_server_count + var.app_server_count
+  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "libvirt_volume" "netweaver_image_disk" {
@@ -21,7 +22,7 @@ resource "libvirt_volume" "netweaver_image_disk" {
 }
 
 resource "libvirt_domain" "netweaver_domain" {
-  name       = "${var.common_variables["deployment_name"]}-${var.name}-${count.index + 1}"
+  name       = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   memory     = var.memory
   vcpu       = var.vcpu
   count      = local.vm_count

--- a/libvirt/modules/netweaver_node/salt_provisioner.tf
+++ b/libvirt/modules/netweaver_node/salt_provisioner.tf
@@ -19,8 +19,8 @@ resource "null_resource" "netweaver_node_provisioner" {
 role: netweaver_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["netweaver_grains_output"]}
-name_prefix: ${var.name}
-hostname: ${var.name}${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -95,7 +95,7 @@ variable "isolated_network_name" {
 
 variable "network_domain" {
   description = "hostname's network domain"
-  default     = "tf.local"
+  type        = string
 }
 
 variable "network_name" {

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -37,6 +37,9 @@ iprange = "192.168.XXX.Y/24"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Add the "deployment_name" as a prefix to the hostname.
+#deployment_name_in_hostname = true
+
 # SUSE Customer Center Registration parameters.
 #reg_code = "<<REG_CODE>>"
 #reg_email = "<<your email>>"
@@ -97,6 +100,9 @@ ha_sap_deployment_repo = ""
 #########################
 # HANA machines variables
 #########################
+
+# Hostname, without the domain part
+#hana_name = "vmhana"
 
 # Set specific image for HANA (it's the same for iscsi, monitoring, netweaver and drbd)
 # This option has preference over base image options
@@ -194,6 +200,10 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 #######################
 
 # In order to enable the iscsi machine creation _fencing_mechanism must be set to 'sbd' for any of the clusters
+
+# Hostname, without the domain part
+#iscsi_name = "vmiscsi"
+
 # Choose the sbd storage option. Options: iscsi, shared-disk
 #sbd_storage_type = "iscsi"
 #iscsi_srv_ip = "192.168.XXX.Y+6"
@@ -211,6 +221,9 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
+# Hostname, without the domain part
+#monitoring_name = "vmmonitoring"
+
 # IP address of the machine where prometheus and grafana are running
 #monitoring_srv_ip = "192.168.XXX.Y+7"
 
@@ -220,6 +233,9 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 
 # Enable the DRBD cluster for nfs
 #drbd_enabled = true
+
+# Hostname, without the domain part
+#drbd_name = "vmdrbd"
 
 # IP of DRBD cluster
 #drbd_ips = ["192.168.XXX.Y+8", "192.168.XXX.Y+9"]
@@ -234,6 +250,9 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 
 # Enable/disable Netweaver deployment
 #netweaver_enabled = true
+
+# Hostname, without the domain part
+#netweaver_name = "vmnetweaver"
 
 # Netweaver APP server count (PAS and AAS)
 # Set to 0 to install the PAS instance in the same instance as the ASCS. This means only 1 machine is installed in the deployment (2 if HA capabilities are enabled)

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -67,6 +67,18 @@ variable "deployment_name" {
   default     = ""
 }
 
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+  default     = true
+}
+
+variable "network_domain" {
+  description = "hostname's network domain for all hosts. Can be overwritten by modules."
+  type        = string
+  default     = "tf.local"
+}
+
 variable "reg_code" {
   description = "If informed, register the product using SUSEConnect"
   default     = ""
@@ -132,6 +144,18 @@ variable "provisioning_output_colored" {
 
 #
 # Hana related variables
+
+variable "hana_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmhana"
+}
+
+variable "hana_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "hana_count" {
   description = "Number of hana nodes"
@@ -362,6 +386,18 @@ variable "sbd_storage_type" {
   }
 }
 
+variable "iscsi_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmiscsi"
+}
+
+variable "iscsi_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_vcpu" {
   description = "Number of CPUs for the iSCSI server"
   type        = number
@@ -412,6 +448,18 @@ variable "iscsi_srv_ip" {
 #
 # Monitoring related variables
 #
+variable "monitoring_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmmonitoring"
+}
+
+variable "monitoring_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "Enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool
@@ -457,6 +505,18 @@ variable "monitoring_srv_ip" {
 #
 # Netweaver related variables
 #
+variable "netweaver_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmnetweaver"
+}
+
+variable "netweaver_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "netweaver_enabled" {
   description = "Enable SAP Netweaver deployment"
   type        = bool
@@ -640,6 +700,18 @@ variable "netweaver_ha_enabled" {
 #
 # DRBD related variables
 #
+variable "drbd_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmdrbd"
+}
+
+variable "drbd_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "drbd_enabled" {
   description = "Enable the drbd cluster for nfs"
   type        = bool

--- a/openstack/infrastructure.tf
+++ b/openstack/infrastructure.tf
@@ -114,6 +114,8 @@ resource "openstack_networking_secgroup_rule_v2" "ha_firewall_internal_allow_all
 module "bastion" {
   source           = "./modules/bastion"
   common_variables = module.common_variables.configuration
+  name             = var.bastion_name
+  network_domain   = var.bastion_network_domain == "" ? var.network_domain : var.bastion_network_domain
   region           = var.region
   region_net       = var.region_net
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -74,6 +74,7 @@ module "common_variables" {
   source                              = "../generic_modules/common_variables"
   provider_type                       = "openstack"
   deployment_name                     = local.deployment_name
+  deployment_name_in_hostname         = var.deployment_name_in_hostname
   reg_code                            = var.reg_code
   reg_email                           = var.reg_email
   reg_additional_modules              = var.reg_additional_modules
@@ -156,6 +157,8 @@ module "common_variables" {
 module "drbd_node" {
   source              = "./modules/drbd_node"
   common_variables    = module.common_variables.configuration
+  name                = var.drbd_name
+  network_domain      = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
   region              = var.region
   region_net          = var.region_net
   bastion_host        = module.bastion.public_ip
@@ -187,6 +190,8 @@ module "drbd_node" {
 module "netweaver_node" {
   source                    = "./modules/netweaver_node"
   common_variables          = module.common_variables.configuration
+  name                      = var.netweaver_name
+  network_domain            = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
   region                    = var.region
   region_net                = var.region_net
   bastion_host              = module.bastion.public_ip
@@ -200,7 +205,6 @@ module "netweaver_node" {
   network_subnet_id         = local.subnet_id
   firewall_internal         = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                  = local.netweaver_os_image
-  network_domain            = "tf.local"
   iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
   fencing_mechanism         = var.hana_cluster_fencing_mechanism
   sbd_storage_type          = var.sbd_storage_type
@@ -218,6 +222,8 @@ module "netweaver_node" {
 module "hana_node" {
   source                     = "./modules/hana_node"
   common_variables           = module.common_variables.configuration
+  name                       = var.hana_name
+  network_domain             = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
   region                     = var.region
   region_net                 = var.region_net
   bastion_host               = module.bastion.public_ip
@@ -250,6 +256,8 @@ module "hana_node" {
 module "monitoring" {
   source              = "./modules/monitoring"
   common_variables    = module.common_variables.configuration
+  name                = var.monitoring_name
+  network_domain      = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
   region              = var.region
   region_net          = var.region_net
   bastion_host        = module.bastion.public_ip
@@ -271,6 +279,8 @@ module "monitoring" {
 module "iscsi_server" {
   source              = "./modules/iscsi_server"
   common_variables    = module.common_variables.configuration
+  name                = var.iscsi_name
+  network_domain      = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
   region              = var.region
   region_net          = var.region_net
   bastion_host        = module.bastion.public_ip

--- a/openstack/modules/bastion/main.tf
+++ b/openstack/modules/bastion/main.tf
@@ -4,6 +4,7 @@ locals {
   bastion_public_key = var.common_variables["bastion_public_key"] != "" ? var.common_variables["bastion_public_key"] : var.common_variables["public_key"]
   use_data_volume    = var.common_variables["bastion_enabled"] && (var.bastion_data_disk_type == "volume" || var.bastion_data_disk_name == "") ? true : false
   create_data_volume = var.common_variables["bastion_enabled"] && local.use_data_volume && var.bastion_data_disk_name == "" ? true : false
+  hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "openstack_networking_floatingip_v2" "bastion" {
@@ -65,7 +66,7 @@ resource "openstack_compute_volume_attach_v2" "data_attached" {
 
 resource "openstack_compute_instance_v2" "bastion" {
   count        = local.bastion_count
-  name         = "${var.common_variables["deployment_name"]}-bastion"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}"
   flavor_name  = var.bastion_flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/bastion/salt_provisioner.tf
+++ b/openstack/modules/bastion/salt_provisioner.tf
@@ -36,6 +36,9 @@ resource "null_resource" "bastion_provisioner" {
     content     = <<EOF
 role: bastion
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 data_disk_type: ${var.bastion_data_disk_type}
 data_disk_device: /dev/sdb
 EOF

--- a/openstack/modules/bastion/variables.tf
+++ b/openstack/modules/bastion/variables.tf
@@ -17,6 +17,11 @@ variable "bastion_flavor" {
   default = "2C-2GB-40GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "bastion_data_disk_name" {
   description = "Use existing volume to mount on bastion for NFS server"
   type        = string
@@ -29,6 +34,11 @@ variable "bastion_data_disk_type" {
 
 variable "bastion_data_disk_size" {
   description = "Disk Size of the disks used to serve as NFS server"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 

--- a/openstack/modules/drbd_node/main.tf
+++ b/openstack/modules/drbd_node/main.tf
@@ -4,6 +4,7 @@ locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = openstack_compute_instance_v2.drbd.*.access_ip_v4
   create_volumes         = var.drbd_count > 1 && var.drbd_data_disk_type != "ephemeral" ? true : false
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "openstack_blockstorage_volume_v3" "data" {
@@ -40,7 +41,7 @@ resource "openstack_networking_port_v2" "drbd" {
 
 resource "openstack_compute_instance_v2" "drbd" {
   count        = var.drbd_count
-  name         = "${var.common_variables["deployment_name"]}-drbd-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   flavor_name  = var.flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/drbd_node/salt_provisioner.tf
+++ b/openstack/modules/drbd_node/salt_provisioner.tf
@@ -48,8 +48,8 @@ resource "null_resource" "drbd_node_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-drbd
-hostname: ${var.common_variables["deployment_name"]}-drbd${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}

--- a/openstack/modules/drbd_node/variables.tf
+++ b/openstack/modules/drbd_node/variables.tf
@@ -17,6 +17,16 @@ variable "flavor" {
   default = "2C-2GB-40GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "network_name" {
   description = "Network to attach the static route (temporary solution)"
   type        = string
@@ -61,11 +71,6 @@ variable "host_ips" {
 variable "firewall_internal" {
   description = "Internal firewall to attach VM to"
   type        = string
-}
-
-variable "network_domain" {
-  description = "hostname's network domain"
-  default     = "tf.local"
 }
 
 variable "fencing_mechanism" {

--- a/openstack/modules/hana_node/main.tf
+++ b/openstack/modules/hana_node/main.tf
@@ -7,6 +7,7 @@ locals {
   create_backup_volumes      = var.hana_count > 1 && var.hana_backup_disk_type != "ephemeral" ? true : false
   create_active_active_infra = local.create_ha_infra == 1 && var.common_variables["hana"]["cluster_vip_secondary"] != "" ? 1 : 0
   provisioning_addresses     = openstack_compute_instance_v2.hana.*.access_ip_v4
+  hostname                   = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "openstack_blockstorage_volume_v3" "data" {
@@ -60,7 +61,7 @@ resource "openstack_networking_port_v2" "hana" {
 
 resource "openstack_compute_instance_v2" "hana" {
   count        = var.hana_count
-  name         = "${var.common_variables["deployment_name"]}-hana-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   flavor_name  = var.flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/hana_node/salt_provisioner.tf
+++ b/openstack/modules/hana_node/salt_provisioner.tf
@@ -49,10 +49,10 @@ resource "null_resource" "hana_node_provisioner" {
 role: hana_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["hana_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-hana
-hostname: ${var.common_variables["deployment_name"]}-hana${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
-network_domain: "tf.local"
 sbd_lun_index: 0
 hana_disk_device: /dev/sdc
 hana_backup_device: /dev/sdb

--- a/openstack/modules/hana_node/variables.tf
+++ b/openstack/modules/hana_node/variables.tf
@@ -17,6 +17,16 @@ variable "flavor" {
   default = "8C-32GB-40GB-200GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "network_name" {
   description = "Network to attach the static route (temporary solution)"
   type        = string
@@ -61,11 +71,6 @@ variable "host_ips" {
 variable "firewall_internal" {
   description = "Internal firewall to attach VM to"
   type        = string
-}
-
-variable "network_domain" {
-  description = "hostname's network domain"
-  default     = "tf.local"
 }
 
 variable "fencing_mechanism" {

--- a/openstack/modules/iscsi_server/main.tf
+++ b/openstack/modules/iscsi_server/main.tf
@@ -1,6 +1,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 
@@ -27,7 +28,7 @@ resource "openstack_blockstorage_volume_v3" "iscsisrv_sbd" {
 
 resource "openstack_compute_instance_v2" "iscsisrv" {
   count        = var.iscsi_count
-  name         = "${var.common_variables["deployment_name"]}-iscsisrv-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   flavor_name  = var.flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/iscsi_server/salt_provisioner.tf
+++ b/openstack/modules/iscsi_server/salt_provisioner.tf
@@ -47,6 +47,9 @@ resource "null_resource" "iscsi_provisioner" {
     content = <<EOF
 role: iscsi_srv
 ${var.common_variables["grains_output"]}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
+network_domain: ${var.network_domain}
 iscsi_srv_ip: ${element(var.host_ips, count.index)}
 iscsidev: /dev/sdb
 ${yamlencode(

--- a/openstack/modules/iscsi_server/variables.tf
+++ b/openstack/modules/iscsi_server/variables.tf
@@ -17,6 +17,16 @@ variable "flavor" {
   default = "2C-2GB-40GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "network_name" {
   description = "Network to attach the static route (temporary solution)"
   type        = string
@@ -61,11 +71,6 @@ variable "host_ips" {
 variable "firewall_internal" {
   description = "Internal firewall to attach VM to"
   type        = string
-}
-
-variable "network_domain" {
-  description = "hostname's network domain"
-  default     = "tf.local"
 }
 
 # variable "fencing_mechanism" {

--- a/openstack/modules/monitoring/main.tf
+++ b/openstack/modules/monitoring/main.tf
@@ -4,6 +4,7 @@ locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   vm_count               = var.monitoring_enabled == "true" ? 0 : 1
   provisioning_addresses = openstack_compute_instance_v2.monitoring.*.access_ip_v4
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "openstack_networking_port_v2" "monitoring" {
@@ -21,7 +22,7 @@ resource "openstack_networking_port_v2" "monitoring" {
 
 resource "openstack_compute_instance_v2" "monitoring" {
   count        = local.vm_count
-  name         = "${var.common_variables["deployment_name"]}-monitoring-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}"
   flavor_name  = var.flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/monitoring/salt_provisioner.tf
+++ b/openstack/modules/monitoring/salt_provisioner.tf
@@ -52,9 +52,9 @@ resource "null_resource" "monitoring_node_provisioner" {
 role: monitoring_srv
 ${var.common_variables["grains_output"]}
 ${var.common_variables["monitoring_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-monitoring
-hostname: ${var.common_variables["deployment_name"]}-monitoring
-network_domain: "tf.local"
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}
+network_domain: ${var.network_domain}
 host_ip: ${element(var.host_ips, count.index)}
 public_ip: ${var.monitoring_srv_ip}
 EOF

--- a/openstack/modules/monitoring/variables.tf
+++ b/openstack/modules/monitoring/variables.tf
@@ -17,8 +17,18 @@ variable "flavor" {
   default = "4C-8GB-40GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
 variable "network_name" {
   description = "Network to attach the static route (temporary solution)"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
   type        = string
 }
 
@@ -61,11 +71,6 @@ variable "host_ips" {
 variable "firewall_internal" {
   description = "Internal firewall to attach VM to"
   type        = string
-}
-
-variable "network_domain" {
-  type    = string
-  default = "tf.local"
 }
 
 # variable "fencing_mechanism" {

--- a/openstack/modules/netweaver_node/main.tf
+++ b/openstack/modules/netweaver_node/main.tf
@@ -5,6 +5,7 @@ locals {
   vm_count               = var.xscs_server_count + var.app_server_count
   create_ha_infra        = local.vm_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
   provisioning_addresses = openstack_compute_instance_v2.netweaver.*.access_ip_v4
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "openstack_networking_port_v2" "netweaver" {
@@ -34,7 +35,7 @@ resource "openstack_networking_port_v2" "netweaver" {
 
 resource "openstack_compute_instance_v2" "netweaver" {
   count        = local.vm_count
-  name         = "${var.common_variables["deployment_name"]}-netweaver-${count.index + 1}"
+  name         = "${var.common_variables["deployment_name"]}-${var.name}${format("%02d", count.index + 1)}"
   flavor_name  = var.flavor
   image_id     = var.os_image
   config_drive = true

--- a/openstack/modules/netweaver_node/salt_provisioner.tf
+++ b/openstack/modules/netweaver_node/salt_provisioner.tf
@@ -49,8 +49,8 @@ resource "null_resource" "netweaver_node_provisioner" {
 role: netweaver_node
 ${var.common_variables["grains_output"]}
 ${var.common_variables["netweaver_grains_output"]}
-name_prefix: ${var.common_variables["deployment_name"]}-netweaver
-hostname: ${var.common_variables["deployment_name"]}-netweaver${format("%02d", count.index + 1)}
+name_prefix: ${local.hostname}
+hostname: ${local.hostname}${format("%02d", count.index + 1)}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 virtual_host_ips: [${join(", ", formatlist("'%s'", var.virtual_host_ips))}]

--- a/openstack/modules/netweaver_node/variables.tf
+++ b/openstack/modules/netweaver_node/variables.tf
@@ -17,6 +17,16 @@ variable "flavor" {
   default = "2C-2GB-40GB"
 }
 
+variable "name" {
+  description = "hostname, without the domain part"
+  type        = string
+}
+
+variable "network_domain" {
+  description = "hostname's network domain"
+  type        = string
+}
+
 variable "network_name" {
   description = "Network to attach the static route (temporary solution)"
   type        = string
@@ -62,11 +72,6 @@ variable "host_ips" {
 variable "firewall_internal" {
   description = "Internal firewall to attach VM to"
   type        = string
-}
-
-variable "network_domain" {
-  type    = string
-  default = "tf.local"
 }
 
 variable "fencing_mechanism" {

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -93,3 +93,9 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
+
+# bastion
+
+output "bastion_public_ip" {
+  value = module.bastion.public_ip
+}

--- a/openstack/terraform.tfvars.example
+++ b/openstack/terraform.tfvars.example
@@ -41,6 +41,9 @@ ip_cidr_range = "10.0.0.0/24"
 # The name must be unique among different deployments
 # deployment_name = "mydeployment"
 
+# Add the "deployment_name" as a prefix to the hostname.
+#deployment_name_in_hostname = true
+
 # If BYOS images are used in the deployment, SCC registration code is required. Set `reg_code` and `reg_email` variables below
 # By default, all the images are PAYG, so these next parameters are not needed
 #reg_code = "<<REG_CODE>>"
@@ -132,7 +135,7 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # qa_mode must be set to true for executing hwcct
 # true or false (default)
 #hwcct = false
-#
+
 ##########################
 # Bastion (jumpbox) machine variables
 ##########################
@@ -165,6 +168,9 @@ bastion_data_disk_type = ""
 #########################
 # HANA machines variables
 #########################
+
+# Hostname, without the domain part
+#hana_name = "vmhana"
 
 # HANA flavor
 hana_flavor = "8C-32GB-40GB-200GB"
@@ -282,6 +288,9 @@ hana_ips = ["10.0.0.10", "10.0.0.11"]
 # All the clusters will use the same mechanism
 # In order to enable the iscsi machine creation _fencing_mechanism must be set to 'sbd' for any of the clusters
 
+# Hostname, without the domain part
+#iscsi_name = "vmiscsi"
+
 # iSCSI server os_image. This value is used to overwrite the default "os_image".
 # If `openstack` utility is available in your local machine, the next command shows some of the available options
 # openstack image list
@@ -304,6 +313,9 @@ iscsi_flavor = "2C-2GB-40GB"
 # Enable the host to be monitored by exporters
 #monitoring_enabled = true
 
+# Hostname, without the domain part
+#hana_name = "vmmonitoring"
+
 monitoring_flavor = "4C-8GB-40GB"
 
 # Monitoring server os_image. This value is used to overwrite the default "os_image".
@@ -320,6 +332,9 @@ monitoring_flavor = "4C-8GB-40GB"
 
 # Enable drbd cluster
 #drbd_enabled = true
+
+# Hostname, without the domain part
+#drbd_name = "vmdrbd"
 
 drbd_flavor = "8C-32GB-40GB-200GB"
 
@@ -354,6 +369,9 @@ drbd_nfs_mounting_point = "/mnt_permanent/sapdata"
 
 # Enable netweaver cluster
 #netweaver_enabled = true
+
+# Hostname, without the domain part
+#netweaver_name = "vmnetweaver"
 
 # Netweaver APP server count (PAS and AAS)
 # Set to 0 to install the PAS instance in the same instance as the ASCS. This means only 1 machine is installed in the deployment (2 if HA capabilities are enabled)

--- a/openstack/variables.tf
+++ b/openstack/variables.tf
@@ -86,6 +86,18 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "bastion_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmbastion"
+}
+
+variable "bastion_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "bastion_enabled" {
   description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
   type        = bool
@@ -146,6 +158,18 @@ variable "deployment_name" {
   description = "Suffix string added to some of the infrastructure resources names. If it is not provided, the terraform workspace string is used as suffix"
   type        = string
   default     = ""
+}
+
+variable "deployment_name_in_hostname" {
+  description = "Add deployment_name as a prefix to all hostnames."
+  type        = bool
+  default     = true
+}
+
+variable "network_domain" {
+  description = "hostname's network domain for all hosts. Can be overwritten by modules."
+  type        = string
+  default     = "tf.local"
 }
 
 variable "os_image" {
@@ -234,6 +258,18 @@ variable "provisioning_output_colored" {
 }
 
 # Hana related variables
+
+variable "hana_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmhana"
+}
+
+variable "hana_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "hana_count" {
   description = "Number of hana nodes"
@@ -431,6 +467,18 @@ variable "scenario_type" {
 }
 
 # Monitoring related variables
+variable "monitoring_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmmonitoring"
+}
+
+variable "monitoring_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_srv_ip" {
   description = "Monitoring server address"
   type        = string
@@ -468,6 +516,18 @@ variable "sbd_storage_type" {
 # If iscsi is selected as sbd_storage_type
 # Use the next variables for advanced configuration
 
+variable "iscsi_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmiscsi"
+}
+
+variable "iscsi_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
 variable "iscsi_os_image" {
   description = "The image used to create the iscsi machines"
   type        = string
@@ -498,6 +558,18 @@ variable "iscsi_disk_size" {
 }
 
 # DRBD related variables
+
+variable "drbd_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmdrbd"
+}
+
+variable "drbd_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "drbd_enabled" {
   description = "Enable the DRBD cluster for nfs"
@@ -554,6 +626,18 @@ variable "drbd_nfs_mounting_point" {
 }
 
 # Netweaver related variables
+
+variable "netweaver_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmnetweaver"
+}
+
+variable "netweaver_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
 
 variable "netweaver_enabled" {
   description = "Enable netweaver cluster creation"

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -21,21 +21,21 @@ base:
     - cluster
 
 predeployment:
+  '*':
+    - default
+
   'role:hana_node':
     - match: grain
-    - default
     - cluster_node
     - hana_node
 
   'role:netweaver_node':
     - match: grain
-    - default
     - cluster_node
     - netweaver_node
 
   'role:drbd_node':
     - match: grain
-    - default
     - cluster_node
     - drbd_node
 
@@ -45,7 +45,6 @@ predeployment:
 
   'role:monitoring_srv':
     - match: grain
-    - default
     - monitoring_srv
 
   'role:bastion':


### PR DESCRIPTION
This PR makes it possible to configure the hostnames of each VM type via variables in `terraform.tfvars`. It addresses #757 .
Additionally there is the possibility to add the `deployment_name` as a prefix to the actual hostname (in salt and OS).
The `deployment_name` will be added to terraform resources as usual (no change in behavior).
``` 
  # Add the "deployment_name" as a prefix to the hostname.
  #deployment_name_in_hostname = false

  #hana_name = "vmhana"
  #iscsi_name = "vmiscsi"
  #monitoring_name = "vmmonitoring"
  #drbd_name = "vmdrbd"
  #netweaver_name = "vmnetweaver"
``` 


- run salt default state on all hosts
  * needed to actually change hostnames via state `default.hostname`

- ignore terraform lockfiles

- ignore gcp credentials

- azure: make hostnames configurable

- aws: make hostnames configurable

- gcp: make hostnames configurable

- libvirt: make hostnames configurable

