### PR TITLE
 gcp: add filestore shared storage to netweaver

### DIFF
--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -202,26 +202,27 @@ module "drbd_node" {
 }
 
 module "netweaver_node" {
-  source                           = "./modules/netweaver_node"
-  common_variables                 = module.common_variables.configuration
-  name                             = var.netweaver_name
-  network_domain                   = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
-  bastion_host                     = module.bastion.public_ip
-  xscs_server_count                = local.netweaver_xscs_server_count
-  app_server_count                 = var.netweaver_enabled ? var.netweaver_app_server_count : 0
-  machine_type                     = var.netweaver_machine_type
-  compute_zones                    = data.google_compute_zones.available.names
-  network_name                     = local.vpc_name
-  network_subnet_name              = local.subnet_name
-  os_image                         = local.netweaver_os_image
-  gcp_credentials_file             = var.gcp_credentials_file
-  host_ips                         = local.netweaver_ips
-  iscsi_srv_ip                     = module.iscsi_server.iscsisrv_ip
-  cluster_ssh_pub                  = var.cluster_ssh_pub
-  cluster_ssh_key                  = var.cluster_ssh_key
-  netweaver_software_bucket        = var.netweaver_software_bucket
-  virtual_host_ips                 = local.netweaver_virtual_ips
-  filestore_tier                   = var.filestore_tier
+  source                    = "./modules/netweaver_node"
+  common_variables          = module.common_variables.configuration
+  name                      = var.netweaver_name
+  network_domain            = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
+  bastion_host              = module.bastion.public_ip
+  xscs_server_count         = local.netweaver_xscs_server_count
+  app_server_count          = var.netweaver_enabled ? var.netweaver_app_server_count : 0
+  machine_type              = var.netweaver_machine_type
+  compute_zones             = data.google_compute_zones.available.names
+  network_name              = local.vpc_name
+  network_subnet_name       = local.subnet_name
+  os_image                  = local.netweaver_os_image
+  gcp_credentials_file      = var.gcp_credentials_file
+  host_ips                  = local.netweaver_ips
+  iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
+  cluster_ssh_pub           = var.cluster_ssh_pub
+  cluster_ssh_key           = var.cluster_ssh_key
+  netweaver_software_bucket = var.netweaver_software_bucket
+  virtual_host_ips          = local.netweaver_virtual_ips
+  # always multi-zonal (ENTERPRISEon)
+  filestore_tier                   = "ENTERPRISE"
   netweaver_filestore_quota_sapmnt = var.netweaver_filestore_quota_sapmnt
   on_destroy_dependencies = [
     google_compute_firewall.ha_firewall_allow_tcp,

--- a/gcp/modules/hana_node/main.tf
+++ b/gcp/modules/hana_node/main.tf
@@ -129,6 +129,10 @@ resource "google_filestore_instance" "data" {
     modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
+
+  timeouts {
+    create = "60m"
+  }
 }
 
 resource "google_filestore_instance" "log" {
@@ -155,6 +159,10 @@ resource "google_filestore_instance" "log" {
     network      = var.network_name
     modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
+  }
+
+  timeouts {
+    create = "60m"
   }
 }
 
@@ -183,6 +191,10 @@ resource "google_filestore_instance" "backup" {
     modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
   }
+
+  timeouts {
+    create = "60m"
+  }
 }
 
 resource "google_filestore_instance" "shared" {
@@ -209,6 +221,10 @@ resource "google_filestore_instance" "shared" {
     network      = var.network_name
     modes        = ["MODE_IPV4"]
     connect_mode = "DIRECT_PEERING"
+  }
+
+  timeouts {
+    create = "60m"
   }
 }
 

--- a/gcp/modules/netweaver_node/salt_provisioner.tf
+++ b/gcp/modules/netweaver_node/salt_provisioner.tf
@@ -47,7 +47,8 @@ vpc_network_name: ${var.network_name}
 ascs_route_name: ${join(",", google_compute_route.nw-ascs-route.*.name)}
 ers_route_name: ${join(",", google_compute_route.nw-ers-route.*.name)}
 app_server_count: ${var.app_server_count}
-
+filestore_mount_ip:
+  sapmnt: [ ${local.shared_storage_filestore == 1 ? join("", google_filestore_instance.sapmnt.*.networks.0.ip_addresses.0) : ""} ]
 EOF
     destination = "/tmp/grains"
   }

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -464,6 +464,17 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 # Example:
 #netweaver_product_id = "NW750.HDB.ABAPHA"
 
