### PR TITLE
make sure cloud_provider grain is set on SLES 15 SP4 (salt-3004)

### DIFF
--- a/salt/cluster_node/init.sls
+++ b/salt/cluster_node/init.sls
@@ -10,3 +10,7 @@ include:
   - cluster_node.aws_add_credentials
   - cluster_node.aws_data_provider
   {%- endif %}
+  # make sure cloud_provider grains is set in this salt run (to be available in provisioning run)
+  # currently we have possible race condition here https://github.com/saltstack/salt/issues/54331 with salt >=3003
+  # SLES 15 SP4 uses salt-3004
+  - cluster.cloud_detection


### PR DESCRIPTION
The SLES 15 SP4 QA is failing at the moment because the `cloud_provider` grains is not set.
```
2022-05-24 07:54:37,589 [salt.state       :318 ][ERROR   ][8024] Unable to manage file: Jinja variable 'dict object' has no attribute 'cloud_provider'
```
It does not always fail and not on every cloud provider (only azure so far), so I suspect a race condition as mentioned in here https://github.com/saltstack/salt/issues/54331 with salt >= 3003.

To workaround this condition, we can simply make sure that the `cloud_provider` grain is already set in the `salt-deployment` run.