### PR TITLE
master: use `registercloudguest` where available and rework PAYG workaround

### DIFF
--- a/generic_modules/on_destroy/on_destroy.sh
+++ b/generic_modules/on_destroy/on_destroy.sh
@@ -1,5 +1,9 @@
 #!/bin/bash
 
 if ! SUSEConnect -s | grep -q "Not Registered"; then
-  sudo /usr/bin/SUSEConnect -d
+  if [ -f /usr/sbin/registercloudguest ]; then
+    /usr/sbin/registercloudguest --clean
+  else
+    /usr/bin/SUSEConnect -d
+  fi
 fi

--- a/salt/os_setup/registration.sls
+++ b/salt/os_setup/registration.sls
@@ -3,7 +3,27 @@
 {% if grains['reg_code'] and (not grains.get('qa_mode') or '_node' not in grains.get('role')) %}
 {% set reg_code = grains['reg_code'] %}
 {% set arch = grains['osarch'] %}
-register_system:
+
+# use registercloudguest for BYOS cloud images where available (images later than 20220103)
+{% if salt['file.file_exists']('/usr/sbin/registercloudguest') %}
+
+registercloudguest_registration:
+  cmd.run:
+    - name: |
+        /usr/sbin/registercloudguest --clean
+        /usr/sbin/registercloudguest --force-new -r $reg_code {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }}
+        # a second register prevents "permission denied to repo" errors on some older images
+        /usr/sbin/registercloudguest --force-new -r $reg_code {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }}
+    - env:
+        - reg_code: {{ reg_code }}
+    - retry:
+        attempts: 3
+        interval: 15
+
+# use SUSEConnect in case registercloudguest is not available, e.g. not public cloud or old images
+{% else %}
+
+SUSEConnect_registration:
   cmd.run:
     - name: /usr/bin/SUSEConnect -r $reg_code {{ ("-e " ~ grains['reg_email']) if grains['reg_email'] else "" }}
     - env:
@@ -59,17 +79,17 @@ default_sle_module_public_cloud_registration:
 
 {% endif %}
 
+# on-demand/PAYG image specific
+# PAYG images will use registercloudguest as part of their boot process (regardless of this state)
+{% else %}
+
 # Workaround for the 'Script died unexpectedly' error bsc#1158664
 # If it is a PAYG image, it will force a new registration before refreshing.
 # Also the pure refresh will not be executed as salt will still report failure.
 # See: https://github.com/saltstack/salt/issues/16291
 workaround_payg_cleanup:
   cmd.run:
-    - name: |
-        rm -f /etc/SUSEConnect &&
-        rm -f /etc/zypp/{repos,services,credentials}.d/* &&
-        rm -f /usr/lib/zypp/plugins/services/* &&
-        sed -i '/^# Added by SMT reg/,+1d' /etc/hosts
+    - name: /usr/sbin/registercloudguest --clean
     - onlyif: 'test -e /usr/sbin/registercloudguest'
 
 workaround_payg_new_register:
@@ -79,5 +99,9 @@ workaround_payg_new_register:
         attempts: 3
         interval: 15
     - onlyif: 'test -e /usr/sbin/registercloudguest'
+    - require:
+      - workaround_payg_cleanup
+
+{% endif %}
 
 {% endif %}


### PR DESCRIPTION
From https://www.suse.com/c/byos-instances-and-the-suse-public-cloud-update-infrastructure/:
>For BYOS images with a datestamp later than 20220103, spare -chost- images, the cloud-regionsrv-client package will be installed by default to make registration more straight forward. Unlike for on-demand instances the registration is not automatic on instance startup. The reason for this is that your SUSE registration code is required for access to the update infrastructure.

This means, that never public cloud images in azure/aws/gcp should use `registercloudguest` to connect to the update servers.

This PR introduces:
- use `registercloudguest` if it available (baked into the image)
- update old workaround that is broken with new `registercloudguest` releases
  - fixes #812 

## tested with the following images

### azure
```
os_image = "SUSE:sles-sap-15-sp3-byos:gen2:2021.12.19"
os_image = "SUSE:sles-sap-15-sp3-byos:gen2:2022.01.27"
os_image = "SUSE:sles-sap-12-sp5-byos:gen2:2021.12.09"
os_image = "SUSE:sles-sap-12-sp5-byos:gen2:2022.01.27"

os_image = "SUSE:sles-sap-15-sp3:gen2:2021.12.19"
os_image = "SUSE:sles-sap-15-sp3:gen2:2022.01.26"
os_image = "SUSE:sles-sap-12-sp5:gen2:2021.12.15"
os_image = "SUSE:sles-sap-12-sp5:gen2:2022.01.26"
```

### GCP
```
os_image = "suse-byos-cloud/sles-15-sp3-sap-byos-v20211113"
os_image = "suse-byos-cloud/sles-15-sp3-sap-byos-v20220126"
os_image = "suse-byos-cloud/sles-15-sp2-sap-byos-v20220126"
os_image = "suse-byos-cloud/sles-12-sp5-sap-byos-v20220126"

os_image = "suse-sap-cloud/sles-15-sp3-sap-v20211113"
os_image = "suse-sap-cloud/sles-15-sp3-sap-v20220126"
os_image = "suse-sap-cloud/sles-15-sp2-sap-v20220126"
os_image = "suse-sap-cloud/sles-12-sp5-sap-v20220126"
```

PR for develop is #815 