### PR TITLE
add grain/pillar to let netweaver know about HANA HA/SR

### DIFF
--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -97,6 +97,7 @@ output "configuration" {
       hana_sid              = var.netweaver_hana_sid
       hana_instance_number  = var.netweaver_hana_instance_number
       hana_master_password  = var.netweaver_hana_master_password
+      hana_sr_enabled       = var.hana_ha_enabled
       shared_storage_type   = var.netweaver_shared_storage_type
     }
     monitoring = {
@@ -190,6 +191,7 @@ hana_ip: ${var.netweaver_hana_ip}
 hana_sid: ${var.netweaver_hana_sid}
 hana_instance_number: ${var.netweaver_hana_instance_number}
 hana_master_password: ${var.netweaver_hana_master_password}
+hana_sr_enabled: ${var.hana_ha_enabled}
 EOF
     monitoring_grains_output = <<EOF
 hana_targets: [${join(", ", formatlist("'%s'", var.monitoring_hana_targets))}]

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -77,6 +77,7 @@ netweaver:
     sid: {{ hana_sid_upper }}
     instance: {{ hana_instance_number }}
     password: {{ grains['hana_master_password'] }}
+    sr_enabled: {{ grains['hana_sr_enabled']|default(false) }}
 
   schema:
     {%- if product_id_header in ['S4HANA1809', 'S4HANA1909', 'S4HANA2020', 'S4HANA2021'] %}


### PR DESCRIPTION
This completes the feature of creating a HANA DB backup after the initial "Netweaver / S/4HANA import" is done (if HANA SR is enabled) in https://github.com/SUSE/sapnwbootstrap-formula/pull/95.

It introduces a new pillar switch called `netweaver.hana.ha_enabled` for this.

After the very large initial "Netweaver / S/4HANA import", the 1st backup on the HANA (done by `saphanabootstrap-formula`) differs to much to re-initiate HANA System Replication. This is why this new backup is needed.

Tested and verified on Azure and GCP with S/4HANA 2021.

## helps to fix
https://github.com/SUSE/ha-sap-terraform-deployments/issues/739
https://github.com/SUSE/ha-sap-terraform-deployments/issues/803

## related
https://github.com/SUSE/sapnwbootstrap-formula/pull/95

`salt-shaptools-0.3.14` including these fixes:
https://github.com/SUSE/salt-shaptools/pull/84
https://github.com/SUSE/salt-shaptools/pull/86