### PR TITLE
gcp: fix install of gcloud tool on SLES12

### DIFF
--- a/salt/macros/download_from_google_storage.sls
+++ b/salt/macros/download_from_google_storage.sls
@@ -5,9 +5,22 @@
 {% set gcloud_dir = gcloud_inst_dir~'/google-cloud-sdk' %}
 {% set gcloud_bin_dir = '/usr/local/bin' %}
 
+# Fix for https://github.com/SUSE/ha-sap-terraform-deployments/issues/669
+# gcloud and gsutil don't support python3.4 usage
+{%- set python3_version = salt['cmd.run']('python3 --version').split(' ')[1] %}
+{%- if salt['pkg.version_cmp'](python3_version, '3.5') < 0 %}
+{%- set use_py2 = true %}
+{%- else %}
+{%- set use_py2 = false %}
+{%- endif %}
+
 install_gcloud:
   cmd.run:
-    - name: curl https://sdk.cloud.google.com | bash -s -- '--disable-prompts' '--install-dir={{ gcloud_inst_dir }}'
+    - name: export CLOUDSDK_PYTHON; curl https://sdk.cloud.google.com | bash -s -- '--disable-prompts' '--install-dir={{ gcloud_inst_dir }}'
+    {%- if use_py2 %}
+    - env:
+      - CLOUDSDK_PYTHON: python2.7
+    {%- endif %}
     - unless: ls {{ gcloud_dir }}
 
 /etc/profile.d/google-cloud-sdk.completion.sh:
@@ -21,15 +34,6 @@ install_gcloud:
 {{ gcloud_bin_dir }}/gsutil:
   file.symlink:
   - target: {{ gcloud_dir }}/bin/gsutil
-
-# Fix for https://github.com/SUSE/ha-sap-terraform-deployments/issues/669
-# gcloud and gsutil don't support python3.4 usage
-{%- set python3_version = salt['cmd.run']('python3 --version').split(' ')[1] %}
-{%- if salt['pkg.version_cmp'](python3_version, '3.5') < 0 %}
-{%- set use_py2 = true %}
-{%- else %}
-{%- set use_py2 = false %}
-{%- endif %}
 
 configure_gcloud_credentials:
   cmd.run:


### PR DESCRIPTION
Fix installation of `gcloud`tools on SLES12 by also passing `CLOUDSDK_PYTHON` to install script.