### PR TITLE
common variables: set password length to 10-14 everywhere

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -573,7 +573,7 @@ When the process is completed, the `describe-import-snapshot-tasks` command will
 
 Notice the **completed** status in the above JSON output.
 
-Also notice tne `SnapshotId` which will be used in the next step to register the AMI.
+Also notice the `SnapshotId` which will be used in the next step to register the AMI.
 
 Once the snapshot is completely imported, the next step is to register an AMI with the command:
 

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -283,7 +283,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
-# HANA instance master password (length 8-64, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
+# HANA instance master password (length 10-14, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
 #hana_master_password = "YourPassword1234"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
@@ -400,7 +400,7 @@ hana_inst_master = "s3://sapdata/sap_inst_media/51053381"
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# NetWeaver or S/4HANA master password (length 6-40, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
+# NetWeaver or S/4HANA master password (length 10-14, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
 #netweaver_master_password = "SuSE1234"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers

--- a/azure/terraform.tfvars.example
+++ b/azure/terraform.tfvars.example
@@ -362,7 +362,7 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
-# HANA instance master password (length 8-64, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
+# HANA instance master password (length 10-14, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
 #hana_master_password = "YourPassword1234"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
@@ -479,7 +479,7 @@ hana_inst_master = "//YOUR_STORAGE_ACCOUNT_NAME.file.core.windows.net/sapdata/sa
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# NetWeaver or S/4HANA master password (length 6-40, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
+# NetWeaver or S/4HANA master password (length 10-14, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
 #netweaver_master_password = "SuSE1234"
 
 # Enabling this option will create a ASCS/ERS HA available cluster

--- a/doc/sap_passwords.md
+++ b/doc/sap_passwords.md
@@ -11,6 +11,7 @@
 ## SAP HANA
 
   The password for SAP HANA supports password lengths between 8 up to 64 characters.
+  We enforce 10 to 14 characters to be compatible with the Netweaver and S/4HANA deployments, though.
   It can be composed of lowercase letters (`a-z`), uppercase letters (`A-Z`) and numerical
   digits (`0-9`). All other characters are considered as special character.
   The default configuration requires passwords to contain at least one uppercase letter,
@@ -25,7 +26,7 @@
 
 ## SAP NetWeaver/SAP S/4HANA
 
-  The password for SAP NetWeaver supports password lengths between 6 and 40 characters.
+  The password for SAP NetWeaver supports password lengths between 10 and 14 characters.
   The password can only consist of digits, letters, and the following (ASCII) special characters: `!"@ $%&/()=?'*+~#-_.,;:{[]}<>`, and space and the grave accent.
   The password can consist of any characters including national special characters (such as `ä`, `ç`, `ß` from ISO Latin-1, 8859-1).
   However, all characters that aren’t contained in the set above are mapped to the same special character, and the system therefore doesn’t differentiate between them.

--- a/gcp/terraform.tfvars.example
+++ b/gcp/terraform.tfvars.example
@@ -336,7 +336,7 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
-# HANA instance master password (length 8-64, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
+# HANA instance master password (length 10-14, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
 #hana_master_password = "YourPassword1234"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
@@ -518,7 +518,7 @@ hana_inst_master = "MyHanaBucket/sapdata/sap_inst_media/51053381"
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# NetWeaver or S/4HANA master password (length 6-40, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
+# NetWeaver or S/4HANA master password (length 10-14, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
 #netweaver_master_password = "SuSE1234"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers

--- a/generic_modules/common_variables/hana_variables.tf
+++ b/generic_modules/common_variables/hana_variables.tf
@@ -51,9 +51,9 @@ variable "hana_master_password" {
       can(regex("[0-9]+", var.hana_master_password)) &&
       can(regex("[a-z]+", var.hana_master_password)) &&
       can(regex("[A-Z]+", var.hana_master_password)) &&
-      can(regex("^.{8,64}$", var.hana_master_password))
+      can(regex("^.{10,14}$", var.hana_master_password))
     )
