### PR TITLE
aws: master: change instances types from xen to nitro (KVM)

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -128,6 +128,10 @@ module "common_variables" {
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
+  drbd_cluster_vip                    = local.drbd_cluster_vip
+  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
+  drbd_sbd_storage_type               = var.sbd_storage_type
 }
 
 module "drbd_node" {
@@ -148,8 +152,6 @@ module "drbd_node" {
   aws_access_key_id     = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
   host_ips              = local.drbd_ips
-  fencing_mechanism     = var.drbd_cluster_fencing_mechanism
-  drbd_cluster_vip      = local.drbd_cluster_vip
   drbd_data_disk_size   = var.drbd_data_disk_size
   drbd_data_disk_type   = var.drbd_data_disk_type
   cluster_ssh_pub       = var.cluster_ssh_pub

--- a/aws/modules/drbd_node/main.tf
+++ b/aws/modules/drbd_node/main.tf
@@ -63,7 +63,7 @@ resource "aws_instance" "drbd" {
   ebs_block_device {
     volume_type = var.drbd_data_disk_type
     volume_size = var.drbd_data_disk_size
-    device_name = "/dev/xvdd"
+    device_name = "/dev/sdb"
   }
 
   volume_tags = {

--- a/aws/modules/drbd_node/main.tf
+++ b/aws/modules/drbd_node/main.tf
@@ -21,7 +21,7 @@ resource "aws_route_table_association" "drbd-subnet-route-association" {
 resource "aws_route" "drbd-cluster-vip" {
   count                  = var.drbd_count > 0 ? 1 : 0
   route_table_id         = var.route_table_id
-  destination_cidr_block = "${var.drbd_cluster_vip}/32"
+  destination_cidr_block = "${var.common_variables["drbd"]["cluster_vip"]}/32"
   instance_id            = aws_instance.drbd.0.id
 }
 

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -21,6 +21,7 @@ resource "null_resource" "drbd_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
+${var.common_variables["drbd_grains_output"]}
 region: ${var.aws_region}
 name_prefix: ${var.name}
 aws_cluster_profile: Cluster
@@ -32,9 +33,7 @@ hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-fencing_mechanism: ${var.fencing_mechanism}
 drbd_disk_device: /dev/xvdd
-drbd_cluster_vip: ${var.drbd_cluster_vip}
 route_table: ${var.route_table_id}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -33,7 +33,7 @@ hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-drbd_disk_device: /dev/xvdd
+drbd_disk_device: /dev/nvme1n1
 route_table: ${var.route_table_id}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}

--- a/aws/modules/drbd_node/variables.tf
+++ b/aws/modules/drbd_node/variables.tf
@@ -73,16 +73,6 @@ variable "host_ips" {
   type        = list(string)
 }
 
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd, native"
-  type        = string
-}
-
-variable "drbd_cluster_vip" {
-  description = "IP address used to configure the drbd cluster floating IP. It must be in other subnet than the machines!"
-  type        = string
-}
-
 variable "drbd_data_disk_size" {
   description = "Disk size of the disks used to store drbd content"
   type        = string

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -1,7 +1,5 @@
-
 locals {
-  hana_disk_device = "/dev/xvdd"
-  create_ha_infra  = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  create_ha_infra = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
 }
 
 # Network resources: subnets, routes, etc

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -74,7 +74,7 @@ resource "aws_instance" "clusternodes" {
   ebs_block_device {
     volume_type = var.hana_data_disk_type
     volume_size = var.hana_data_disk_size
-    device_name = local.hana_disk_device
+    device_name = "/dev/sdb"
   }
 
   volume_tags = {

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -35,7 +35,7 @@ host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 network_domain: "tf.local"
 sbd_lun_index: 0
 iscsi_srv_ip: ${var.iscsi_srv_ip}
-hana_disk_device: ${local.hana_disk_device}
+hana_disk_device: /dev/nvme1n1
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 EOF

--- a/aws/modules/iscsi_server/main.tf
+++ b/aws/modules/iscsi_server/main.tf
@@ -1,9 +1,5 @@
 # iscsi server resources
 
-locals {
-  iscsi_device_name = "/dev/xvdd"
-}
-
 module "get_os_image" {
   source   = "../../modules/get_os_image"
   os_image = var.os_image
@@ -29,7 +25,7 @@ resource "aws_instance" "iscsisrv" {
   ebs_block_device {
     volume_type = "gp2"
     volume_size = var.iscsi_disk_size
-    device_name = local.iscsi_device_name
+    device_name = "/dev/sdb"
   }
 
   volume_tags = {

--- a/aws/modules/iscsi_server/salt_provisioner.tf
+++ b/aws/modules/iscsi_server/salt_provisioner.tf
@@ -18,7 +18,7 @@ role: iscsi_srv
 ${var.common_variables["grains_output"]}
 region: ${var.aws_region}
 iscsi_srv_ip: ${element(aws_instance.iscsisrv.*.private_ip, count.index)}
-iscsidev: ${local.iscsi_device_name}
+iscsidev: /dev/nvme1n1
 ${yamlencode(
     { partitions : { for index in range(var.lun_count) :
       tonumber(index + 1) => {

--- a/aws/modules/monitoring/main.tf
+++ b/aws/modules/monitoring/main.tf
@@ -23,7 +23,7 @@ resource "aws_instance" "monitoring" {
   ebs_block_device {
     volume_type = "gp2"
     volume_size = "10"
-    device_name = "/dev/xvdd"
+    device_name = "/dev/sdb"
   }
 
   volume_tags = {

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -98,7 +98,7 @@ resource "aws_instance" "netweaver" {
   ebs_block_device {
     volume_type = "gp2"
     volume_size = "60"
-    device_name = "/dev/xvdd"
+    device_name = "/dev/sdb"
   }
 
   volume_tags = {

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -40,7 +40,7 @@ cluster_ssh_key: ${var.cluster_ssh_key}
 sbd_lun_index: 1
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 app_server_count: ${var.app_server_count}
-netweaver_inst_disk_device: /dev/xvdd
+netweaver_inst_disk_device: /dev/nvme1n1
 s3_bucket: ${var.s3_bucket}
   EOF
     destination = "/tmp/grains"

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -200,9 +200,6 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #hana_client_archive_file = "IMDB_CLIENT20_003_144-80002090.SAR"
 #hana_client_extract_dir = "/sapmedia_extract/HANA_CLIENT"
 
-# Device used by node where HANA will be installed
-#hana_disk_device = "/dev/xvdd"
-
 # IP address used to configure the hana cluster floating IP. It must belong to the same subnet than the machines!
 #hana_cluster_vip = "192.168.1.10"
 

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -128,7 +128,9 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 #########################
 
 # Instance type to use for the hana cluster nodes
-#hana_instancetype = "r3.8xlarge"
+# SAP certified instances types can be found at https://aws.amazon.com/sap/instance-types/
+# and example sizing at https://aws.amazon.com/sap/solutions/s4hana/ .
+#hana_instancetype = "r6i.xlarge"
 
 # Disk type for HANA
 #hana_data_disk_type = "gp2"
@@ -275,7 +277,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # Enable drbd cluster
 #drbd_enabled = false
 
-#drbd_instancetype = "t2.micro"
+#drbd_instancetype = "t3.medium"
 
 # DRBD machines image. By default, PAYG image is used. The usage is the same as the HANA images
 #drbd_os_image = "suse-sles-sap-15-sp1-byos"
@@ -308,7 +310,10 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 # Set to 2 or higher to deploy additional AAS instances in new machines
 #netweaver_app_server_count = 2
 
-#netweaver_instancetype = "r3.8xlarge"
+# Instance type to use for the Netweaver nodes
+# SAP certified instances types can be found at https://aws.amazon.com/sap/instance-types/
+# and example sizing at https://aws.amazon.com/sap/solutions/s4hana/ .
+#netweaver_instancetype = "r5.large"
 
 # Netweaver machines image. By default, PAYG image is used. The usage is the same as the HANA images
 #netweaver_os_image = "suse-sles-sap-15-sp1-byos"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -696,7 +696,7 @@ variable "netweaver_cluster_fencing_mechanism" {
     condition = (
       can(regex("^(native|sbd)$", var.netweaver_cluster_fencing_mechanism))
     )
-    error_message = "Invalid Netweaver cluster fending mechanism. Options: native|sbd ."
+    error_message = "Invalid Netweaver cluster fencing mechanism. Options: native|sbd ."
   }
 }
 

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -208,7 +208,7 @@ variable "hana_os_owner" {
 variable "hana_instancetype" {
   description = "The instance type of the hana nodes"
   type        = string
-  default     = "r3.8xlarge"
+  default     = "r6i.xlarge"
 }
 
 variable "hana_subnet_address_range" {
@@ -423,7 +423,7 @@ variable "drbd_os_owner" {
 variable "drbd_instancetype" {
   description = "The instance type of the drbd node"
   type        = string
-  default     = "t2.large"
+  default     = "t3.medium"
 }
 
 variable "drbd_cluster_vip" {
@@ -520,7 +520,7 @@ variable "iscsi_os_owner" {
 variable "iscsi_instancetype" {
   description = "The instance type of the iscsi server node."
   type        = string
-  default     = "t2.large"
+  default     = "t3.micro"
 }
 
 variable "iscsi_srv_ip" {
@@ -611,9 +611,9 @@ variable "netweaver_os_owner" {
 }
 
 variable "netweaver_instancetype" {
-  description = "Instance type for the Netweaver machines. Default to r3.8xlarge"
+  description = "Instance type for the Netweaver machines"
   type        = string
-  default     = "r3.8xlarge"
+  default     = "r5.large"
 }
 
 variable "netweaver_s3_bucket" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -126,6 +126,10 @@ module "common_variables" {
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
+  drbd_cluster_vip                    = local.drbd_cluster_vip
+  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
+  drbd_sbd_storage_type               = var.sbd_storage_type
 }
 
 module "drbd_node" {
@@ -143,12 +147,9 @@ module "drbd_node" {
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
   host_ips            = local.drbd_ips
-  fencing_mechanism   = var.drbd_cluster_fencing_mechanism
-  sbd_storage_type    = var.sbd_storage_type
   iscsi_srv_ip        = join("", module.iscsi_server.iscsisrv_ip)
   nfs_mounting_point  = var.drbd_nfs_mounting_point
   nfs_export_name     = var.netweaver_sid
-  drbd_cluster_vip    = local.drbd_cluster_vip
 }
 
 module "netweaver_node" {

--- a/azure/modules/drbd_node/main.tf
+++ b/azure/modules/drbd_node/main.tf
@@ -32,7 +32,7 @@ resource "azurerm_lb" "drbd-load-balancer" {
     name                          = "lbfe-drbd"
     subnet_id                     = var.network_subnet_id
     private_ip_address_allocation = "static"
-    private_ip_address            = var.drbd_cluster_vip
+    private_ip_address            = var.common_variables["drbd"]["cluster_vip"]
   }
 
   tags = {

--- a/azure/modules/drbd_node/salt_provisioner.tf
+++ b/azure/modules/drbd_node/salt_provisioner.tf
@@ -20,6 +20,7 @@ resource "null_resource" "drbd_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
+${var.common_variables["drbd_grains_output"]}
 name_prefix: vm${var.name}
 hostname: vm${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
@@ -28,9 +29,6 @@ host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 drbd_disk_device: /dev/disk/azure/scsi1/lun0
-drbd_cluster_vip: ${var.drbd_cluster_vip}
-fencing_mechanism: ${var.fencing_mechanism}
-sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 nfs_mounting_point: ${var.nfs_mounting_point}

--- a/azure/modules/drbd_node/variables.tf
+++ b/azure/modules/drbd_node/variables.tf
@@ -62,17 +62,6 @@ variable "network_domain" {
   default = "tf.local"
 }
 
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi"
-  type        = string
-  default     = "iscsi"
-}
-
 variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string
@@ -85,11 +74,6 @@ variable "cluster_ssh_pub" {
 
 variable "cluster_ssh_key" {
   description = "path for the private key needed by the cluster"
-  type        = string
-}
-
-variable "drbd_cluster_vip" {
-  description = "Virtual ip for the drbd cluster"
   type        = string
 }
 

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -138,6 +138,10 @@ module "common_variables" {
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
+  drbd_cluster_vip                    = local.drbd_cluster_vip
+  drbd_cluster_vip_mechanism          = var.drbd_cluster_vip_mechanism
+  drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
+  drbd_sbd_storage_type               = var.sbd_storage_type
 }
 
 module "drbd_node" {
@@ -152,12 +156,9 @@ module "drbd_node" {
   os_image             = local.drbd_os_image
   drbd_data_disk_size  = var.drbd_data_disk_size
   drbd_data_disk_type  = var.drbd_data_disk_type
-  drbd_cluster_vip     = local.drbd_cluster_vip
   gcp_credentials_file = var.gcp_credentials_file
   network_domain       = "tf.local"
   host_ips             = local.drbd_ips
-  fencing_mechanism    = var.drbd_cluster_fencing_mechanism
-  sbd_storage_type     = var.sbd_storage_type
   iscsi_srv_ip         = module.iscsi_server.iscsisrv_ip
   cluster_ssh_pub      = var.cluster_ssh_pub
   cluster_ssh_key      = var.cluster_ssh_key

--- a/gcp/modules/drbd_node/main.tf
+++ b/gcp/modules/drbd_node/main.tf
@@ -18,7 +18,7 @@ resource "google_compute_disk" "data" {
 resource "google_compute_route" "drbd-route" {
   name                   = "${var.common_variables["deployment_name"]}-drbd-route"
   count                  = var.drbd_count > 0 ? 1 : 0
-  dest_range             = "${var.drbd_cluster_vip}/32"
+  dest_range             = "${var.common_variables["drbd"]["cluster_vip_mechanism"]}/32"
   network                = var.network_name
   next_hop_instance      = google_compute_instance.drbd.0.name
   next_hop_instance_zone = element(var.compute_zones, 0)

--- a/gcp/modules/drbd_node/salt_provisioner.tf
+++ b/gcp/modules/drbd_node/salt_provisioner.tf
@@ -20,6 +20,7 @@ resource "null_resource" "drbd_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
+${var.common_variables["drbd_grains_output"]}
 name_prefix: ${var.common_variables["deployment_name"]}-drbd
 hostname: ${var.common_variables["deployment_name"]}-drbd0${count.index + 1}
 network_domain: ${var.network_domain}
@@ -29,15 +30,12 @@ cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
 drbd_disk_device: ${format("%s%s", "/dev/disk/by-id/google-", element(google_compute_instance.drbd.*.attached_disk.0.device_name, count.index))}
 drbd_disk_device_list: [${join(", ", formatlist("'/dev/disk/by-id/google-%s'", google_compute_instance.drbd.*.attached_disk.0.device_name))}]
-drbd_cluster_vip: ${var.drbd_cluster_vip}
-fencing_mechanism: ${var.fencing_mechanism}
-sbd_storage_type: ${var.sbd_storage_type}
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 nfs_mounting_point: ${var.nfs_mounting_point}
 nfs_export_name: ${var.nfs_export_name}
 vpc_network_name: ${var.network_name}
-route_name: ${google_compute_route.drbd-route[0].name}
+route_name: ${join(",", google_compute_route.drbd-route.*.name)}
 partitions:
   1:
     start: 0%

--- a/gcp/modules/drbd_node/variables.tf
+++ b/gcp/modules/drbd_node/variables.tf
@@ -51,11 +51,6 @@ variable "drbd_data_disk_type" {
   default     = "pd-standard"
 }
 
-variable "drbd_cluster_vip" {
-  description = "IP address used to configure the drbd cluster floating IP. It must be in other subnet than the machines!"
-  type        = string
-}
-
 variable "gcp_credentials_file" {
   description = "Path to your local gcp credentials file"
   type        = string
@@ -69,17 +64,6 @@ variable "network_domain" {
 variable "host_ips" {
   description = "ip addresses to set to the nodes"
   type        = list(string)
-}
-
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd, native"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi"
-  type        = string
-  default     = "iscsi"
 }
 
 variable "iscsi_srv_ip" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -558,6 +558,18 @@ variable "drbd_cluster_fencing_mechanism" {
   }
 }
 
+variable "drbd_cluster_vip_mechanism" {
+  description = "Mechanism used to manage the virtual IP address in the drbd cluster. Options: load-balancer, route"
+  type        = string
+  default     = "load-balancer"
+  validation {
+    condition = (
+      can(regex("^(load-balancer|route)$", var.drbd_cluster_vip_mechanism))
+    )
+    error_message = "Invalid DRBD cluster vip mechanism. Options: load-balancer|route ."
+  }
+}
+
 variable "drbd_nfs_mounting_point" {
   description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
   type        = string

--- a/generic_modules/common_variables/drbd_variables.tf
+++ b/generic_modules/common_variables/drbd_variables.tf
@@ -1,0 +1,19 @@
+variable "drbd_cluster_vip" {
+  description = "IP address used to configure the drbd cluster floating IP."
+  type        = string
+}
+
+variable "drbd_cluster_vip_mechanism" {
+  description = "Mechanism used to manage the virtual IP address in the drbd cluster."
+  type        = string
+}
+
+variable "drbd_cluster_fencing_mechanism" {
+  description = "Select the DRBD cluster fencing mechanism. Options: sbd"
+  type        = string
+}
+
+variable "drbd_sbd_storage_type" {
+  description = "Choose the SBD storage type. Options: iscsi, shared-disk(this option available in Libvirt only)"
+  type        = string
+}

--- a/generic_modules/common_variables/outputs.tf
+++ b/generic_modules/common_variables/outputs.tf
@@ -91,7 +91,13 @@ output "configuration" {
       hana_instance_number = var.netweaver_hana_instance_number
       hana_master_password = var.netweaver_hana_master_password
     }
-    grains_output           = <<EOF
+    drbd = {
+      cluster_vip           = var.drbd_cluster_vip
+      cluster_vip_mechanism = var.drbd_cluster_vip_mechanism
+      fencing_mechanism     = var.drbd_cluster_fencing_mechanism
+      sbd_storage_type      = var.drbd_sbd_storage_type
+    }
+    grains_output            = <<EOF
 provider: ${var.provider_type}
 reg_code: ${var.reg_code}
 reg_email: ${var.reg_email}
@@ -158,6 +164,12 @@ hana_ip: ${var.netweaver_hana_ip}
 hana_sid: ${var.netweaver_hana_sid}
 hana_instance_number: ${var.netweaver_hana_instance_number}
 hana_master_password: ${var.netweaver_hana_master_password}
+EOF
+    drbd_grains_output       = <<EOF
+drbd_cluster_vip: ${var.drbd_cluster_vip}
+drbd_cluster_vip_mechanism: ${var.drbd_cluster_vip_mechanism}
+fencing_mechanism: ${var.drbd_cluster_fencing_mechanism}
+sbd_storage_type: ${var.drbd_sbd_storage_type}
 EOF
   }
 }

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -114,6 +114,10 @@ module "common_variables" {
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
+  drbd_cluster_vip                    = local.drbd_cluster_vip
+  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
+  drbd_sbd_storage_type               = var.sbd_storage_type
 }
 
 module "iscsi_server" {
@@ -163,10 +167,7 @@ module "drbd_node" {
   memory                = var.drbd_node_memory
   bridge                = "br0"
   host_ips              = local.drbd_ips
-  drbd_cluster_vip      = local.drbd_cluster_vip
   drbd_disk_size        = var.drbd_disk_size
-  fencing_mechanism     = var.drbd_cluster_fencing_mechanism
-  sbd_storage_type      = var.sbd_storage_type
   sbd_disk_id           = module.drbd_sbd_disk.id
   iscsi_srv_ip          = module.iscsi_server.output_data.private_addresses.0
   isolated_network_id   = local.internal_network_id

--- a/libvirt/modules/drbd_node/main.tf
+++ b/libvirt/modules/drbd_node/main.tf
@@ -49,9 +49,9 @@ resource "libvirt_domain" "drbd_domain" {
       [
         {
           // we set null but it will never reached because the slice with 0 cut it off
-          "volume_id" = var.sbd_storage_type == "shared-disk" ? var.sbd_disk_id : "null"
+          "volume_id" = var.common_variables["drbd"]["sbd_storage_type"] == "shared-disk" ? var.sbd_disk_id : "null"
         },
-    ], 0, var.fencing_mechanism == "sbd" && var.sbd_storage_type == "shared-disk" ? 1 : 0, )
+    ], 0, var.common_variables["drbd"]["fencing_mechanism"] == "sbd" && var.common_variables["drbd"]["sbd_storage_type"] == "shared-disk" ? 1 : 0, )
     content {
       volume_id = disk.value.volume_id
     }

--- a/libvirt/modules/drbd_node/salt_provisioner.tf
+++ b/libvirt/modules/drbd_node/salt_provisioner.tf
@@ -18,17 +18,15 @@ resource "null_resource" "drbd_node_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
+${var.common_variables["drbd_grains_output"]}
 name_prefix: ${var.name}
 hostname: ${var.name}0${count.index + 1}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
-drbd_cluster_vip: ${var.drbd_cluster_vip}
 drbd_disk_device: /dev/vdb
-fencing_mechanism: ${var.fencing_mechanism}
-sbd_storage_type: ${var.sbd_storage_type}
-sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/vdc" : ""}"
+sbd_disk_device: "${var.common_variables["drbd"]["sbd_storage_type"] == "shared-disk" ? "/dev/vdc" : ""}"
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 nfs_mounting_point: ${var.nfs_mounting_point}

--- a/libvirt/modules/drbd_node/variables.tf
+++ b/libvirt/modules/drbd_node/variables.tf
@@ -32,11 +32,6 @@ variable "host_ips" {
   type        = list(string)
 }
 
-variable "drbd_cluster_vip" {
-  description = "IP address used to configure the drbd cluster floating IP. It must be in other subnet than the machines!"
-  type        = string
-}
-
 variable "nfs_mounting_point" {
   description = "Mounting point of the NFS share created in to of DRBD (`/mnt` must not be used in Azure)"
   type        = string
@@ -45,17 +40,6 @@ variable "nfs_mounting_point" {
 variable "nfs_export_name" {
   description = "Name of the created export in the NFS service. Usually, the `sid` of the SAP instances is used"
   type        = string
-}
-
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi, shared-disk"
-  type        = string
-  default     = "shared-disk"
 }
 
 variable "sbd_disk_id" {

--- a/libvirt/modules/netweaver_node/variables.tf
+++ b/libvirt/modules/netweaver_node/variables.tf
@@ -32,12 +32,6 @@ variable "virtual_host_ips" {
   type        = list(string)
 }
 
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi, shared-disk"
-  type        = string
-  default     = "shared-disk"
-}
-
 variable "shared_disk_id" {
   description = "Disk used by SBD and, ASCS/ERS"
   type        = string

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -163,6 +163,10 @@ module "common_variables" {
   netweaver_ha_enabled                = var.netweaver_ha_enabled
   netweaver_cluster_fencing_mechanism = var.netweaver_cluster_fencing_mechanism
   netweaver_sbd_storage_type          = var.sbd_storage_type
+  drbd_cluster_vip                    = local.drbd_cluster_vip
+  drbd_cluster_vip_mechanism          = ""
+  drbd_cluster_fencing_mechanism      = var.drbd_cluster_fencing_mechanism
+  drbd_sbd_storage_type               = var.sbd_storage_type
 }
 
 module "drbd_node" {
@@ -181,12 +185,9 @@ module "drbd_node" {
   firewall_internal   = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image            = local.drbd_os_image
   host_ips            = local.drbd_ips
-  fencing_mechanism   = var.drbd_cluster_fencing_mechanism
-  sbd_storage_type    = var.sbd_storage_type
   iscsi_srv_ip        = module.iscsi_server.iscsisrv_ip
   drbd_data_disk_type = var.drbd_data_disk_type
   drbd_data_disk_size = var.drbd_data_disk_size
-  drbd_cluster_vip    = local.drbd_cluster_vip
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
   nfs_mounting_point  = var.drbd_nfs_mounting_point
@@ -214,8 +215,6 @@ module "netweaver_node" {
   os_image                  = local.netweaver_os_image
   network_domain            = "tf.local"
   iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
-  fencing_mechanism         = var.hana_cluster_fencing_mechanism
-  sbd_storage_type          = var.sbd_storage_type
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -243,8 +242,6 @@ module "hana_node" {
   firewall_internal          = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                   = local.hana_os_image
   host_ips                   = local.hana_ips
-  fencing_mechanism          = var.hana_cluster_fencing_mechanism
-  sbd_storage_type           = var.sbd_storage_type
   hana_cluster_vip           = local.hana_cluster_vip
   hana_cluster_vip_secondary = local.hana_cluster_vip_secondary
   iscsi_srv_ip               = module.iscsi_server.iscsisrv_ip

--- a/openstack/modules/drbd_node/main.tf
+++ b/openstack/modules/drbd_node/main.tf
@@ -33,7 +33,7 @@ resource "openstack_networking_port_v2" "drbd" {
     ip_address = var.host_ips[count.index]
   }
   allowed_address_pairs {
-    ip_address = var.drbd_cluster_vip
+    ip_address = var.common_variables["drbd"]["cluster_vip"]
   }
   security_group_ids = [var.firewall_internal]
 }

--- a/openstack/modules/drbd_node/salt_provisioner.tf
+++ b/openstack/modules/drbd_node/salt_provisioner.tf
@@ -48,6 +48,7 @@ resource "null_resource" "drbd_node_provisioner" {
     content     = <<EOF
 role: drbd_node
 ${var.common_variables["grains_output"]}
+${var.common_variables["drbd_grains_output"]}
 name_prefix: ${var.common_variables["deployment_name"]}-drbd
 hostname: ${var.common_variables["deployment_name"]}-drbd0${count.index + 1}
 network_domain: ${var.network_domain}
@@ -55,11 +56,8 @@ host_ips: [${join(", ", formatlist("'%s'", var.host_ips))}]
 host_ip: ${element(var.host_ips, count.index)}
 cluster_ssh_pub:  ${var.cluster_ssh_pub}
 cluster_ssh_key: ${var.cluster_ssh_key}
-drbd_cluster_vip: ${var.drbd_cluster_vip}
 drbd_disk_device: /dev/sdb
-fencing_mechanism: ${var.fencing_mechanism}
-sbd_storage_type: ${var.sbd_storage_type}
-sbd_disk_device: "${var.sbd_storage_type == "shared-disk" ? "/dev/sdc" : ""}"
+sbd_disk_device: "${var.common_variables["drbd"]["sbd_storage_type"] == "shared-disk" ? "/dev/sdc" : ""}"
 sbd_lun_index: 2
 iscsi_srv_ip: ${var.iscsi_srv_ip}
 nfs_mounting_point: ${var.nfs_mounting_point}

--- a/openstack/modules/drbd_node/variables.tf
+++ b/openstack/modules/drbd_node/variables.tf
@@ -68,17 +68,6 @@ variable "network_domain" {
   default     = "tf.local"
 }
 
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi"
-  type        = string
-  default     = "iscsi"
-}
-
 variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string
@@ -109,11 +98,6 @@ variable "drbd_data_disk_size" {
   description = "Disk size of the disks used to store drbd database content"
   type        = string
   default     = "50"
-}
-
-variable "drbd_cluster_vip" {
-  description = "IP address used to configure the drbd cluster floating IP. It must be in other subnet than the machines!"
-  type        = string
 }
 
 variable "on_destroy_dependencies" {

--- a/openstack/modules/hana_node/variables.tf
+++ b/openstack/modules/hana_node/variables.tf
@@ -68,17 +68,6 @@ variable "network_domain" {
   default     = "tf.local"
 }
 
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi"
-  type        = string
-  default     = "iscsi"
-}
-
 variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string

--- a/openstack/modules/iscsi_server/variables.tf
+++ b/openstack/modules/iscsi_server/variables.tf
@@ -68,32 +68,10 @@ variable "network_domain" {
   default     = "tf.local"
 }
 
-# variable "fencing_mechanism" {
-#   description = "Choose the fencing mechanism for the cluster. Options: sbd"
-#   type        = string
-# }
-
-# variable "sbd_storage_type" {
-#   description = "Choose the SBD storage type. Options: iscsi"
-#   type        = string
-#   default     = "iscsi"
-# }
-
 variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string
 }
-
-# variable "cluster_ssh_pub" {
-#   description = "path for the public key needed by the cluster"
-#   type        = string
-# }
-
-# variable "cluster_ssh_key" {
-#   description = "path for the private key needed by the cluster"
-#   type        = string
-# }
-
 
 variable "iscsi_count" {
   type        = number

--- a/openstack/modules/monitoring/variables.tf
+++ b/openstack/modules/monitoring/variables.tf
@@ -68,32 +68,6 @@ variable "network_domain" {
   default = "tf.local"
 }
 
-# variable "fencing_mechanism" {
-#   description = "Choose the fencing mechanism for the cluster. Options: sbd"
-#   type        = string
-# }
-
-# variable "sbd_storage_type" {
-#   description = "Choose the SBD storage type. Options: iscsi"
-#   type        = string
-#   default     = "iscsi"
-# }
-
-# variable "iscsi_srv_ip" {
-#   description = "iscsi server address"
-#   type        = string
-# }
-
-# variable "cluster_ssh_pub" {
-#   description = "path for the public key needed by the cluster"
-#   type        = string
-# }
-
-# variable "cluster_ssh_key" {
-#   description = "path for the private key needed by the cluster"
-#   type        = string
-# }
-
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool

--- a/openstack/modules/netweaver_node/variables.tf
+++ b/openstack/modules/netweaver_node/variables.tf
@@ -69,17 +69,6 @@ variable "network_domain" {
   default = "tf.local"
 }
 
-variable "fencing_mechanism" {
-  description = "Choose the fencing mechanism for the cluster. Options: sbd"
-  type        = string
-}
-
-variable "sbd_storage_type" {
-  description = "Choose the SBD storage type. Options: iscsi"
-  type        = string
-  default     = "iscsi"
-}
-
 variable "iscsi_srv_ip" {
   description = "iscsi server address"
   type        = string

--- a/pillar/iscsi_srv.sls
+++ b/pillar/iscsi_srv.sls
@@ -1,3 +1,8 @@
+{% if grains['provider'] == 'aws' %}
+{% set devicepartprefix = 'p' %}
+{% else %}
+{% set devicepartprefix = '' %}
+{% endif %}
 {% set devicenum = 'abcdefghijklmnopqrstuvwxyz' %}
 {% set partitions = grains['partitions'] %}
 {% set real_iscsidev = salt['cmd.run']('realpath '~grains['iscsidev']) %}
@@ -29,7 +34,7 @@ iscsi:
               block_size: 512
               emulate_write_cache: 0
               unmap_granularity: 0
-            dev: {{ real_iscsidev }}{{ loop.index }}
+            dev: {{ real_iscsidev }}{{ devicepartprefix }}{{ loop.index }}
             name: sd{{ devicenum[loop.index0] }}
             plugin: "block"
 {%- endfor %}

--- a/pillar_examples/automatic/drbd/drbd.sls
+++ b/pillar_examples/automatic/drbd/drbd.sls
@@ -1,3 +1,8 @@
+{% if grains['provider'] == 'aws' %}
+{% set devicepartprefix = 'p' %}
+{% else %}
+{% set devicepartprefix = '' %}
+{% endif %}
 {% set drbd_disk_device = salt['cmd.run']('realpath '~grains['drbd_disk_device']) %}
 
 drbd:
@@ -65,7 +70,7 @@ drbd:
     - name: "sapdata"
       device: "/dev/drbd1"
       {% if grains['provider'] != 'gcp' %}
-      disk: {{ drbd_disk_device }}1
+      disk: {{ drbd_disk_device }}{{ devicepartprefix }}1
       {% endif %}
 
       file_system: "xfs"

--- a/salt/hana_node/mount/mount.sls
+++ b/salt/hana_node/mount/mount.sls
@@ -1,10 +1,16 @@
+{% if grains['provider'] == 'aws' %}
+{% set devicepartprefix = 'p' %}
+{% else %}
+{% set devicepartprefix = '' %}
+{% endif %}
+
 hana_partition:
   cmd.run:
     - name: |
         /usr/sbin/parted -s {{ grains['hana_disk_device'] }} mklabel msdos && \
         /usr/sbin/parted -s {{ grains['hana_disk_device'] }} mkpart primary ext2 1M 100% && sleep 1 && \
-        /sbin/mkfs -t {{ grains['hana_fstype'] }} {{ grains['hana_disk_device'] }}1
-    - unless: ls {{ grains['hana_disk_device'] }}1
+        /sbin/mkfs -t {{ grains['hana_fstype'] }} {{ grains['hana_disk_device'] }}{{ devicepartprefix }}1
+    - unless: ls {{ grains['hana_disk_device'] }}{{ devicepartprefix }}1
     - require:
       - pkg: parted
 
@@ -16,7 +22,7 @@ hana_directory:
     - makedirs: True
   mount.mounted:
     - name: /hana
-    - device: {{ grains['hana_disk_device'] }}1
+    - device: {{ grains['hana_disk_device'] }}{{ devicepartprefix }}1
     - fstype: {{ grains['hana_fstype'] }}
     - mkmnt: True
     - persist: True

--- a/salt/netweaver_node/installation_files.sls
+++ b/salt/netweaver_node/installation_files.sls
@@ -1,3 +1,9 @@
+{% if grains['provider'] == 'aws' %}
+{% set devicepartprefix = 'p' %}
+{% else %}
+{% set devicepartprefix = '' %}
+{% endif %}
+
 {% if grains.get('provider') in ['libvirt', 'openstack'] %}
 mount_swpm:
   mount.mounted:
@@ -27,13 +33,13 @@ nw_inst_partition:
     - name: |
         /usr/sbin/parted -s {{ netweaver_inst_disk_device }} mklabel msdos && \
         /usr/sbin/parted -s {{ netweaver_inst_disk_device }} mkpart primary ext2 1M 100% && sleep 1 && \
-        /sbin/mkfs -t xfs {{ netweaver_inst_disk_device }}1
-    - unless: ls {{ netweaver_inst_disk_device }}1
+        /sbin/mkfs -t xfs {{ netweaver_inst_disk_device }}{{ devicepartprefix }}1
+    - unless: ls {{ netweaver_inst_disk_device }}{{ devicepartprefix }}1
 
 mount_swpm:
   mount.mounted:
     - name: {{ grains['netweaver_inst_folder'] }}
-    - device: {{ netweaver_inst_disk_device }}1
+    - device: {{ netweaver_inst_disk_device }}{{ devicepartprefix }}1
     - fstype: xfs
     - mkmnt: True
     - persist: True


### PR DESCRIPTION
This updates the AWS instances types from xen to the more up to date nitro (KVM) platform.
In addition to being more up to date and better performance, it resolves a current issue where xen instance type VMs do not come up after `zypper update`.

- All instance types are chosen from the officially certified ones on https://aws.amazon.com/sap/instance-types/. https://github.com/SUSE/ha-sap-terraform-deployments/pull/822/commits/fa42aa776cc81f0cd9eac2a53b81254449ad5aaa
- Disk naming conventions need to be adapted as xen uses a different naming scheme than nitro (KVM). https://github.com/SUSE/ha-sap-terraform-deployments/pull/822/commits/6afd9ac9f5593f79a80f255a250e797b8451912e
- Forward port `[common_variables['drbd']` from `develop` to fix non-existing `sbd_storage_type` in case of iscsi+drdb deployment. [fa42aa7](https://github.com/SUSE/ha-sap-terraform-deployments/pull/822/commits/fa42aa776cc81f0cd9eac2a53b81254449ad5aaa)