### PR TITLE
aws: adapt netweaver EFS shared storage to mechanisms from other cloud providers

### DIFF
--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -33,18 +33,6 @@ locals {
   for index in range(2) : cidrsubnet(local.vpc_address_range, 8, index + var.hana_count + 2 + 1)]
 }
 
-# EFS storage for nfs share used by Netweaver for /usr/sap/{sid} and /sapmnt
-# It will be created for netweaver only when drbd is disabled
-resource "aws_efs_file_system" "netweaver-efs" {
-  count            = var.netweaver_enabled == true && var.drbd_enabled == false ? 1 : 0
-  creation_token   = "${local.deployment_name}-netweaver-efs"
-  performance_mode = var.netweaver_efs_performance_mode
-
-  tags = {
-    Name = "${local.deployment_name}-efs"
-  }
-}
-
 # AWS key pair
 resource "aws_key_pair" "key-pair" {
   key_name   = "${local.deployment_name} - terraform"

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -125,7 +125,7 @@ module "common_variables" {
   netweaver_swpm_sar                  = var.netweaver_swpm_sar
   netweaver_sapexe_folder             = var.netweaver_sapexe_folder
   netweaver_additional_dvds           = var.netweaver_additional_dvds
-  netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : "${join("", aws_efs_file_system.netweaver-efs.*.dns_name)}:"
+  netweaver_nfs_share                 = var.drbd_enabled ? "${local.drbd_cluster_vip}:/${var.netweaver_sid}" : var.netweaver_nfs_share
   netweaver_sapmnt_path               = var.netweaver_sapmnt_path
   netweaver_hana_ip                   = var.hana_ha_enabled ? local.hana_cluster_vip : element(local.hana_ips, 0)
   netweaver_hana_sid                  = var.hana_sid
@@ -227,8 +227,7 @@ module "netweaver_node" {
   key_name              = aws_key_pair.key-pair.key_name
   security_group_id     = local.security_group_id
   route_table_id        = aws_route_table.route-table.id
-  efs_enable_mount      = var.netweaver_enabled == true && var.drbd_enabled == false ? true : false
-  efs_file_system_id    = join("", aws_efs_file_system.netweaver-efs.*.id)
+  efs_performance_mode  = var.netweaver_efs_performance_mode
   aws_credentials       = var.aws_credentials
   aws_access_key_id     = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -42,6 +42,8 @@ iscsi_srv_ip: ${var.iscsi_srv_ip}
 app_server_count: ${var.app_server_count}
 netweaver_inst_disk_device: /dev/nvme1n1
 s3_bucket: ${var.s3_bucket}
+efs_mount_ip:
+  sapmnt: [ ${local.shared_storage_efs == 1 ? join("", aws_efs_file_system.netweaver-efs.*.dns_name) : ""} ]
   EOF
     destination = "/tmp/grains"
   }

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -61,14 +61,10 @@ variable "route_table_id" {
   description = "Route table id"
 }
 
-variable "efs_enable_mount" {
-  type        = bool
-  description = "Enable the mount operation on the EFS storage"
-}
-
-variable "efs_file_system_id" {
+variable "efs_performance_mode" {
   type        = string
-  description = "AWS efs file system ID to be used by EFS mount target"
+  description = "Performance mode of the EFS storage used by Netweaver"
+  default     = "generalPurpose"
 }
 
 variable "aws_credentials" {

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -335,8 +335,6 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #netweaver_os_image = "suse-sles-sap-15-sp1-byos"
 #netweaver_os_owner = "amazon"
 
-#AWS efs performance mode used by netweaver nfs share, if efs storage is used
-#netweaver_efs_performance_mode = "generalPurpose"
 #netweaver_ips = ["10.0.2.7", "10.0.3.8", "10.0.2.9", "10.0.3.10"]
 #netweaver_virtual_ips = ["192.168.1.20", "192.168.1.21", "192.168.1.22", "192.168.1.23"]
 
@@ -380,6 +378,14 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 
 # Example:
 #netweaver_product_id = "NW750.HDB.ABAPHA"
+
+#########################
+# Netweaver shared storage variables
+# Needed if Netweaver is deployed HA
+#########################
+#netweaver_shared_storage_type      = "efs"  # drbd,efs supported at the moment (default: "efs")
+#AWS efs performance mode used by netweaver nfs share, if efs storage is used
+#netweaver_efs_performance_mode = "generalPurpose"
 
 # Path where netweaver sapmnt data is stored.
 #netweaver_sapmnt_path = "/sapmnt"

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -805,6 +805,12 @@ variable "netweaver_cluster_fencing_mechanism" {
   }
 }
 
+variable "netweaver_nfs_share" {
+  description = "URL of the NFS share where /sapmnt and /usr/sap/{sid}/SYS will be mounted. This folder must have the sapmnt and usrsapsys folders. This parameter can be omitted if drbd_enabled is set to true, as a HA nfs share will be deployed by the project. Finally, if it is not used or set empty, these folders are created locally (for single machine deployments)"
+  type        = string
+  default     = ""
+}
+
 variable "netweaver_sapmnt_path" {
   description = "Path where sapmnt folder is stored"
   type        = string
@@ -866,14 +872,14 @@ variable "netweaver_ha_enabled" {
 }
 
 variable "netweaver_shared_storage_type" {
-  description = "shared Storage type to use for Netweaver deployment - not supported yet for this cloud provider yet"
+  description = "shared Storage type to use for Netweaver deployment"
   type        = string
-  default     = ""
+  default     = "efs"
   validation {
     condition = (
-      can(regex("^(|)$", var.netweaver_shared_storage_type))
+      can(regex("^(drbd|efs)$", var.netweaver_shared_storage_type))
     )
-    error_message = "Invalid Netweaver shared storage type. Options: none."
+    error_message = "Invalid Netweaver shared storage type. Options: drbd|efs."
   }
 }
 

--- a/generic_modules/common_variables/netweaver_variables.tf
+++ b/generic_modules/common_variables/netweaver_variables.tf
@@ -172,8 +172,8 @@ variable "netweaver_shared_storage_type" {
   type        = string
   validation {
     condition = (
-      can(regex("^(|drbd|anf|nfs)$", var.netweaver_shared_storage_type))
+      can(regex("^(|drbd|anf|efs|nfs)$", var.netweaver_shared_storage_type))
     )
-    error_message = "Invalid Netweaver shared storage type. Options: drbd|anf|nfs."
+    error_message = "Invalid Netweaver shared storage type. Options: drbd|anf|efs|nfs."
   }
 }

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -65,6 +65,11 @@ cluster:
         ascs_fstype: xfs
         ers_device: {{ netweaver.netweaver.nodes[1].shared_disk_dev }}3
         ers_fstype: xfs
+        {%- elif grains['provider'] == 'aws' and grains['netweaver_shared_storage_type'] == 'efs' %}
+        ascs_device: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ASCS
+        ascs_fstype: nfs4
+        ers_device: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ERS
+        ers_fstype: nfs4
         {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
         ascs_device: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ASCS
         ascs_fstype: nfs4

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -41,7 +41,9 @@ netweaver:
   sid_adm_password: {{ grains['netweaver_master_password'] }}
   sap_adm_password: {{ grains['netweaver_master_password'] }}
   master_password: {{ grains['netweaver_master_password'] }}
-  {%- if grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
+  {%- if grains['provider'] == 'aws' and grains['netweaver_shared_storage_type'] == 'efs' %}
+  sapmnt_inst_media: "{{ grains['efs_mount_ip']['sapmnt'][0] }}:/"
+  {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
   sapmnt_inst_media: "{{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt"
   {%- else %}
   sapmnt_inst_media: "{{ grains['netweaver_nfs_share'] }}"
@@ -108,7 +110,9 @@ netweaver:
       shared_disk_dev: /dev/vdb
       init_shared_disk: True
       {%- elif grains['ha_enabled'] %}
-      {%- if grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
+      {%- if grains['provider'] == 'aws' and grains['netweaver_shared_storage_type'] == 'efs' %}
+      shared_disk_dev: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ASCS
+      {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
       shared_disk_dev: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ASCS
       {%- elif grains['provider'] == 'openstack' and grains['netweaver_shared_storage_type'] == 'nfs' %}
       shared_disk_dev: {{ grains['netweaver_nfs_share'] }}/ASCS{{ '{:0>2}'.format(grains['ascs_instance_number']) }}
@@ -130,7 +134,9 @@ netweaver:
       {%- if grains['provider'] == 'libvirt' %}
       shared_disk_dev: /dev/vdb
       {%- else %}
-      {%- if grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
+      {%- if grains['provider'] == 'aws' and grains['netweaver_shared_storage_type'] == 'efs' %}
+      shared_disk_dev: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ERS
+      {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
       shared_disk_dev: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ERS
       {%- elif grains['provider'] == 'openstack' and grains['netweaver_shared_storage_type'] == 'nfs' %}
       shared_disk_dev: {{ grains['netweaver_nfs_share'] }}/ERS{{ '{:0>2}'.format(grains['ers_instance_number']) }}

--- a/salt/netweaver_node/nfs.sls
+++ b/salt/netweaver_node/nfs.sls
@@ -2,7 +2,7 @@
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-nfs
 # Maybe it should go in the netweaver salt formula directly
 
-{% if grains['netweaver_nfs_share'] or grains['netweaver_shared_storage_type'] == "anf" %}
+{% if grains['netweaver_nfs_share'] or grains['netweaver_shared_storage_type'] == "efs" or grains['netweaver_shared_storage_type'] == "anf" %}
 
 include:
   - shared_storage.nfs

--- a/salt/shared_storage/nfs.sls
+++ b/salt/shared_storage/nfs.sls
@@ -58,7 +58,13 @@ include:
       {% set nfs_share = grains['netweaver_nfs_share'] %}
     {% endif %}
     # overwrite netweaver nfs variables on a per cloud provider and scenario basis
-    {% if grains['provider'] == 'azure' %}
+    {% if grains['provider'] == 'aws' %}
+      {% if grains['netweaver_shared_storage_type'] == "efs" %}
+        # define IPs and share
+        {% set nfs_server_ip = grains['efs_mount_ip'][mount][0] %}
+        {% set nfs_share = nfs_server_ip + ':/' %}
+      {% endif %}
+    {% elif grains['provider'] == 'azure' %}
       {% if grains['netweaver_shared_storage_type'] == "anf" %}
         # define IPs and share
         {% set nfs_server_ip = grains['anf_mount_ip'][mount][0] %}
@@ -72,7 +78,13 @@ include:
       {% endif %}
     {% endif %}
   {% elif grains['role'] == "hana_node" %}
-    {% if grains['provider'] == 'azure' %}
+    {% if grains['provider'] == 'aws' %}
+      {% if grains['hana_scale_out_enabled'] and grains['hana_scale_out_shared_storage_type'] == "efs" %}
+        # define IPs and share
+        {% set nfs_server_ip = grains['efs_mount_ip'][mount][site - 1] %}
+        {% set nfs_share = nfs_server_ip + ':/' + grains['name_prefix'] + '-' + mount + '-' + site|string %}
+      {% endif %}
+    {% elif grains['provider'] == 'azure' %}
       {% if grains['hana_scale_out_enabled'] and grains['hana_scale_out_shared_storage_type'] == "anf" %}
         # define IPs and share
         {% set nfs_server_ip = grains['anf_mount_ip'][mount][site - 1] %}


### PR DESCRIPTION
https://github.com/SUSE/ha-sap-terraform-deployments/pull/733 and https://github.com/SUSE/ha-sap-terraform-deployments/pull/796 introduced new mechanisms to handle shared storage for Netweaver and HANA scenarios.

These are now adapted for AWS netweaver deployments in this PR.

It includes:
- deploy EFS resources inside Netweaver module
- EFS is still default (DRBD is an alternative)
- use same code as for azure/openstack `salt/shared_storage/nfs.sls`

This also fixes #832 