### PR TITLE
hana scale-out: fix ssh test and make it more resilient

### DIFF
--- a/salt/hana_node/wait.sls
+++ b/salt/hana_node/wait.sls
@@ -5,7 +5,7 @@
 {%- set node = grains['name_prefix'] ~ '%02d' % num %}
 wait_until_ssh_is_ready_{{ node }}:
   cmd.run:
-    - name: until ssh {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
+    - name: until ssh -o ConnectTimeout=3 -o PreferredAuthentications=publickey {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
     - output_loglevel: quiet
     - timeout: 1200
 {%- endfor %}
@@ -14,7 +14,7 @@ wait_until_ssh_is_ready_{{ node }}:
 {%- set node = grains['name_prefix'] ~ 'mm' %}
 wait_until_ssh_is_ready_{{ node }}:
   cmd.run:
-    - name: until ssh {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
+    - name: until ssh -o ConnectTimeout=3 -o PreferredAuthentications=publickey {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
     - output_loglevel: quiet
     - timeout: 1200
 {%- endif %}

--- a/salt/majority_maker_node/init.sls
+++ b/salt/majority_maker_node/init.sls
@@ -1,5 +1,6 @@
 include:
   - majority_maker_node.packages
+  - hana_node.hana_packages
   {% if grains['cluster_ssh_pub'] is defined and grains['cluster_ssh_key'] is defined %}
   - majority_maker_node.wait
   {% endif %}

--- a/salt/majority_maker_node/wait.sls
+++ b/salt/majority_maker_node/wait.sls
@@ -5,7 +5,7 @@
 {%- set node = grains['name_prefix'] ~ '%02d' % num %}
 wait_until_ssh_is_ready_{{ node }}:
   cmd.run:
-    - name: until ssh {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
+    - name: until ssh -o ConnectTimeout=3 -o PreferredAuthentications=publickey {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
     - output_loglevel: quiet
     - timeout: 1200
 {%- endfor %}
@@ -14,7 +14,7 @@ wait_until_ssh_is_ready_{{ node }}:
 {%- set node = grains['name_prefix'] ~ 'mm' %}
 wait_until_ssh_is_ready_{{ node }}:
   cmd.run:
-    - name: until ssh {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
+    - name: until ssh -o ConnectTimeout=3 -o PreferredAuthentications=publickey {{ node }} "rpm -q saphanabootstrap-formula";do sleep 30;done
     - output_loglevel: quiet
     - timeout: 1200
 {%- endif %}


### PR DESCRIPTION
- ssh commands will not hang anymore because of password promt
- make sure `saphanabootstrap-formula` is installed in majority maker