### PR TITLE
use `registercloudguest` where available and rework PAYG workaround

### DIFF
--- a/generic_modules/on_destroy/on_destroy.sh
+++ b/generic_modules/on_destroy/on_destroy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 if ! SUSEConnect -s | grep -q "Not Registered"; then
-  sudo /usr/bin/SUSEConnect -d
+  if [ -f /usr/sbin/registercloudguest ]; then
+    /usr/sbin/registercloudguest --clean
+  else
+    /usr/bin/SUSEConnect -d
+  fi
 fi


### PR DESCRIPTION
From https://www.suse.com/c/byos-instances-and-the-suse-public-cloud-update-infrastructure/:
>For BYOS images with a datestamp later than 20220103, spare -chost- images, the cloud-regionsrv-client package will be installed by default to make registration more straight forward. Unlike for on-demand instances the registration is not automatic on instance startup. The reason for this is that your SUSE registration code is required for access to the update infrastructure.

This means, that never public cloud images in azure/aws/gcp should use `registercloudguest` to connect to the update servers.

This PR introduces:
- use `registercloudguest` if it available (baked into the image)
- update old workaround that is broken with new `registercloudguest` releases
  - fixes #812 

## tested with the following images

### azure
```
os_image = "SUSE:sles-sap-15-sp3-byos:gen2:2021.12.19"
os_image = "SUSE:sles-sap-15-sp3-byos:gen2:2022.01.27"
os_image = "SUSE:sles-sap-12-sp5-byos:gen2:2021.12.09"
os_image = "SUSE:sles-sap-12-sp5-byos:gen2:2022.01.27"

os_image = "SUSE:sles-sap-15-sp3:gen2:2021.12.19"
os_image = "SUSE:sles-sap-15-sp3:gen2:2022.01.26"
os_image = "SUSE:sles-sap-12-sp5:gen2:2021.12.15"
os_image = "SUSE:sles-sap-12-sp5:gen2:2022.01.26"
```

### GCP
```
os_image = "suse-byos-cloud/sles-15-sp3-sap-byos-v20211113"
os_image = "suse-byos-cloud/sles-15-sp3-sap-byos-v20220126"
os_image = "suse-byos-cloud/sles-15-sp2-sap-byos-v20220126"
os_image = "suse-byos-cloud/sles-12-sp5-sap-byos-v20220126"

os_image = "suse-sap-cloud/sles-15-sp3-sap-v20211113"
os_image = "suse-sap-cloud/sles-15-sp3-sap-v20220126"
os_image = "suse-sap-cloud/sles-15-sp2-sap-v20220126"
os_image = "suse-sap-cloud/sles-12-sp5-sap-v20220126"
```

PR for master is #816 