### PR TITLE
azure: fix ANF variables in non-ANF case

### DIFF
--- a/azure/infrastructure.tf
+++ b/azure/infrastructure.tf
@@ -39,9 +39,8 @@ locals {
   subnet_address_range        = var.subnet_name == "" ? (var.subnet_address_range == "" ? cidrsubnet(local.vnet_address_range, 8, 1) : var.subnet_address_range) : (var.subnet_address_range == "" ? data.azurerm_subnet.mysubnet.0.address_prefix : var.subnet_address_range)
   subnet_netapp_address_range = var.subnet_netapp_name == "" ? (var.subnet_netapp_address_range == "" ? cidrsubnet(local.vnet_address_range, 8, 3) : var.subnet_netapp_address_range) : (var.subnet_netapp_address_range == "" ? data.azurerm_subnet.mysubnet-netapp.0.address_prefix : var.subnet_netapp_address_range)
   shared_storage_anf          = (var.hana_scale_out_shared_storage_type == "anf" || var.netweaver_shared_storage_type == "anf") ? 1 : 0
-  anf_account_name            = var.anf_account_name == "" ? azurerm_netapp_account.mynetapp-acc.0.name : var.anf_account_name
-  anf_pool_name               = var.anf_pool_name == "" ? azurerm_netapp_pool.mynetapp-pool.0.name : var.anf_pool_name
-  anf_pool_service_level      = var.anf_pool_service_level == "" ? azurerm_netapp_pool.mynetapp-pool.0.service_level : var.anf_pool_service_level
+  anf_account_name            = local.shared_storage_anf == 1 ? (var.anf_account_name == "" ? azurerm_netapp_account.mynetapp-acc.0.name : var.anf_account_name) : ""
+  anf_pool_name               = local.shared_storage_anf == 1 ? (var.anf_pool_name == "" ? azurerm_netapp_pool.mynetapp-pool.0.name : var.anf_pool_name) : ""
 }
 
 # Azure resource group and storage account resources

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -203,7 +203,7 @@ module "netweaver_node" {
   # ANF specific
   anf_account_name           = local.anf_account_name
   anf_pool_name              = local.anf_pool_name
-  anf_pool_service_level     = local.anf_pool_service_level
+  anf_pool_service_level     = var.anf_pool_service_level
   netweaver_anf_quota_sapmnt = var.netweaver_anf_quota_sapmnt
   # only used by azure fence agent (native fencing)
   subscription_id           = data.azurerm_subscription.current.subscription_id
@@ -238,7 +238,7 @@ module "hana_node" {
   # ANF specific
   anf_account_name                = local.anf_account_name
   anf_pool_name                   = local.anf_pool_name
-  anf_pool_service_level          = local.anf_pool_service_level
+  anf_pool_service_level          = var.anf_pool_service_level
   hana_scale_out_anf_quota_data   = var.hana_scale_out_anf_quota_data
   hana_scale_out_anf_quota_log    = var.hana_scale_out_anf_quota_log
   hana_scale_out_anf_quota_backup = var.hana_scale_out_anf_quota_backup


### PR DESCRIPTION
This fixes the following error message after the latest #733 merge in non-ANF use cases.

```
Error: Invalid index

  on infrastructure.tf line 42, in locals:
  42:   anf_account_name            = var.anf_account_name == "" ? azurerm_netapp_account.mynetapp-acc.0.name : var.anf_account_name
    |----------------
    | azurerm_netapp_account.mynetapp-acc is empty tuple
```