+#########################
+# shared storage variables
+# Needed if Netweaver is deployed HA
+# see https://cloud.google.com/solutions/sap/docs/filers-for-sap
+# and https://cloud.google.com/filestore/docs/creating-instances
+# for reference and minimum requirements
+#########################
+#netweaver_shared_storage_type          = "filestore"  # drbd,filestore supported at the moment (default: "drbd")
+#filestore_tier                         = "BASIC_SSD"  # BASIC_SSD or ENTERPRISE are recommended
+#netweaver_filestore_quota_sapmnt       = "1024"       # deployed 1x
+
 # NFS share to store the Netweaver shared files. Only used if drbd_enabled is not set. For single machine deployments (ASCS and PAS in the same machine) set an empty string
 #netweaver_nfs_share = "url-to-your-netweaver-sapmnt-nfs-share"
 

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -944,12 +944,12 @@ variable "netweaver_ha_enabled" {
 variable "netweaver_shared_storage_type" {
   description = "shared Storage type to use for Netweaver deployment - not supported yet for this cloud provider yet"
   type        = string
-  default     = ""
+  default     = "drbd"
   validation {
     condition = (
-      can(regex("^(|)$", var.netweaver_shared_storage_type))
+      can(regex("^(drbd|filestore)$", var.netweaver_shared_storage_type))
     )
-    error_message = "Invalid Netweaver shared storage type. Options: none."
+    error_message = "Invalid Netweaver shared storage type. Options: drbd|filestore."
   }
 }
 

--- a/pillar_examples/automatic/netweaver/cluster.sls
+++ b/pillar_examples/automatic/netweaver/cluster.sls
@@ -75,6 +75,11 @@ cluster:
         ascs_fstype: nfs4
         ers_device: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ERS
         ers_fstype: nfs4
+        {%- elif grains['provider'] == 'gcp' and grains['netweaver_shared_storage_type'] == 'filestore' %}
+        ascs_device: {{ grains['filestore_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt/ASCS
+        ascs_fstype: nfs4
+        ers_device: {{ grains['filestore_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt/ERS
+        ers_fstype: nfs4
         {%- elif grains['provider'] == 'openstack' and grains['netweaver_shared_storage_type'] == 'nfs' %}
         ascs_device: {{ grains['netweaver_nfs_share'] }}/ASCS{{ '{:0>2}'.format(grains['ascs_instance_number']) }}
         ascs_fstype: nfs4

--- a/pillar_examples/automatic/netweaver/netweaver.sls
+++ b/pillar_examples/automatic/netweaver/netweaver.sls
@@ -44,7 +44,9 @@ netweaver:
   {%- if grains['provider'] == 'aws' and grains['netweaver_shared_storage_type'] == 'efs' %}
   sapmnt_inst_media: "{{ grains['efs_mount_ip']['sapmnt'][0] }}:/"
   {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
-  sapmnt_inst_media: "{{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt"
+  sapmnt_inst_media: "{{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt"
+  {%- elif grains['provider'] == 'gcp' and grains['netweaver_shared_storage_type'] == 'filestore' %}
+  sapmnt_inst_media: "{{ grains['filestore_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt"
   {%- else %}
   sapmnt_inst_media: "{{ grains['netweaver_nfs_share'] }}"
   {%- endif %}
@@ -114,6 +116,8 @@ netweaver:
       shared_disk_dev: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ASCS
       {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
       shared_disk_dev: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ASCS
+      {%- elif grains['provider'] == 'gcp' and grains['netweaver_shared_storage_type'] == 'filestore' %}
+      shared_disk_dev: {{ grains['filestore_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt/ASCS
       {%- elif grains['provider'] == 'openstack' and grains['netweaver_shared_storage_type'] == 'nfs' %}
       shared_disk_dev: {{ grains['netweaver_nfs_share'] }}/ASCS{{ '{:0>2}'.format(grains['ascs_instance_number']) }}
       {%- else %}
@@ -138,6 +142,8 @@ netweaver:
       shared_disk_dev: {{ grains['efs_mount_ip']['sapmnt'][0] }}:/ERS
       {%- elif grains['provider'] == 'azure' and grains['netweaver_shared_storage_type'] == 'anf' %}
       shared_disk_dev: {{ grains['anf_mount_ip']['sapmnt'][0] }}:/netweaver-sapmnt/ERS
+      {%- elif grains['provider'] == 'gcp' and grains['netweaver_shared_storage_type'] == 'filestore' %}
+      shared_disk_dev: {{ grains['filestore_mount_ip']['sapmnt'][0] }}:/netweaver_sapmnt/ERS
       {%- elif grains['provider'] == 'openstack' and grains['netweaver_shared_storage_type'] == 'nfs' %}
       shared_disk_dev: {{ grains['netweaver_nfs_share'] }}/ERS{{ '{:0>2}'.format(grains['ers_instance_number']) }}
       {%- else %}

--- a/salt/netweaver_node/nfs.sls
+++ b/salt/netweaver_node/nfs.sls
@@ -2,7 +2,7 @@
 # https://docs.microsoft.com/en-us/azure/virtual-machines/workloads/sap/high-availability-guide-suse-nfs
 # Maybe it should go in the netweaver salt formula directly
 
-{% if grains['netweaver_nfs_share'] or grains['netweaver_shared_storage_type'] == "efs" or grains['netweaver_shared_storage_type'] == "anf" %}
+{% if grains['netweaver_nfs_share'] or grains['netweaver_shared_storage_type'] in ['anf', 'efs', 'filestore'] %}
 
 include:
   - shared_storage.nfs

--- a/salt/shared_storage/nfs.sls
+++ b/salt/shared_storage/nfs.sls
@@ -82,6 +82,12 @@ include:
         {% set nfs_server_ip = grains['anf_mount_ip'][mount][0] %}
         {% set nfs_share = nfs_server_ip + ':/netweaver-' + mount %}
       {% endif %}
+    {% elif grains['provider'] == 'gcp' %}
+      {% if grains['netweaver_shared_storage_type'] == "filestore" %}
+        # define IPs and share
+        {% set nfs_server_ip = grains['filestore_mount_ip'][mount][0] %}
+        {% set nfs_share = nfs_server_ip + ':/netweaver_' + mount %}
+      {% endif %}
     {% elif grains['provider'] == 'libvirt' %}
       {% if grains['netweaver_shared_storage_type'] == "nfs" %}
         # define IPs and share


### PR DESCRIPTION
https://github.com/SUSE/ha-sap-terraform-deployments/pull/733 and https://github.com/SUSE/ha-sap-terraform-deployments/pull/796 and https://github.com/SUSE/ha-sap-terraform-deployments/pull/834 introduced new mechanisms to handle shared storage for Netweaver and HANA scenarios.

These are now adapted for GCP netweaver deployments in this PR.

It includes:
- deploy filestore shared storage resources inside Netweaver module (similar to HANA scale-out implementation)
- DRBD is still default (filestore is an alternative)
- use same code as for aws/azure/openstack `salt/shared_storage/nfs.sls`