### PR TITLE
Disable nw-pas-route creation if nw is not enabled

### DIFF
--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -40,7 +40,7 @@ resource "aws_route" "nw-ers-route" {
 
 # deploy if PAS on same machine as ASCS
 resource "aws_route" "nw-pas-route" {
-  count                  = var.app_server_count == 0 ? 1 : 0
+  count                  = local.vm_count > 0 && var.app_server_count == 0 ? 1 : 0
   route_table_id         = var.route_table_id
   destination_cidr_block = "${element(var.virtual_host_ips, local.app_start_index)}/32"
   instance_id            = aws_instance.netweaver.0.id

--- a/gcp/modules/netweaver_node/main.tf
+++ b/gcp/modules/netweaver_node/main.tf
@@ -42,7 +42,7 @@ resource "google_compute_route" "nw-ers-route" {
 # deploy if PAS on same machine as ASCS
 resource "google_compute_route" "nw-pas-route" {
   name                   = "${var.common_variables["deployment_name"]}-nw-pas-route-${format("%02d", 1)}"
-  count                  = var.app_server_count == 0 ? 1 : 0
+  count                  = local.vm_count > 0 && var.app_server_count == 0 ? 1 : 0
   dest_range             = "${element(var.virtual_host_ips, local.app_start_index)}/32"
   network                = var.network_name
   next_hop_instance      = google_compute_instance.netweaver.0.name


### PR DESCRIPTION
The deployment in AWS is failing if Netweaver is not enabled:

```
Error: Invalid index

  on modules/netweaver_node/main.tf line 46, in resource "aws_route" "nw-pas-route":
  46:   instance_id            = aws_instance.netweaver.0.id
    |----------------
    | aws_instance.netweaver is empty tuple

The given key does not identify an element in this collection value.
```

This fix basically checks if there is any NW vm before checking the current condition and create the route