### PR TITLE
master ci: enable salt-lint again (was missing)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -139,6 +139,9 @@ jobs:
           sudo apt-get install -y git python3 python3-pip
           python3 -m pip install salt-lint
 
+      - name: salt-lint
+        run: make test-salt-lint
+
   terraform-format:
     name: 'terraform format'
     runs-on: ubuntu-20.04

--- a/.salt-lint
+++ b/.salt-lint
@@ -1,0 +1,4 @@
+---
+rules:
+  204:
+    ignore: 'salt/shared_storage/nfs.sls'


### PR DESCRIPTION
Somehow `salt-lint` is not executed in the CI.