### PR TITLE
Fix wait_until_ssh_is_ready_xxx failure in libvirt and correct requirements for hana_node

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -4,7 +4,7 @@ hana_node:
   python3-shaptools: 0.3.12+git.1619007514.1951d23
   salt-shaptools: 0.3.11+git.1605797958.ae2f08a
   habootstrap-formula: 0.4.1+git.1611775401.451718e
-  saphanabootstrap-formula: 0.7.1+git.1619008686.8600866
+  saphanabootstrap-formula: 0.8.0+git.1634566980.9dcfa9f
 drbd_node:
   python-shaptools: 0.3.12+git.1619007514.1951d23
   python3-shaptools: 0.3.12+git.1619007514.1951d23

--- a/salt/drbd_node/custom_handlers.sls
+++ b/salt/drbd_node/custom_handlers.sls
@@ -3,5 +3,6 @@
   file.managed:
     - source: salt://drbd/templates/ha_cluster_exporter/notify-split-brain-haclusterexporter-suse-metric.sh
     - mode: "0744"
+    - makedirs: True
     - require:
       - pkg: drbd-formula

--- a/salt/hana_node/init.sls
+++ b/salt/hana_node/init.sls
@@ -6,4 +6,6 @@ include:
   {% endif %}
   - hana_node.mount
   - hana_node.hana_packages
+  {% if grains['cluster_ssh_pub'] is defined and grains['cluster_ssh_key'] is defined %}
   - hana_node.wait
+  {% endif %}

--- a/salt/majority_maker_node/init.sls
+++ b/salt/majority_maker_node/init.sls
@@ -1,3 +1,5 @@
 include:
   - majority_maker_node.packages
+  {% if grains['cluster_ssh_pub'] is defined and grains['cluster_ssh_key'] is defined %}
   - majority_maker_node.wait
+  {% endif %}


### PR DESCRIPTION
Bug fixes for hana_node/drbd_node:

1. Fix wait_until_ssh_is_ready_xxx failure after timeout when no cluster_ssh_pub/cluster_ssh_key defined
Salt state 'wait_until_ssh_is_ready_xxx' in 'wait.sls' is introduced in scale out feature.
It depends on the ssh keys (cluster_ssh_pub/cluster_ssh_key) of clusters and only deployed via 'cluster_node/ha/ssh.sls' (cluster_node/ha/init.sls)

Without the two keys defined in tfvars file, 'wait.sls' will wait until
failure. And wait.sls is not a must in non scale out hana scenario.
Only run the state when ssh key available.

2. drbd_node: allow create parent directory of notify-split-brain-haclusterexporter-suse-metric.sh

3. fix the requirements.yml for saphanabootstrap-formula since the template name is changed.