### PR TITLE
add minimal NFS server to be used on libvirt/openstack (instead of DRBD) - not for production workloads

### DIFF
--- a/salt/nfs_srv/directories.sls
+++ b/salt/nfs_srv/directories.sls
@@ -1,0 +1,32 @@
+{% set basedir = grains['nfs_mounting_point'] %}
+
+# create directories for HANA scale-out deployment
+{% if grains['hana_scale_out_shared_storage_type'] == 'nfs' %}
+{% set hana_sid = grains['hana_sid'].upper() %}
+{% set hana_instance = '{:0>2}'.format(grains['hana_instance']) %}
+{% set mounts = ["data", "log", "backup", "shared"] %}
+{%- for site in [1,2] %}
+{%- for mount in mounts %}
+dir_{{ hana_sid }}_{{ hana_instance }}_site_{{ site }}_{{ mount }}:
+  file.directory:
+    - name: {{ basedir }}/{{ hana_sid }}/{{ hana_instance }}/site_{{ site }}/{{ mount }}
+    - makedirs: True
+{% endfor %}
+{% endfor %}
+{% endif %}
+
+# create directories for Netweaver deployment
+{% if grains['netweaver_shared_storage_type'] == 'nfs' %}
+{% set netweaver_sid = grains['netweaver_sid'].upper() %}
+{% set netweaver_ascs_instance = '{:0>2}'.format(grains['netweaver_ascs_instance']) %}
+{% set netweaver_ers_instance = '{:0>2}'.format(grains['netweaver_ers_instance']) %}
+{% set netweaver_ascs_dir = 'ASCS' + netweaver_ascs_instance %}
+{% set netweaver_ers_dir = 'ERS' + netweaver_ers_instance %}
+{% set mounts = ["sapmnt", "usrsapsys", netweaver_ascs_dir, netweaver_ers_dir] %}
+{%- for mount in mounts %}
+dir_{{ netweaver_sid }}_{{ mount }}:
+  file.directory:
+    - name: {{ basedir }}/{{ netweaver_sid }}/{{ mount }}
+    - makedirs: True
+{% endfor %}
+{% endif %}

--- a/salt/nfs_srv/init.sls
+++ b/salt/nfs_srv/init.sls
@@ -1,0 +1,5 @@
+include:
+  - nfs_srv.packages
+  - nfs_srv.lvm
+  - nfs_srv.directories
+  - nfs_srv.nfs

--- a/salt/nfs_srv/lvm.sls
+++ b/salt/nfs_srv/lvm.sls
@@ -1,0 +1,71 @@
+# exclude DVD drive and root disk
+{% set pvs = grains['disks']|reject('match', 'sr0')|reject('match', 'sda')|list %}
+{% set fstype = 'xfs' %}
+{% set basedir = grains['nfs_mounting_point'] %}
+
+# Create Physical volumes
+{% for pv in pvs %}
+nfs_lvm_pvcreate_{{ pv }}:
+  lvm.pv_present:
+    - name: /dev/{{ pv }}
+{% endfor %}
+
+# Create Volume group
+nfs_lvm_vgcreate_data:
+  lvm.vg_present:
+    - name: vg_nfs
+    - devices:
+    {% for pv in pvs %}
+      - /dev/{{ pv }}
+    {% endfor %}
+
+# Activate Volume group (may be needed after re-provisioning)
+nfs_lvm_vgactivate_data:
+  cmd.run:
+    - name: vgchange -ay vg_nfs
+    - require:
+      - lvm: nfs_lvm_vgcreate_data
+
+# Create Logical volume
+nfs_lvm_lvcreate_sapdata:
+  lvm.lv_present:
+    - name: lv_sapdata
+    - vgname: vg_nfs
+    - extents: 100%VG
+
+{% for vg in ['nfs'] %}
+
+{% if vg == 'nfs' %}
+  {% set lvs = ['sapdata'] %}
+{% endif %}
+
+{% for lv in lvs %}
+
+# Format lvs
+nfs_format_lv_vg_{{ vg }}_lv_{{ lv }}:
+  cmd.run:
+    - name: |
+        /sbin/mkfs -t {{ fstype }} /dev/vg_{{ vg }}/lv_{{ lv }}
+    - unless: blkid /dev/mapper/vg_{{ vg }}-lv_{{ lv }}
+
+{% endfor %}
+{% endfor %}
+
+# Mount sapdata
+nfs_sapdata_directory_mount:
+  file.directory:
+    - name: {{ basedir }}
+    - user: root
+    - mode: "0755"
+    - makedirs: True
+  mount.mounted:
+    - name: {{ basedir }}
+    - device: /dev/vg_nfs/lv_sapdata
+    - fstype: {{ fstype }}
+    - mkmnt: True
+    - persist: True
+    - opts: defaults,nofail
+    - pass_num: 2
+    - require:
+      - cmd: nfs_format_lv_vg_nfs_lv_sapdata
+

--- a/salt/nfs_srv/nfs.sls
+++ b/salt/nfs_srv/nfs.sls
@@ -1,0 +1,27 @@
+create_nfs_folder:
+  file.directory:
+    - name: {{ grains['nfs_mounting_point'] }}
+    - user: root
+    - mode: "0755"
+    - makedirs: True
+
+
+configure_nfs:
+  nfs_export.present:
+    - name: {{ grains['nfs_mounting_point'] }}
+    - hosts: '*'
+    - options:
+      - rw
+      - no_root_squash
+      - fsid=0
+      - no_subtree_check
+    - require:
+      - create_nfs_folder
+
+nfsserver:
+  service:
+    - running
+    - enable: True
+    - reload: True
+    - watch:
+      - configure_nfs

--- a/salt/nfs_srv/packages.sls
+++ b/salt/nfs_srv/packages.sls
@@ -1,0 +1,20 @@
+xfsprogs_package:
+  pkg.installed:
+    - name: xfsprogs
+    - retry:
+        attempts: 3
+        interval: 15
+
+lvm2_package:
+  pkg.installed:
+    - name: lvm2
+    - retry:
+        attempts: 3
+        interval: 15
+
+nfs_packages:
+  pkg.installed:
+    - name: nfs-kernel-server
+    - retry:
+        attempts: 3
+        interval: 15

--- a/salt/top.sls
+++ b/salt/top.sls
@@ -61,3 +61,8 @@ predeployment:
   'role:bastion':
     - match: grain
     - bastion
+
+# minimal NFS server on libvirt/openstack - should not be used for production
+  'role:nfs_srv':
+    - match: grain
+    - nfs_srv


### PR DESCRIPTION
This is a prerequisite to deploy HANA scale-out on libvirt/openstack. It should not be used for production workloads.