### PR TITLE
powervs: add pi storage type

### DIFF
--- a/powervs/infrastructure.tf
+++ b/powervs/infrastructure.tf
@@ -48,6 +48,7 @@ module "bastion" {
   memory                        = var.bastion_node_memory
   os_image                      = local.bastion_os_image
   pi_sys_type                   = var.pi_sys_type
+  pi_storage_type               = var.pi_storage_type
   pi_network_ids                = local.bastion_network_ids
   private_pi_network_names      = var.private_pi_network_names
   public_pi_network_names       = var.public_pi_network_names

--- a/powervs/main.tf
+++ b/powervs/main.tf
@@ -118,6 +118,7 @@ module "hana_node" {
   os_image                      = local.hana_os_image
   pi_cloud_instance_id          = var.pi_cloud_instance_id
   pi_sys_type                   = var.pi_sys_type
+  pi_storage_type               = var.pi_storage_type
   pi_network_ids                = local.pi_network_ids
   private_pi_network_names      = var.private_pi_network_names
   public_pi_network_names       = var.public_pi_network_names

--- a/powervs/modules/bastion/main.tf
+++ b/powervs/modules/bastion/main.tf
@@ -4,19 +4,6 @@ locals {
   userdata_bastion   = templatefile("${path.module}/userdata_bastion.tpl", {})
 }
 
-# 2021-06-30 Adding a volume is a workaround so the bastion instance will be created
-#   https://github.com/IBM-Cloud/terraform-provider-ibm/issues/2787
-#   The need for an extra volume can be removed once https://github.com/IBM-Cloud/terraform-provider-ibm/pull/2797
-#   is released.
-resource "ibm_pi_volume" "bastion_volume"{
-  count                = local.bastion_count
-  pi_volume_size       = 10
-  pi_volume_name       = "bastion-volume"
-  pi_volume_type       = "tier1"
-  pi_volume_shareable  = false
-  pi_cloud_instance_id = "94ded72b-b08d-4618-b60d-5c3da2dcd3f8"
-}
-
   resource "ibm_pi_instance" "bastion" {
     count                 = local.bastion_count
     pi_cloud_instance_id  = var.pi_cloud_instance_id
@@ -28,16 +15,16 @@ resource "ibm_pi_volume" "bastion_volume"{
     pi_memory             = var.memory
     pi_processors         = var.vcpu
     pi_network_ids        = var.pi_network_ids
-    pi_volume_ids         = [ibm_pi_volume.bastion_volume[count.index].volume_id]
+    pi_volume_ids         = []
     pi_replicants         = 1
     pi_replication_scheme = "suffix"
     pi_user_data          = base64encode(local.userdata_bastion)
     pi_pin_policy         = "none"
     pi_replication_policy = "none"
+    pi_storage_type       = var.pi_storage_type
     pi_health_status      = "OK"
     timeouts {
       create = "15m"
       delete = "15m"
     }
-    depends_on            = [ibm_pi_volume.bastion_volume]
   }

--- a/powervs/modules/bastion/variables.tf
+++ b/powervs/modules/bastion/variables.tf
@@ -73,6 +73,11 @@ variable "pi_sys_type" {
   default     = ""
 }
 
+variable "pi_storage_type" {
+  description = "The storage type used for OS image. Use ibmcloud pi stypes to list available for the region."
+  default     = "tier1"
+}
+
 variable "pi_network_ids" {
   description = "The list of network IDs that you want to assign to the instance."
   type        = list(string)

--- a/powervs/modules/hana_node/main.tf
+++ b/powervs/modules/hana_node/main.tf
@@ -35,6 +35,7 @@ resource "ibm_pi_instance" "ibm_pi_hana" {
   pi_replication_scheme = "suffix"
   pi_pin_policy         = "none"
   pi_replication_policy = "none"
+  pi_storage_type       = var.pi_storage_type
   pi_user_data          = local.bastion_enabled ? base64encode(local.userdata_hana) : ""
   pi_health_status      = "OK"
   pi_volume_ids         = concat([for n in range((count.index * local.disks_number),((count.index + 1) * local.disks_number)) : ibm_pi_volume.ibm_pi_hana_volume[n].volume_id], local.create_shared_infra == 1 ? [var.sbd_disk_id] : [])

--- a/powervs/modules/hana_node/variables.tf
+++ b/powervs/modules/hana_node/variables.tf
@@ -129,6 +129,10 @@ variable "pi_sys_type" {
   default     = ""
 }
 
+variable "pi_storage_type" {
+  description = "The storage type used for OS image. Use ibmcloud pi stypes to list available for the region."
+  default     = "tier1"
+}
 
 variable "pi_network_ids" {
 description = "The list of network IDs that you want to assign to the instance."

--- a/powervs/variables.tf
+++ b/powervs/variables.tf
@@ -34,6 +34,11 @@ variable "pi_sys_type" {
   default     = ""
 }
 
+variable "pi_storage_type" {
+  description = "The storage type used for OS image. Use ibmcloud pi stypes to list available for the region."
+  default     = "tier1"
+}
+
 variable "public_pi_network_ids" {
   description = "The list of public network IDs that you want to assign to an instance."
   type        = list(string)


### PR DESCRIPTION
Changes to the IBM Cloud terraform backend caused instance deployments to fail with a 504 error.  A new resource option `pi_storage_type` is needed to select the storage tier that the IBM Cloud provided SLES for SAP image will use.