### PR TITLE
powervs: change timeouts

### DIFF
--- a/powervs/modules/bastion/main.tf
+++ b/powervs/modules/bastion/main.tf
@@ -36,8 +36,8 @@ resource "ibm_pi_volume" "bastion_volume"{
     pi_replication_policy = "none"
     pi_health_status      = "OK"
     timeouts {
-      create = "15m"
-      delete = "15m"
+      create = "30m"
+      delete = "30m"
     }
     depends_on            = [ibm_pi_volume.bastion_volume]
   }

--- a/powervs/modules/hana_node/main.tf
+++ b/powervs/modules/hana_node/main.tf
@@ -39,7 +39,7 @@ resource "ibm_pi_instance" "ibm_pi_hana" {
   pi_health_status      = "OK"
   pi_volume_ids         = concat([for n in range((count.index * local.disks_number),((count.index + 1) * local.disks_number)) : ibm_pi_volume.ibm_pi_hana_volume[n].volume_id], local.create_shared_infra == 1 ? [var.sbd_disk_id] : [])
   timeouts {
-    create = "15m"
-    delete = "15m"
+    create = "30m"
+    delete = "30m"
   }
 }


### PR DESCRIPTION
Updates to the IBM Cloud terraform backend has caused more timeout failures which should be avoided.