### PR TITLE
set default VIP mechanisms to support latest DRBD, HANA, Netweaver formulas

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -101,7 +101,7 @@ module "common_variables" {
   hana_client_archive_file            = var.hana_client_archive_file
   hana_client_extract_dir             = var.hana_client_extract_dir
   hana_scenario_type                  = var.scenario_type
-  hana_cluster_vip_mechanism          = ""
+  hana_cluster_vip_mechanism          = "route"
   hana_cluster_vip                    = local.hana_cluster_vip
   hana_cluster_vip_secondary          = var.hana_active_active ? local.hana_cluster_vip_secondary : ""
   hana_ha_enabled                     = var.hana_ha_enabled
@@ -132,7 +132,7 @@ module "common_variables" {
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_hana_master_password      = var.hana_master_password
   netweaver_ha_enabled                = var.netweaver_ha_enabled
-  netweaver_cluster_vip_mechanism     = ""
+  netweaver_cluster_vip_mechanism     = "route"
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
   netweaver_shared_storage_type       = var.netweaver_shared_storage_type
@@ -146,7 +146,7 @@ module "common_variables" {
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   drbd_cluster_vip                    = local.drbd_cluster_vip
-  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_vip_mechanism          = "route"
   drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
   drbd_sbd_storage_type               = var.sbd_storage_type
 }

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -101,7 +101,7 @@ module "common_variables" {
   hana_client_archive_file            = var.hana_client_archive_file
   hana_client_extract_dir             = var.hana_client_extract_dir
   hana_scenario_type                  = var.scenario_type
-  hana_cluster_vip_mechanism          = ""
+  hana_cluster_vip_mechanism          = "load-balancer"
   hana_cluster_vip                    = var.hana_ha_enabled ? local.hana_cluster_vip : ""
   hana_cluster_vip_secondary          = var.hana_active_active ? local.hana_cluster_vip_secondary : ""
   hana_ha_enabled                     = var.hana_ha_enabled
@@ -132,7 +132,7 @@ module "common_variables" {
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_hana_master_password      = var.hana_master_password
   netweaver_ha_enabled                = var.netweaver_ha_enabled
-  netweaver_cluster_vip_mechanism     = ""
+  netweaver_cluster_vip_mechanism     = "load-balancer"
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
   netweaver_shared_storage_type       = var.netweaver_shared_storage_type
@@ -146,7 +146,7 @@ module "common_variables" {
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   drbd_cluster_vip                    = local.drbd_cluster_vip
-  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_vip_mechanism          = "load-balancer"
   drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
   drbd_sbd_storage_type               = var.sbd_storage_type
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -87,7 +87,7 @@ module "common_variables" {
   hana_client_archive_file            = var.hana_client_archive_file
   hana_client_extract_dir             = var.hana_client_extract_dir
   hana_scenario_type                  = var.scenario_type
-  hana_cluster_vip_mechanism          = ""
+  hana_cluster_vip_mechanism          = "vip-only"
   hana_cluster_vip                    = local.hana_cluster_vip
   hana_cluster_vip_secondary          = var.hana_active_active ? local.hana_cluster_vip_secondary : ""
   hana_ha_enabled                     = var.hana_ha_enabled
@@ -118,7 +118,7 @@ module "common_variables" {
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_hana_master_password      = var.hana_master_password
   netweaver_ha_enabled                = var.netweaver_ha_enabled
-  netweaver_cluster_vip_mechanism     = ""
+  netweaver_cluster_vip_mechanism     = "vip-only"
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
   netweaver_shared_storage_type       = var.netweaver_shared_storage_type
@@ -132,7 +132,7 @@ module "common_variables" {
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   drbd_cluster_vip                    = local.drbd_cluster_vip
-  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_vip_mechanism          = "vip-only"
   drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
   drbd_sbd_storage_type               = var.sbd_storage_type
 }

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -114,7 +114,7 @@ module "common_variables" {
   hana_client_archive_file            = var.hana_client_archive_file
   hana_client_extract_dir             = var.hana_client_extract_dir
   hana_scenario_type                  = var.scenario_type
-  hana_cluster_vip_mechanism          = ""
+  hana_cluster_vip_mechanism          = "vip-only"
   hana_cluster_vip                    = local.hana_cluster_vip
   hana_cluster_vip_secondary          = var.hana_active_active ? local.hana_cluster_vip_secondary : ""
   hana_ha_enabled                     = var.hana_ha_enabled
@@ -145,7 +145,7 @@ module "common_variables" {
   netweaver_hana_instance_number      = var.hana_instance_number
   netweaver_hana_master_password      = var.hana_master_password
   netweaver_ha_enabled                = var.netweaver_ha_enabled
-  netweaver_cluster_vip_mechanism     = ""
+  netweaver_cluster_vip_mechanism     = "vip-only"
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
   netweaver_shared_storage_type       = var.netweaver_shared_storage_type
@@ -159,7 +159,7 @@ module "common_variables" {
   monitoring_netweaver_targets_ha     = var.netweaver_enabled && var.netweaver_ha_enabled ? [local.netweaver_ips[0], local.netweaver_ips[1]] : []
   monitoring_netweaver_targets_vip    = var.netweaver_enabled ? local.netweaver_virtual_ips : []
   drbd_cluster_vip                    = local.drbd_cluster_vip
-  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_vip_mechanism          = "vip-only"
   drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
   drbd_sbd_storage_type               = var.sbd_storage_type
 }


### PR DESCRIPTION
These formula changes make it mandatory to set a valid `*_vip_mechanism` for each cluster setup.

* https://github.com/SUSE/saphanabootstrap-formula/pull/137
* https://github.com/SUSE/sapnwbootstrap-formula/pull/91
* https://github.com/SUSE/drbd-formula/pull/28

Currently we mostly set `""` which will result in the grains beeing `null` which is not interpretable by the formulas.