-    error_message = "The hana master password in default configuration must contain at least 8 up to 64 characters. It must contain at least 1 digit, 1 upper-case character, 1 lower-case character and optional special characters. For more information see: 'doc/sap_passwords.md'."
+    error_message = "The hana master password in default configuration must contain at least 8 up to 64 characters. To be compatible with our Netweaver and S/4HANA deployment we set it to 10 to 14 characters, though. It must contain at least 1 digit, 1 upper-case character, 1 lower-case character and optional special characters. For more information see: 'doc/sap_passwords.md'."
   }
 }
 

--- a/generic_modules/common_variables/netweaver_variables.tf
+++ b/generic_modules/common_variables/netweaver_variables.tf
@@ -68,9 +68,9 @@ variable "netweaver_master_password" {
   type        = string
   validation {
     condition = (
-      can(regex("^.{6,40}$", var.netweaver_master_password))
+      can(regex("^.{10,14}$", var.netweaver_master_password))
     )
-    error_message = "The netweaver master password must contain at least 6 up to 40 characters. The password can only consist of digits, letters, and the ASCII special characters. Other non-ASCII characters will be mapped to the same special character. For more information see: 'doc/sap_passwords.md'."
+    error_message = "The netweaver master password must contain at least 10 up to 14 characters. The password can only consist of digits, letters, and the ASCII special characters. Other non-ASCII characters will be mapped to the same special character. For more information see: 'doc/sap_passwords.md'."
   }
 }
 

--- a/libvirt/terraform.tfvars.example
+++ b/libvirt/terraform.tfvars.example
@@ -212,7 +212,7 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
-# HANA instance master password (length 8-64, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
+# HANA instance master password (length 10-14, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
 #hana_master_password = "YourPassword1234"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
@@ -398,5 +398,5 @@ hana_inst_master = "url-to-your-nfs-share:/sapdata/sap_inst_media/51053381"
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# NetWeaver or S/4HANA master password (length 6-40, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
+# NetWeaver or S/4HANA master password (length 10-14, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
 #netweaver_master_password = "SuSE1234"

--- a/openstack/terraform.tfvars.example
+++ b/openstack/terraform.tfvars.example
@@ -342,7 +342,7 @@ hana_ips = ["10.0.0.10", "10.0.0.11"]
 #hana_sid = "PRD"
 # HANA instance number. It's composed of 2 integers string
 #hana_instance_number = "00"
-# HANA instance master password (length 8-64, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
+# HANA instance master password (length 10-14, 1 digit, 1 lowercase, 1 uppercase). For detailed password rules see: doc/sap_passwords.md
 #hana_master_password = "YourPassword1234"
 # HANA primary site name. Only used if HANA's system replication feature is enabled (hana_ha_enabled to true)
 #hana_primary_site = "Site1"
@@ -509,7 +509,7 @@ netweaver_virtual_ips = ["10.0.0.34", "10.0.0.35", "10.0.0.36", "10.0.0.37"]
 #netweaver_ers_instance_number = "10"
 # Netweaver PAS instance number. If additional AAS machines are deployed, they get the next number starting from the PAS instance number. It's composed of 2 integers string
 #netweaver_pas_instance_number = "01"
-# NetWeaver or S/4HANA master password (length 6-40, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
+# NetWeaver or S/4HANA master password (length 10-14, ASCII prefered). For detailed password rules see: doc/sap_passwords.md
 #netweaver_master_password = "SuSE1234"
 
 # Enabling this option will create a ASCS/ERS HA available cluster together with a PAS and AAS application servers


### PR DESCRIPTION
As per suggestion https://github.com/SUSE/ha-sap-terraform-deployments/pull/873#issuecomment-1188279358, we now set this to 10-14 for HANA and Netweaver / S/4HANA deployments.