### PR TITLE
aws: add option to deploy bastion host setup and private subnets

### DIFF
--- a/aws/README.md
+++ b/aws/README.md
@@ -149,7 +149,29 @@ For detailed information and deployment options have a look at `terraform.tfvars
 
 ## Bastion
 
-A bastion host is not implemented for AWS. 
+By default, the bastion machine is enabled in AWS (it can be disabled), which will have the unique public IP address of the deployment. Connect using ssh and the selected admin user with:
+
+```
+ssh {admin_user}@{bastion_ip} -i {private_key_location}
+```
+
+To log to hana and others instances, use:
+
+```
+ssh -o ProxyCommand="ssh -W %h:%p {admin_user}@{bastion_ip} -i {private_key_location} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no" {admin_user}@{private_hana_instance_ip} -i {private_key_location} -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no
+```
+
+To disable the bastion use:
+
+```
+bastion_enabled = false
+```
+
+Destroy the created infrastructure with:
+
+```
+terraform destroy
+```
 
 # Highlevel description
 
@@ -218,6 +240,7 @@ Example based on `10.0.0.0/16` address range (VPC address range) and `192.168.1.
 
 | Service                          | Variable                     | Addresses                                                      | Comments                                                                                            |
 | ----                             | --------                     | ---------                                                      | --------                                                                                            |
+| Bastion                          | -                            | `10.0.254.254`                                         |                                                                                                        |
 | iSCSI server                     | `iscsi_srv_ip`               | `10.0.0.4`                                                     |                                                                                                     |
 | Monitoring                       | `monitoring_srv_ip`          | `10.0.0.5`                                                     |                                                                                                     |
 | HANA ips                         | `hana_ips`                   | `10.0.1.10`, `10.0.2.11`                                       |                                                                                                     |

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -20,7 +20,7 @@ locals {
   vpc_address_range = var.vpc_id == "" ? var.vpc_address_range : (var.vpc_address_range == "" ? data.aws_vpc.current-vpc.0.cidr_block : var.vpc_address_range)
 
   public_subnet_address_range = var.public_subnet_address_range != "" ? var.public_subnet_address_range : cidrsubnet(local.vpc_address_range, 8, 254)
-  infra_subnet_address_range = var.infra_subnet_address_range != "" ? var.infra_subnet_address_range : cidrsubnet(local.vpc_address_range, 8, 0)
+  infra_subnet_address_range  = var.infra_subnet_address_range != "" ? var.infra_subnet_address_range : cidrsubnet(local.vpc_address_range, 8, 0)
 
   # The +1 is added in case we have a HANA scale-out setup
   hana_subnet_address_range = length(var.hana_subnet_address_range) != 0 ? var.hana_subnet_address_range : [
@@ -82,7 +82,7 @@ resource "aws_subnet" "infra" {
 }
 
 resource "aws_route_table" "private" {
-  count   = var.bastion_enabled ? 1 : 0
+  count  = var.bastion_enabled ? 1 : 0
   vpc_id = local.vpc_id
 
   tags = {
@@ -94,10 +94,10 @@ resource "aws_route_table" "private" {
 }
 
 resource "aws_route" "private" {
-  count   = var.bastion_enabled ? 1 : 0
+  count                  = var.bastion_enabled ? 1 : 0
   route_table_id         = aws_route_table.private.0.id
   destination_cidr_block = "0.0.0.0/0"
-  nat_gateway_id             = aws_nat_gateway.ngw.0.id
+  nat_gateway_id         = aws_nat_gateway.ngw.0.id
 }
 
 resource "aws_route_table_association" "infra" {
@@ -107,8 +107,8 @@ resource "aws_route_table_association" "infra" {
 
 # Network resources: NAT Gateway, subnets and routes when deploying the bastion host setup
 resource "aws_eip" "ngw" {
-  count       = var.bastion_enabled ? 1 : 0
-  vpc      = true
+  count = var.bastion_enabled ? 1 : 0
+  vpc   = true
 
   tags = {
     Name      = "${local.deployment_name}-eip-ngw"
@@ -119,10 +119,10 @@ resource "aws_eip" "ngw" {
 }
 
 resource "aws_nat_gateway" "ngw" {
-  count  = var.vpc_id == "" && var.bastion_enabled ? 1 : 0
+  count             = var.vpc_id == "" && var.bastion_enabled ? 1 : 0
   connectivity_type = "public"
-  allocation_id = aws_eip.ngw.0.id
-  subnet_id = aws_subnet.public.id
+  allocation_id     = aws_eip.ngw.0.id
+  subnet_id         = aws_subnet.public.id
 
   tags = {
     Name      = "${local.deployment_name}-ngw"
@@ -131,9 +131,9 @@ resource "aws_nat_gateway" "ngw" {
 }
 
 resource "aws_subnet" "public" {
-  vpc_id            = local.vpc_id
-  cidr_block        = local.public_subnet_address_range
-  availability_zone = element(data.aws_availability_zones.available.names, 0)
+  vpc_id                  = local.vpc_id
+  cidr_block              = local.public_subnet_address_range
+  availability_zone       = element(data.aws_availability_zones.available.names, 0)
   map_public_ip_on_launch = true
 
   tags = {
@@ -329,7 +329,7 @@ module "bastion" {
   os_owner           = local.bastion_os_owner
   instance_type      = var.bastion_instancetype
   key_name           = aws_key_pair.key-pair.key_name
-  security_group_id = local.security_group_id
+  security_group_id  = local.security_group_id
   host_ips           = [local.bastion_ip]
   on_destroy_dependencies = [
     aws_route_table_association.public,

--- a/aws/infrastructure.tf
+++ b/aws/infrastructure.tf
@@ -19,6 +19,7 @@ locals {
   security_group_id = var.security_group_id != "" ? var.security_group_id : aws_security_group.secgroup.0.id
   vpc_address_range = var.vpc_id == "" ? var.vpc_address_range : (var.vpc_address_range == "" ? data.aws_vpc.current-vpc.0.cidr_block : var.vpc_address_range)
 
+  public_subnet_address_range = var.public_subnet_address_range != "" ? var.public_subnet_address_range : cidrsubnet(local.vpc_address_range, 8, 254)
   infra_subnet_address_range = var.infra_subnet_address_range != "" ? var.infra_subnet_address_range : cidrsubnet(local.vpc_address_range, 8, 0)
 
   # The +1 is added in case we have a HANA scale-out setup
@@ -69,7 +70,7 @@ resource "aws_internet_gateway" "igw" {
   }
 }
 
-resource "aws_subnet" "infra-subnet" {
+resource "aws_subnet" "infra" {
   vpc_id            = local.vpc_id
   cidr_block        = local.infra_subnet_address_range
   availability_zone = element(data.aws_availability_zones.available.names, 0)
@@ -80,22 +81,85 @@ resource "aws_subnet" "infra-subnet" {
   }
 }
 
-resource "aws_route_table" "route-table" {
+resource "aws_route_table" "private" {
+  count   = var.bastion_enabled ? 1 : 0
   vpc_id = local.vpc_id
 
   tags = {
-    Name      = "${local.deployment_name}-hana-route-table"
+    Name      = "${local.deployment_name}-route-table-private"
+    Workspace = local.deployment_name
+  }
+
+  depends_on = [aws_nat_gateway.ngw]
+}
+
+resource "aws_route" "private" {
+  count   = var.bastion_enabled ? 1 : 0
+  route_table_id         = aws_route_table.private.0.id
+  destination_cidr_block = "0.0.0.0/0"
+  nat_gateway_id             = aws_nat_gateway.ngw.0.id
+}
+
+resource "aws_route_table_association" "infra" {
+  subnet_id      = aws_subnet.infra.id
+  route_table_id = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
+}
+
+# Network resources: NAT Gateway, subnets and routes when deploying the bastion host setup
+resource "aws_eip" "ngw" {
+  count       = var.bastion_enabled ? 1 : 0
+  vpc      = true
+
+  tags = {
+    Name      = "${local.deployment_name}-eip-ngw"
+    Workspace = local.deployment_name
+  }
+
+  depends_on = [local.internet_gateway]
+}
+
+resource "aws_nat_gateway" "ngw" {
+  count  = var.vpc_id == "" && var.bastion_enabled ? 1 : 0
+  connectivity_type = "public"
+  allocation_id = aws_eip.ngw.0.id
+  subnet_id = aws_subnet.public.id
+
+  tags = {
+    Name      = "${local.deployment_name}-ngw"
     Workspace = local.deployment_name
   }
 }
 
-resource "aws_route_table_association" "infra-subnet-route-association" {
-  subnet_id      = aws_subnet.infra-subnet.id
-  route_table_id = aws_route_table.route-table.id
+resource "aws_subnet" "public" {
+  vpc_id            = local.vpc_id
+  cidr_block        = local.public_subnet_address_range
+  availability_zone = element(data.aws_availability_zones.available.names, 0)
+  map_public_ip_on_launch = true
+
+  tags = {
+    Name      = "${local.deployment_name}-public-subnet"
+    Workspace = local.deployment_name
+  }
+}
+
+resource "aws_route_table" "public" {
+  vpc_id = local.vpc_id
+
+  tags = {
+    Name      = "${local.deployment_name}-route-table-public"
+    Workspace = local.deployment_name
+  }
+
+  depends_on = [aws_nat_gateway.ngw]
+}
+
+resource "aws_route_table_association" "public" {
+  subnet_id      = aws_subnet.public.id
+  route_table_id = aws_route_table.public.id
 }
 
 resource "aws_route" "public" {
-  route_table_id         = aws_route_table.route-table.id
+  route_table_id         = aws_route_table.public.id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = local.internet_gateway
 }
@@ -138,30 +202,8 @@ resource "aws_security_group_rule" "local" {
   security_group_id = local.security_group_id
 }
 
-resource "aws_security_group_rule" "http" {
-  count       = local.create_security_group
-  type        = "ingress"
-  from_port   = 80
-  to_port     = 80
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
-
-  security_group_id = local.security_group_id
-}
-
-resource "aws_security_group_rule" "https" {
-  count       = local.create_security_group
-  type        = "ingress"
-  from_port   = 443
-  to_port     = 443
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
-
-  security_group_id = local.security_group_id
-}
-
 resource "aws_security_group_rule" "hawk" {
-  count       = local.create_security_group
+  count       = var.bastion_enabled ? 0 : local.create_security_group
   type        = "ingress"
   from_port   = 7630
   to_port     = 7630
@@ -184,61 +226,83 @@ resource "aws_security_group_rule" "ssh" {
 
 
 # Monitoring rules
-resource "aws_security_group_rule" "hanadb_exporter" {
+resource "aws_security_group_rule" "http" {
   count       = local.create_security_group_monitoring
   type        = "ingress"
-  from_port   = 9668
-  to_port     = 9668
+  from_port   = 80
+  to_port     = 80
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = local.security_group_id
 }
 
-
-resource "aws_security_group_rule" "node_exporter" {
+resource "aws_security_group_rule" "https" {
   count       = local.create_security_group_monitoring
   type        = "ingress"
-  from_port   = 9100
-  to_port     = 9100
+  from_port   = 443
+  to_port     = 443
   protocol    = "tcp"
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = local.security_group_id
 }
 
-resource "aws_security_group_rule" "ha_exporter" {
-  count       = local.create_security_group_monitoring
-  type        = "ingress"
-  from_port   = 9664
-  to_port     = 9664
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
+#resource "aws_security_group_rule" "hanadb_exporter" {
+#  count       = local.create_security_group_monitoring
+#  type        = "ingress"
+#  from_port   = 9668
+#  to_port     = 9668
+#  protocol    = "tcp"
+#  cidr_blocks = ["0.0.0.0/0"]
+#
+#  security_group_id = local.security_group_id
+#}
+#
+#
+#resource "aws_security_group_rule" "node_exporter" {
+#  count       = local.create_security_group_monitoring
+#  type        = "ingress"
+#  from_port   = 9100
+#  to_port     = 9100
+#  protocol    = "tcp"
+#  cidr_blocks = ["0.0.0.0/0"]
+#
+#  security_group_id = local.security_group_id
+#}
+#
+#resource "aws_security_group_rule" "ha_exporter" {
+#  count       = local.create_security_group_monitoring
+#  type        = "ingress"
+#  from_port   = 9664
+#  to_port     = 9664
+#  protocol    = "tcp"
+#  cidr_blocks = ["0.0.0.0/0"]
+#
+#  security_group_id = local.security_group_id
+#}
+#
+#resource "aws_security_group_rule" "saphost_exporter" {
+#  count       = local.create_security_group_monitoring
+#  type        = "ingress"
+#  from_port   = 9680
+#  to_port     = 9680
+#  protocol    = "tcp"
+#  cidr_blocks = ["0.0.0.0/0"]
+#
+#  security_group_id = local.security_group_id
+#}
 
-  security_group_id = local.security_group_id
-}
-
-resource "aws_security_group_rule" "saphost_exporter" {
-  count       = local.create_security_group_monitoring
-  type        = "ingress"
-  from_port   = 9680
-  to_port     = 9680
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
-
-  security_group_id = local.security_group_id
-}
-
-resource "aws_security_group_rule" "prometheus_server" {
-  count       = local.create_security_group_monitoring
-  type        = "ingress"
-  from_port   = 9090
-  to_port     = 9090
-  protocol    = "tcp"
-  cidr_blocks = ["0.0.0.0/0"]
-
-  security_group_id = local.security_group_id
-}
+#resource "aws_security_group_rule" "prometheus_server" {
+#  count       = local.create_security_group_monitoring
+#  type        = "ingress"
+#  from_port   = 9090
+#  to_port     = 9090
+#  protocol    = "tcp"
+#  cidr_blocks = ["0.0.0.0/0"]
+#
+#  security_group_id = local.security_group_id
+#}
 
 resource "aws_security_group_rule" "grafana_server" {
   count       = local.create_security_group_monitoring
@@ -249,4 +313,28 @@ resource "aws_security_group_rule" "grafana_server" {
   cidr_blocks = ["0.0.0.0/0"]
 
   security_group_id = local.security_group_id
+}
+
+# Bastion
+module "bastion" {
+  source             = "./modules/bastion"
+  common_variables   = module.common_variables.configuration
+  name               = var.bastion_name
+  network_domain     = var.bastion_network_domain == "" ? var.network_domain : var.bastion_network_domain
+  bastion_count      = module.common_variables.configuration["bastion_enabled"] ? 1 : 0
+  aws_region         = var.aws_region
+  availability_zones = data.aws_availability_zones.available.names
+  subnet_ids         = var.bastion_enabled ? [aws_subnet.public.id] : []
+  os_image           = local.bastion_os_image
+  os_owner           = local.bastion_os_owner
+  instance_type      = var.bastion_instancetype
+  key_name           = aws_key_pair.key-pair.key_name
+  security_group_id = local.security_group_id
+  host_ips           = [local.bastion_ip]
+  on_destroy_dependencies = [
+    aws_route_table_association.public,
+    aws_route.public,
+    aws_security_group_rule.ssh,
+    aws_security_group_rule.outall
+  ]
 }

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -17,6 +17,7 @@ module "local_execution" {
 # DRBD cluster vip: 192.168.1.20 (virtual ip address must be in a different range than the vpc)
 # If the addresses are provided by the user will always have preference
 locals {
+  bastion_ip    = var.bastion_ip != "" ? var.bastion_ip : cidrhost(local.public_subnet_address_range, 254)
   iscsi_ip      = var.iscsi_srv_ip != "" ? var.iscsi_srv_ip : cidrhost(local.infra_subnet_address_range, 4)
   monitoring_ip = var.monitoring_srv_ip != "" ? var.monitoring_srv_ip : cidrhost(local.infra_subnet_address_range, 5)
 
@@ -44,6 +45,8 @@ locals {
   iscsi_enabled = var.sbd_storage_type == "iscsi" && ((var.hana_count > 1 && var.hana_ha_enabled) || var.drbd_enabled || (local.netweaver_count > 1 && var.netweaver_ha_enabled)) && local.use_sbd ? true : false
 
   # Obtain machines os_image and os_owner values
+  bastion_os_image  = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
+  bastion_os_owner  = var.bastion_os_owner != "" ? var.bastion_os_owner : var.os_owner
   hana_os_image       = var.hana_os_image != "" ? var.hana_os_image : var.os_image
   hana_os_owner       = var.hana_os_owner != "" ? var.hana_os_owner : var.os_owner
   iscsi_os_image      = var.iscsi_os_image != "" ? var.iscsi_os_image : var.os_image
@@ -80,6 +83,9 @@ module "common_variables" {
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
   authorized_user                     = "ec2-user"
+  bastion_enabled                     = var.bastion_enabled
+  bastion_public_key                  = var.bastion_public_key
+  bastion_private_key                 = var.bastion_private_key
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
   provisioning_output_colored         = var.provisioning_output_colored
@@ -164,6 +170,7 @@ module "drbd_node" {
   common_variables      = module.common_variables.configuration
   name                  = var.drbd_name
   network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
+  bastion_host         = module.bastion.bastion_public_ip
   drbd_count            = var.drbd_enabled == true ? 2 : 0
   instance_type         = var.drbd_instancetype
   aws_region            = var.aws_region
@@ -174,7 +181,7 @@ module "drbd_node" {
   subnet_address_range  = local.drbd_subnet_address_range
   key_name              = aws_key_pair.key-pair.key_name
   security_group_id     = local.security_group_id
-  route_table_id        = aws_route_table.route-table.id
+  route_table_id        = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
   aws_credentials       = var.aws_credentials
   aws_access_key_id     = var.aws_access_key_id
   aws_secret_access_key = var.aws_secret_access_key
@@ -198,10 +205,11 @@ module "iscsi_server" {
   common_variables   = module.common_variables.configuration
   name               = var.iscsi_name
   network_domain     = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
+  bastion_host         = module.bastion.bastion_public_ip
   iscsi_count        = local.iscsi_enabled == true ? 1 : 0
   aws_region         = var.aws_region
   availability_zones = data.aws_availability_zones.available.names
-  subnet_ids         = aws_subnet.infra-subnet.*.id
+  subnet_ids         = aws_subnet.infra.*.id
   os_image           = local.iscsi_os_image
   os_owner           = local.iscsi_os_owner
   instance_type      = var.iscsi_instancetype
@@ -211,8 +219,7 @@ module "iscsi_server" {
   lun_count          = var.iscsi_lun_count
   iscsi_disk_size    = var.iscsi_disk_size
   on_destroy_dependencies = [
-    aws_route_table_association.infra-subnet-route-association,
-    aws_route.public,
+    aws_route_table_association.infra,
     aws_security_group_rule.ssh,
     aws_security_group_rule.outall
   ]
@@ -223,6 +230,7 @@ module "netweaver_node" {
   common_variables      = module.common_variables.configuration
   name                  = var.netweaver_name
   network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
+  bastion_host         = module.bastion.bastion_public_ip
   xscs_server_count     = local.netweaver_xscs_server_count
   app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
   instance_type         = var.netweaver_instancetype
@@ -234,7 +242,7 @@ module "netweaver_node" {
   subnet_address_range  = local.netweaver_subnet_address_range
   key_name              = aws_key_pair.key-pair.key_name
   security_group_id     = local.security_group_id
-  route_table_id        = aws_route_table.route-table.id
+  route_table_id        = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
   efs_performance_mode  = var.netweaver_efs_performance_mode
   aws_credentials       = var.aws_credentials
   aws_access_key_id     = var.aws_access_key_id
@@ -257,6 +265,7 @@ module "hana_node" {
   common_variables              = module.common_variables.configuration
   name                          = var.hana_name
   network_domain                = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
+  bastion_host         = module.bastion.bastion_public_ip
   hana_count                    = var.hana_count
   instance_type                 = var.hana_instancetype
   aws_region                    = var.aws_region
@@ -267,7 +276,7 @@ module "hana_node" {
   subnet_address_range          = local.hana_subnet_address_range
   key_name                      = aws_key_pair.key-pair.key_name
   security_group_id             = local.security_group_id
-  route_table_id                = aws_route_table.route-table.id
+  route_table_id        = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
   efs_performance_mode          = var.hana_efs_performance_mode
   aws_credentials               = var.aws_credentials
   aws_access_key_id             = var.aws_access_key_id
@@ -293,6 +302,7 @@ module "monitoring" {
   common_variables   = module.common_variables.configuration
   name               = var.monitoring_name
   network_domain     = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
+  bastion_host         = module.bastion.bastion_public_ip
   monitoring_enabled = var.monitoring_enabled
   instance_type      = var.monitor_instancetype
   key_name           = aws_key_pair.key-pair.key_name
@@ -302,11 +312,10 @@ module "monitoring" {
   availability_zones = data.aws_availability_zones.available.names
   os_image           = local.monitoring_os_image
   os_owner           = local.monitoring_os_owner
-  subnet_ids         = aws_subnet.infra-subnet.*.id
+  subnet_ids         = aws_subnet.infra.*.id
   timezone           = var.timezone
   on_destroy_dependencies = [
-    aws_route_table_association.infra-subnet-route-association,
-    aws_route.public,
+    aws_route_table_association.infra,
     aws_security_group_rule.ssh,
     aws_security_group_rule.outall
   ]

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -45,8 +45,8 @@ locals {
   iscsi_enabled = var.sbd_storage_type == "iscsi" && ((var.hana_count > 1 && var.hana_ha_enabled) || var.drbd_enabled || (local.netweaver_count > 1 && var.netweaver_ha_enabled)) && local.use_sbd ? true : false
 
   # Obtain machines os_image and os_owner values
-  bastion_os_image  = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
-  bastion_os_owner  = var.bastion_os_owner != "" ? var.bastion_os_owner : var.os_owner
+  bastion_os_image    = var.bastion_os_image != "" ? var.bastion_os_image : var.os_image
+  bastion_os_owner    = var.bastion_os_owner != "" ? var.bastion_os_owner : var.os_owner
   hana_os_image       = var.hana_os_image != "" ? var.hana_os_image : var.os_image
   hana_os_owner       = var.hana_os_owner != "" ? var.hana_os_owner : var.os_owner
   iscsi_os_image      = var.iscsi_os_image != "" ? var.iscsi_os_image : var.os_image
@@ -170,7 +170,7 @@ module "drbd_node" {
   common_variables      = module.common_variables.configuration
   name                  = var.drbd_name
   network_domain        = var.drbd_network_domain == "" ? var.network_domain : var.drbd_network_domain
-  bastion_host         = module.bastion.bastion_public_ip
+  bastion_host          = module.bastion.bastion_public_ip
   drbd_count            = var.drbd_enabled == true ? 2 : 0
   instance_type         = var.drbd_instancetype
   aws_region            = var.aws_region
@@ -205,7 +205,7 @@ module "iscsi_server" {
   common_variables   = module.common_variables.configuration
   name               = var.iscsi_name
   network_domain     = var.iscsi_network_domain == "" ? var.network_domain : var.iscsi_network_domain
-  bastion_host         = module.bastion.bastion_public_ip
+  bastion_host       = module.bastion.bastion_public_ip
   iscsi_count        = local.iscsi_enabled == true ? 1 : 0
   aws_region         = var.aws_region
   availability_zones = data.aws_availability_zones.available.names
@@ -230,7 +230,7 @@ module "netweaver_node" {
   common_variables      = module.common_variables.configuration
   name                  = var.netweaver_name
   network_domain        = var.netweaver_network_domain == "" ? var.network_domain : var.netweaver_network_domain
-  bastion_host         = module.bastion.bastion_public_ip
+  bastion_host          = module.bastion.bastion_public_ip
   xscs_server_count     = local.netweaver_xscs_server_count
   app_server_count      = var.netweaver_enabled ? var.netweaver_app_server_count : 0
   instance_type         = var.netweaver_instancetype
@@ -265,7 +265,7 @@ module "hana_node" {
   common_variables              = module.common_variables.configuration
   name                          = var.hana_name
   network_domain                = var.hana_network_domain == "" ? var.network_domain : var.hana_network_domain
-  bastion_host         = module.bastion.bastion_public_ip
+  bastion_host                  = module.bastion.bastion_public_ip
   hana_count                    = var.hana_count
   instance_type                 = var.hana_instancetype
   aws_region                    = var.aws_region
@@ -276,7 +276,7 @@ module "hana_node" {
   subnet_address_range          = local.hana_subnet_address_range
   key_name                      = aws_key_pair.key-pair.key_name
   security_group_id             = local.security_group_id
-  route_table_id        = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
+  route_table_id                = var.bastion_enabled ? aws_route_table.private.0.id : aws_route_table.public.id
   efs_performance_mode          = var.hana_efs_performance_mode
   aws_credentials               = var.aws_credentials
   aws_access_key_id             = var.aws_access_key_id
@@ -302,7 +302,7 @@ module "monitoring" {
   common_variables   = module.common_variables.configuration
   name               = var.monitoring_name
   network_domain     = var.monitoring_network_domain == "" ? var.network_domain : var.monitoring_network_domain
-  bastion_host         = module.bastion.bastion_public_ip
+  bastion_host       = module.bastion.bastion_public_ip
   monitoring_enabled = var.monitoring_enabled
   instance_type      = var.monitor_instancetype
   key_name           = aws_key_pair.key-pair.key_name

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -190,7 +190,7 @@ module "drbd_node" {
   drbd_data_disk_type   = var.drbd_data_disk_type
   cluster_ssh_pub       = var.cluster_ssh_pub
   cluster_ssh_key       = var.cluster_ssh_key
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip          = join("", module.iscsi_server.iscsi_ip)
   nfs_mounting_point    = var.drbd_nfs_mounting_point
   nfs_export_name       = var.netweaver_sid
   on_destroy_dependencies = [
@@ -250,7 +250,7 @@ module "netweaver_node" {
   s3_bucket             = var.netweaver_s3_bucket
   host_ips              = local.netweaver_ips
   virtual_host_ips      = local.netweaver_virtual_ips
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip          = join("", module.iscsi_server.iscsi_ip)
   cluster_ssh_pub       = var.cluster_ssh_pub
   cluster_ssh_key       = var.cluster_ssh_key
   on_destroy_dependencies = [
@@ -284,7 +284,7 @@ module "hana_node" {
   host_ips                      = local.hana_ips
   block_devices                 = var.block_devices
   hana_data_disks_configuration = var.hana_data_disks_configuration
-  iscsi_srv_ip                  = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                  = join("", module.iscsi_server.iscsi_ip)
   cluster_ssh_pub               = var.cluster_ssh_pub
   cluster_ssh_key               = var.cluster_ssh_key
   # passed to majority_maker module

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -82,7 +82,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "ec2-user"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/aws/modules/drbd_node/main.tf
+++ b/aws/modules/drbd_node/main.tf
@@ -2,7 +2,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.drbd.*.private_ip : aws_instance.drbd.*.public_ip
-  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 resource "aws_subnet" "drbd-subnet" {
@@ -83,13 +83,13 @@ resource "aws_instance" "drbd" {
 }
 
 module "drbd_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = var.drbd_count
-  instance_ids = aws_instance.drbd.*.id
-  user         = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = var.drbd_count
+  instance_ids        = aws_instance.drbd.*.id
+  user                = var.common_variables["authorized_user"]
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = local.provisioning_addresses
-  dependencies = var.on_destroy_dependencies
+  public_ips          = local.provisioning_addresses
+  dependencies        = var.on_destroy_dependencies
 }

--- a/aws/modules/drbd_node/main.tf
+++ b/aws/modules/drbd_node/main.tf
@@ -1,5 +1,7 @@
 # drbd resources
 locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? aws_instance.drbd.*.private_ip : aws_instance.drbd.*.public_ip
   hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -50,7 +52,7 @@ resource "aws_instance" "drbd" {
   ami                         = module.get_os_image.image_id
   instance_type               = var.instance_type
   key_name                    = var.key_name
-  associate_public_ip_address = true
+  associate_public_ip_address = local.bastion_enabled ? false : true
   subnet_id                   = element(aws_subnet.drbd-subnet.*.id, count.index)
   private_ip                  = element(var.host_ips, count.index)
   vpc_security_group_ids      = [var.security_group_id]
@@ -84,8 +86,10 @@ module "drbd_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.drbd_count
   instance_ids = aws_instance.drbd.*.id
-  user         = "ec2-user"
+  user         = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.drbd.*.public_ip
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
+  public_ips   = local.provisioning_addresses
   dependencies = var.on_destroy_dependencies
 }

--- a/aws/modules/drbd_node/outputs.tf
+++ b/aws/modules/drbd_node/outputs.tf
@@ -12,6 +12,10 @@ output "drbd_public_ip" {
 }
 
 output "drbd_name" {
+  value = data.aws_instance.drbd.*.tags.Name
+}
+
+output "drbd_id" {
   value = data.aws_instance.drbd.*.id
 }
 

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "drbd_provisioner" {
   }
 
   connection {
-    host        = element(aws_instance.drbd.*.public_ip, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "ec2-user"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -54,8 +58,10 @@ module "drbd_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
   instance_ids = null_resource.drbd_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.drbd.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/drbd_node/salt_provisioner.tf
+++ b/aws/modules/drbd_node/salt_provisioner.tf
@@ -55,13 +55,13 @@ EOF
 }
 
 module "drbd_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
-  instance_ids = null_resource.drbd_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" ? var.drbd_count : 0
+  instance_ids        = null_resource.drbd_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/drbd_node/variables.tf
+++ b/aws/modules/drbd_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -1,11 +1,11 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.hana.*.private_ip : aws_instance.hana.*.public_ip
-  create_scale_out   = var.hana_count > 1 && var.common_variables["hana"]["scale_out_enabled"] ? 1 : 0
-  create_ha_infra    = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
-  hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
-  shared_storage_efs = var.common_variables["hana"]["scale_out_shared_storage_type"] == "efs" ? 1 : 0
-  sites              = local.create_ha_infra == 1 ? 2 : 1
+  create_scale_out       = var.hana_count > 1 && var.common_variables["hana"]["scale_out_enabled"] ? 1 : 0
+  create_ha_infra        = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  shared_storage_efs     = var.common_variables["hana"]["scale_out_shared_storage_type"] == "efs" ? 1 : 0
+  sites                  = local.create_ha_infra == 1 ? 2 : 1
 
   disks_number = length(split(",", var.hana_data_disks_configuration["disks_size"]))
   disks_size   = [for disk_size in split(",", var.hana_data_disks_configuration["disks_size"]) : tonumber(trimspace(disk_size))]
@@ -161,14 +161,14 @@ module "hana_majority_maker" {
 }
 
 module "hana_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = var.hana_count
-  instance_ids = aws_instance.hana.*.id
-  user         = "ec2-user"
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = var.hana_count
+  instance_ids        = aws_instance.hana.*.id
+  user                = "ec2-user"
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = aws_instance.hana.*.public_ip
+  public_ips          = aws_instance.hana.*.public_ip
   dependencies = concat(
     [aws_route_table_association.hana],
     var.on_destroy_dependencies

--- a/aws/modules/hana_node/main.tf
+++ b/aws/modules/hana_node/main.tf
@@ -1,4 +1,6 @@
 locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? aws_instance.hana.*.private_ip : aws_instance.hana.*.public_ip
   create_scale_out   = var.hana_count > 1 && var.common_variables["hana"]["scale_out_enabled"] ? 1 : 0
   create_ha_infra    = var.hana_count > 1 && var.common_variables["hana"]["ha_enabled"] ? 1 : 0
   hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
@@ -25,11 +27,11 @@ locals {
 
 # Network resources: subnets, routes, etc
 
-resource "aws_subnet" "hana-subnet" {
+resource "aws_subnet" "hana" {
   count             = local.sites
   vpc_id            = var.vpc_id
   cidr_block        = element(var.subnet_address_range, count.index)
-  availability_zone = element(var.availability_zones, count.index)
+  availability_zone = element(var.availability_zones, count.index % 2)
 
   tags = {
     Name      = "${var.common_variables["deployment_name"]}-hana-subnet-${count.index + 1}"
@@ -37,9 +39,9 @@ resource "aws_subnet" "hana-subnet" {
   }
 }
 
-resource "aws_route_table_association" "hana-subnet-route-association" {
+resource "aws_route_table_association" "hana" {
   count          = local.sites
-  subnet_id      = element(aws_subnet.hana-subnet.*.id, count.index)
+  subnet_id      = element(aws_subnet.hana.*.id, count.index)
   route_table_id = var.route_table_id
 }
 
@@ -71,7 +73,7 @@ resource "aws_efs_file_system" "scale-out-efs-shared" {
 resource "aws_efs_mount_target" "scale-out-efs-mount-target" {
   count           = local.create_scale_out == 1 && local.shared_storage_efs == 1 ? local.sites : 0
   file_system_id  = aws_efs_file_system.scale-out-efs-shared[count.index].id
-  subnet_id       = element(aws_subnet.hana-subnet.*.id, count.index)
+  subnet_id       = element(aws_subnet.hana.*.id, count.index)
   security_groups = [var.security_group_id]
 }
 
@@ -97,8 +99,8 @@ resource "aws_instance" "hana" {
   ami                         = module.get_os_image.image_id
   instance_type               = var.instance_type
   key_name                    = var.key_name
-  associate_public_ip_address = true
-  subnet_id                   = element(aws_subnet.hana-subnet.*.id, count.index % 2)
+  associate_public_ip_address = local.bastion_enabled ? false : true
+  subnet_id                   = element(aws_subnet.hana.*.id, count.index % 2)
   private_ip                  = element(var.host_ips, count.index)
   vpc_security_group_ids      = [var.security_group_id]
   availability_zone           = element(var.availability_zones, count.index % 2)
@@ -164,9 +166,11 @@ module "hana_on_destroy" {
   instance_ids = aws_instance.hana.*.id
   user         = "ec2-user"
   private_key  = var.common_variables["private_key"]
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   public_ips   = aws_instance.hana.*.public_ip
   dependencies = concat(
-    [aws_route_table_association.hana-subnet-route-association],
+    [aws_route_table_association.hana],
     var.on_destroy_dependencies
   )
 }

--- a/aws/modules/hana_node/outputs.tf
+++ b/aws/modules/hana_node/outputs.tf
@@ -3,19 +3,19 @@ data "aws_instance" "hana" {
   instance_id = element(aws_instance.hana.*.id, count.index)
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = data.aws_instance.hana.*.private_ip
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = data.aws_instance.hana.*.public_ip
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = data.aws_instance.hana.*.id
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = data.aws_instance.hana.*.public_dns
 }
 
@@ -23,14 +23,14 @@ output "majority_maker_ip" {
   value = module.hana_majority_maker.majority_maker_ip
 }
 
-output "majority_maker_public_ip" {
-  value = module.hana_majority_maker.majority_maker_public_ip
+output "hana_majority_maker_public_ip" {
+  value = module.hana_majority_maker.hana_majority_maker_public_ip
 }
 
-output "majority_maker_name" {
-  value = module.hana_majority_maker.majority_maker_name
+output "hana_majority_maker_name" {
+  value = module.hana_majority_maker.hana_majority_maker_name
 }
 
-output "majority_maker_public_name" {
-  value = module.hana_majority_maker.majority_maker_public_name
+output "hana_majority_maker_public_name" {
+  value = module.hana_majority_maker.hana_majority_maker_public_name
 }

--- a/aws/modules/hana_node/outputs.tf
+++ b/aws/modules/hana_node/outputs.tf
@@ -12,6 +12,10 @@ output "hana_public_ip" {
 }
 
 output "hana_name" {
+  value = data.aws_instance.hana.*.tags.Name
+}
+
+output "hana_id" {
   value = data.aws_instance.hana.*.id
 }
 
@@ -29,6 +33,10 @@ output "hana_majority_maker_public_ip" {
 
 output "hana_majority_maker_name" {
   value = module.hana_majority_maker.hana_majority_maker_name
+}
+
+output "hana_majority_maker_id" {
+  value = module.hana_majority_maker.hana_majority_maker_id
 }
 
 output "hana_majority_maker_public_name" {

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -53,13 +53,13 @@ EOF
 }
 
 module "hana_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
-  instance_ids = null_resource.hana_node_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
+  instance_ids        = null_resource.hana_node_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/hana_node/salt_provisioner.tf
+++ b/aws/modules/hana_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "hana_node_provisioner" {
   }
 
   connection {
-    host        = element(aws_instance.hana.*.public_ip, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
     user        = "ec2-user"
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -52,8 +56,10 @@ module "hana_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" ? var.hana_count : 0
   instance_ids = null_resource.hana_node_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.hana.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/hana_node/variables.tf
+++ b/aws/modules/hana_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string

--- a/aws/modules/iscsi_server/main.tf
+++ b/aws/modules/iscsi_server/main.tf
@@ -3,7 +3,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.iscsisrv.*.private_ip : aws_instance.iscsisrv.*.public_ip
-  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 module "get_os_image" {
@@ -45,13 +45,13 @@ resource "aws_instance" "iscsisrv" {
 }
 
 module "iscsi_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = var.iscsi_count
-  instance_ids = aws_instance.iscsisrv.*.id
-  user         = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = var.iscsi_count
+  instance_ids        = aws_instance.iscsisrv.*.id
+  user                = var.common_variables["authorized_user"]
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = local.provisioning_addresses
-  dependencies = var.on_destroy_dependencies
+  public_ips          = local.provisioning_addresses
+  dependencies        = var.on_destroy_dependencies
 }

--- a/aws/modules/iscsi_server/outputs.tf
+++ b/aws/modules/iscsi_server/outputs.tf
@@ -3,18 +3,18 @@ data "aws_instance" "iscsisrv" {
   instance_id = element(aws_instance.iscsisrv.*.id, count.index)
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = data.aws_instance.iscsisrv.*.private_ip
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = data.aws_instance.iscsisrv.*.public_ip
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = data.aws_instance.iscsisrv.*.id
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = data.aws_instance.iscsisrv.*.public_dns
 }

--- a/aws/modules/iscsi_server/outputs.tf
+++ b/aws/modules/iscsi_server/outputs.tf
@@ -12,6 +12,10 @@ output "iscsi_public_ip" {
 }
 
 output "iscsi_name" {
+  value = data.aws_instance.iscsisrv.*.tags.Name
+}
+
+output "iscsi_id" {
   value = data.aws_instance.iscsisrv.*.id
 }
 

--- a/aws/modules/iscsi_server/salt_provisioner.tf
+++ b/aws/modules/iscsi_server/salt_provisioner.tf
@@ -41,13 +41,13 @@ destination = "/tmp/grains"
 }
 
 module "iscsi_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" ? var.iscsi_count : 0
-  instance_ids = null_resource.iscsi_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" ? var.iscsi_count : 0
+  instance_ids        = null_resource.iscsi_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/iscsi_server/salt_provisioner.tf
+++ b/aws/modules/iscsi_server/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "iscsi_provisioner" {
   }
 
   connection {
-    host        = element(aws_instance.iscsisrv.*.public_ip, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "ec2-user"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -40,8 +44,10 @@ module "iscsi_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" ? var.iscsi_count : 0
   instance_ids = null_resource.iscsi_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.iscsisrv.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/iscsi_server/variables.tf
+++ b/aws/modules/iscsi_server/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "aws_region" {
   type        = string
   description = "AWS region where the deployment machines will be created"

--- a/aws/modules/majority_maker_node/main.tf
+++ b/aws/modules/majority_maker_node/main.tf
@@ -1,7 +1,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.majority_maker.*.private_ip : aws_instance.majority_maker.*.public_ip
-  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 # Network resources: subnets, routes, etc
@@ -61,14 +61,14 @@ resource "aws_instance" "majority_maker" {
 }
 
 module "majority_maker_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = var.node_count
-  instance_ids = aws_instance.majority_maker.*.id
-  user         = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = var.node_count
+  instance_ids        = aws_instance.majority_maker.*.id
+  user                = var.common_variables["authorized_user"]
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = local.provisioning_addresses
+  public_ips          = local.provisioning_addresses
   dependencies = concat(
     [aws_route_table_association.majority_maker-subnet-route-association],
     var.on_destroy_dependencies

--- a/aws/modules/majority_maker_node/main.tf
+++ b/aws/modules/majority_maker_node/main.tf
@@ -1,4 +1,6 @@
 locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? aws_instance.majority_maker.*.private_ip : aws_instance.majority_maker.*.public_ip
   hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -34,7 +36,7 @@ resource "aws_instance" "majority_maker" {
   ami                         = module.get_os_image.image_id
   instance_type               = var.instance_type
   key_name                    = var.key_name
-  associate_public_ip_address = true
+  associate_public_ip_address = local.bastion_enabled ? false : true
   subnet_id                   = element(aws_subnet.majority_maker-subnet.*.id, count.index)
   private_ip                  = var.majority_maker_ip
   vpc_security_group_ids      = [var.security_group_id]
@@ -62,9 +64,11 @@ module "majority_maker_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.node_count
   instance_ids = aws_instance.majority_maker.*.id
-  user         = "ec2-user"
+  user         = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.majority_maker.*.public_ip
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
+  public_ips   = local.provisioning_addresses
   dependencies = concat(
     [aws_route_table_association.majority_maker-subnet-route-association],
     var.on_destroy_dependencies

--- a/aws/modules/majority_maker_node/outputs.tf
+++ b/aws/modules/majority_maker_node/outputs.tf
@@ -7,14 +7,14 @@ output "majority_maker_ip" {
   value = data.aws_instance.majority_maker.*.private_ip
 }
 
-output "majority_maker_public_ip" {
+output "hana_majority_maker_public_ip" {
   value = data.aws_instance.majority_maker.*.public_ip
 }
 
-output "majority_maker_name" {
+output "hana_majority_maker_name" {
   value = data.aws_instance.majority_maker.*.id
 }
 
-output "majority_maker_public_name" {
+output "hana_majority_maker_public_name" {
   value = data.aws_instance.majority_maker.*.public_dns
 }

--- a/aws/modules/majority_maker_node/outputs.tf
+++ b/aws/modules/majority_maker_node/outputs.tf
@@ -12,6 +12,10 @@ output "hana_majority_maker_public_ip" {
 }
 
 output "hana_majority_maker_name" {
+  value = data.aws_instance.majority_maker.*.tags.Name
+}
+
+output "hana_majority_maker_id" {
   value = data.aws_instance.majority_maker.*.id
 }
 

--- a/aws/modules/majority_maker_node/salt_provisioner.tf
+++ b/aws/modules/majority_maker_node/salt_provisioner.tf
@@ -50,13 +50,13 @@ EOF
 }
 
 module "majority_maker_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" ? var.node_count : 0
-  instance_ids = null_resource.majority_maker_node_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" ? var.node_count : 0
+  instance_ids        = null_resource.majority_maker_node_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/majority_maker_node/salt_provisioner.tf
+++ b/aws/modules/majority_maker_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "majority_maker_node_provisioner" {
   }
 
   connection {
-    host        = element(aws_instance.majority_maker.*.public_ip, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "ec2-user"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -49,8 +53,10 @@ module "majority_maker_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" ? var.node_count : 0
   instance_ids = null_resource.majority_maker_node_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.majority_maker.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/majority_maker_node/variables.tf
+++ b/aws/modules/majority_maker_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "name" {
   description = "hostname, without the domain part"
   type        = string

--- a/aws/modules/monitoring/main.tf
+++ b/aws/modules/monitoring/main.tf
@@ -1,4 +1,6 @@
 locals {
+  bastion_enabled        = var.common_variables["bastion_enabled"]
+  provisioning_addresses = local.bastion_enabled ? aws_instance.monitoring.*.private_ip : aws_instance.monitoring.*.public_ip
   hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
@@ -13,7 +15,7 @@ resource "aws_instance" "monitoring" {
   ami                         = module.get_os_image.image_id
   instance_type               = var.instance_type
   key_name                    = var.key_name
-  associate_public_ip_address = true
+  associate_public_ip_address = local.bastion_enabled ? false : true
   subnet_id                   = element(var.subnet_ids, 0)
   private_ip                  = var.monitoring_srv_ip
   vpc_security_group_ids      = [var.security_group_id]
@@ -44,8 +46,10 @@ module "monitoring_on_destroy" {
   source       = "../../../generic_modules/on_destroy"
   node_count   = var.monitoring_enabled ? 1 : 0
   instance_ids = aws_instance.monitoring.*.id
-  user         = "ec2-user"
+  user         = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.monitoring.*.public_ip
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
+  public_ips   = local.provisioning_addresses
   dependencies = var.on_destroy_dependencies
 }

--- a/aws/modules/monitoring/main.tf
+++ b/aws/modules/monitoring/main.tf
@@ -1,7 +1,7 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.monitoring.*.private_ip : aws_instance.monitoring.*.public_ip
-  hostname = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
 }
 
 module "get_os_image" {
@@ -43,13 +43,13 @@ resource "aws_instance" "monitoring" {
 }
 
 module "monitoring_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = var.monitoring_enabled ? 1 : 0
-  instance_ids = aws_instance.monitoring.*.id
-  user         = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = var.monitoring_enabled ? 1 : 0
+  instance_ids        = aws_instance.monitoring.*.id
+  user                = var.common_variables["authorized_user"]
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = local.provisioning_addresses
-  dependencies = var.on_destroy_dependencies
+  public_ips          = local.provisioning_addresses
+  dependencies        = var.on_destroy_dependencies
 }

--- a/aws/modules/monitoring/outputs.tf
+++ b/aws/modules/monitoring/outputs.tf
@@ -12,6 +12,10 @@ output "monitoring_public_ip" {
 }
 
 output "monitoring_name" {
+  value = join("", data.aws_instance.monitoring.*.tags.Name)
+}
+
+output "monitoring_id" {
   value = join("", data.aws_instance.monitoring.*.id)
 }
 

--- a/aws/modules/monitoring/salt_provisioner.tf
+++ b/aws/modules/monitoring/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "monitoring_provisioner" {
   }
 
   connection {
-    host        = aws_instance.monitoring.0.public_ip
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "ec2-user"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -23,7 +27,7 @@ hostname: ${local.hostname}
 network_domain: ${var.network_domain}
 timezone: ${var.timezone}
 host_ip: ${var.monitoring_srv_ip}
-public_ip: ${aws_instance.monitoring[0].public_ip}
+public_ip: ${element(local.provisioning_addresses, count.index)}
 EOF
 
     destination = "/tmp/grains"
@@ -34,8 +38,10 @@ module "monitoring_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
   instance_ids = null_resource.monitoring_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.monitoring.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/monitoring/salt_provisioner.tf
+++ b/aws/modules/monitoring/salt_provisioner.tf
@@ -35,13 +35,13 @@ EOF
 }
 
 module "monitoring_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
-  instance_ids = null_resource.monitoring_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" && var.monitoring_enabled ? 1 : 0
+  instance_ids        = null_resource.monitoring_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/monitoring/variables.tf
+++ b/aws/modules/monitoring/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "monitoring_enabled" {
   description = "enable the host to be monitored by exporters, e.g node_exporter"
   type        = bool

--- a/aws/modules/netweaver_node/main.tf
+++ b/aws/modules/netweaver_node/main.tf
@@ -1,11 +1,11 @@
 locals {
   bastion_enabled        = var.common_variables["bastion_enabled"]
   provisioning_addresses = local.bastion_enabled ? aws_instance.netweaver.*.private_ip : aws_instance.netweaver.*.public_ip
-  vm_count           = var.xscs_server_count + var.app_server_count
-  create_ha_infra    = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
-  app_start_index    = local.create_ha_infra == 1 ? 2 : 1
-  hostname           = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
-  shared_storage_efs = var.common_variables["netweaver"]["shared_storage_type"] == "efs" ? 1 : 0
+  vm_count               = var.xscs_server_count + var.app_server_count
+  create_ha_infra        = local.vm_count > 1 && var.common_variables["netweaver"]["ha_enabled"] ? 1 : 0
+  app_start_index        = local.create_ha_infra == 1 ? 2 : 1
+  hostname               = var.common_variables["deployment_name_in_hostname"] ? format("%s-%s", var.common_variables["deployment_name"], var.name) : var.name
+  shared_storage_efs     = var.common_variables["netweaver"]["shared_storage_type"] == "efs" ? 1 : 0
 }
 
 # Network resources: subnets, routes, etc
@@ -130,14 +130,14 @@ resource "aws_instance" "netweaver" {
 }
 
 module "netweaver_on_destroy" {
-  source       = "../../../generic_modules/on_destroy"
-  node_count   = local.vm_count
-  instance_ids = aws_instance.netweaver.*.id
-  user         = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
+  source              = "../../../generic_modules/on_destroy"
+  node_count          = local.vm_count
+  instance_ids        = aws_instance.netweaver.*.id
+  user                = var.common_variables["authorized_user"]
+  private_key         = var.common_variables["private_key"]
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  public_ips   = local.provisioning_addresses
+  public_ips          = local.provisioning_addresses
   dependencies = concat(
     [aws_route_table_association.netweaver],
     var.on_destroy_dependencies

--- a/aws/modules/netweaver_node/outputs.tf
+++ b/aws/modules/netweaver_node/outputs.tf
@@ -12,6 +12,10 @@ output "netweaver_public_ip" {
 }
 
 output "netweaver_name" {
+  value = data.aws_instance.netweaver.*.tags.Name
+}
+
+output "netweaver_id" {
   value = data.aws_instance.netweaver.*.id
 }
 

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -6,10 +6,14 @@ resource "null_resource" "netweaver_provisioner" {
   }
 
   connection {
-    host        = element(aws_instance.netweaver.*.public_ip, count.index)
+    host        = element(local.provisioning_addresses, count.index)
     type        = "ssh"
-    user        = "ec2-user"
+    user        = var.common_variables["authorized_user"]
     private_key = var.common_variables["private_key"]
+
+    bastion_host        = var.bastion_host
+    bastion_user        = var.common_variables["authorized_user"]
+    bastion_private_key = var.common_variables["bastion_private_key"]
   }
 
   provisioner "file" {
@@ -53,8 +57,10 @@ module "netweaver_provision" {
   source       = "../../../generic_modules/salt_provisioner"
   node_count   = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
   instance_ids = null_resource.netweaver_provisioner.*.id
-  user         = "ec2-user"
+  user                = var.common_variables["authorized_user"]
   private_key  = var.common_variables["private_key"]
-  public_ips   = aws_instance.netweaver.*.public_ip
+  public_ips   = local.provisioning_addresses
+  bastion_host        = var.bastion_host
+  bastion_private_key = var.common_variables["bastion_private_key"]
   background   = var.common_variables["background"]
 }

--- a/aws/modules/netweaver_node/salt_provisioner.tf
+++ b/aws/modules/netweaver_node/salt_provisioner.tf
@@ -54,13 +54,13 @@ efs_mount_ip:
 }
 
 module "netweaver_provision" {
-  source       = "../../../generic_modules/salt_provisioner"
-  node_count   = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
-  instance_ids = null_resource.netweaver_provisioner.*.id
+  source              = "../../../generic_modules/salt_provisioner"
+  node_count          = var.common_variables["provisioner"] == "salt" ? local.vm_count : 0
+  instance_ids        = null_resource.netweaver_provisioner.*.id
   user                = var.common_variables["authorized_user"]
-  private_key  = var.common_variables["private_key"]
-  public_ips   = local.provisioning_addresses
+  private_key         = var.common_variables["private_key"]
+  public_ips          = local.provisioning_addresses
   bastion_host        = var.bastion_host
   bastion_private_key = var.common_variables["bastion_private_key"]
-  background   = var.common_variables["background"]
+  background          = var.common_variables["background"]
 }

--- a/aws/modules/netweaver_node/variables.tf
+++ b/aws/modules/netweaver_node/variables.tf
@@ -2,6 +2,12 @@ variable "common_variables" {
   description = "Output of the common_variables module"
 }
 
+variable "bastion_host" {
+  description = "Bastion host address"
+  type        = string
+  default     = ""
+}
+
 variable "xscs_server_count" {
   type    = number
   default = 2

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -6,36 +6,36 @@
 
 # Cluster nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
-  value = module.hana_node.cluster_nodes_public_name
+output "hana_public_name" {
+  value = module.hana_node.hana_public_name
 }
 
-output "majority_maker_ip" {
+output "hana_majority_maker_ip" {
   value = module.hana_node.majority_maker_ip
 }
 
-output "majority_maker_public_ip" {
-  value = module.hana_node.majority_maker_public_ip
+output "hana_majority_maker_public_ip" {
+  value = module.hana_node.hana_majority_maker_public_ip
 }
 
-output "majority_maker_name" {
-  value = module.hana_node.majority_maker_name
+output "hana_majority_maker_name" {
+  value = module.hana_node.hana_majority_maker_name
 }
 
-output "majority_maker_public_name" {
-  value = module.hana_node.majority_maker_public_name
+output "hana_majority_maker_public_name" {
+  value = module.hana_node.hana_majority_maker_public_name
 }
 
 # Monitoring
@@ -76,20 +76,20 @@ output "netweaver_public_name" {
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = join("", module.iscsi_server.iscsisrv_ip)
+output "iscsi_ip" {
+  value = join("", module.iscsi_server.iscsi_ip)
 }
 
-output "iscsisrv_public_ip" {
-  value = join("", module.iscsi_server.iscsisrv_public_ip)
+output "iscsi_public_ip" {
+  value = join("", module.iscsi_server.iscsi_public_ip)
 }
 
-output "iscsisrv_name" {
-  value = join("", module.iscsi_server.iscsisrv_name)
+output "iscsi_name" {
+  value = join("", module.iscsi_server.iscsi_name)
 }
 
-output "iscsisrv_public_name" {
-  value = join("", module.iscsi_server.iscsisrv_public_name)
+output "iscsi_public_name" {
+  value = join("", module.iscsi_server.iscsi_public_name)
 }
 
 # DRBD

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -18,6 +18,10 @@ output "hana_name" {
   value = module.hana_node.hana_name
 }
 
+output "hana_id" {
+  value = module.hana_node.hana_id
+}
+
 output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
@@ -38,6 +42,10 @@ output "hana_majority_maker_name" {
   value = module.hana_node.hana_majority_maker_name
 }
 
+output "hana_majority_maker_id" {
+  value = module.hana_node.hana_majority_maker_id
+}
+
 output "hana_majority_maker_public_name" {
   value = module.hana_node.hana_majority_maker_public_name
 }
@@ -56,6 +64,10 @@ output "monitoring_name" {
   value = module.monitoring.monitoring_name
 }
 
+output "monitoring_id" {
+  value = module.monitoring.monitoring_id
+}
+
 output "monitoring_public_name" {
   value = module.monitoring.monitoring_public_name
 }
@@ -72,6 +84,10 @@ output "netweaver_public_ip" {
 
 output "netweaver_name" {
   value = module.netweaver_node.netweaver_name
+}
+
+output "netweaver_id" {
+  value = module.netweaver_node.netweaver_id
 }
 
 output "netweaver_public_name" {
@@ -96,6 +112,10 @@ output "iscsi_name" {
   value = join("", module.iscsi_server.iscsi_name)
 }
 
+output "iscsi_id" {
+  value = join("", module.iscsi_server.iscsi_id)
+}
+
 output "iscsi_public_name" {
   value = join("", module.iscsi_server.iscsi_public_name)
 }
@@ -112,6 +132,10 @@ output "drbd_public_ip" {
 
 output "drbd_name" {
   value = module.drbd_node.drbd_name
+}
+
+output "drbd_id" {
+  value = module.drbd_node.drbd_id
 }
 
 output "drbd_public_name" {
@@ -134,6 +158,10 @@ output "bastion_public_ip" {
 
 output "bastion_name" {
   value = module.bastion.bastion_name
+}
+
+output "bastion_id" {
+  value = module.bastion.bastion_id
 }
 
 output "bastion_public_name" {

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -22,6 +22,10 @@ output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 output "hana_majority_maker_ip" {
   value = module.hana_node.majority_maker_ip
 }
@@ -74,6 +78,10 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # iSCSI server
 
 output "iscsi_ip" {
@@ -110,6 +118,10 @@ output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
 }
 
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
+}
+
 # bastion
 
 output "bastion_ip" {
@@ -126,4 +138,26 @@ output "bastion_name" {
 
 output "bastion_public_name" {
   value = module.bastion.bastion_public_name
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -109,3 +109,21 @@ output "drbd_name" {
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
 }
+
+# bastion
+
+output "bastion_ip" {
+  value = module.bastion.bastion_ip
+}
+
+output "bastion_public_ip" {
+  value = module.bastion.bastion_public_ip
+}
+
+output "bastion_name" {
+  value = module.bastion.bastion_name
+}
+
+output "bastion_public_name" {
+  value = module.bastion.bastion_public_name
+}

--- a/aws/terraform.tfvars.example
+++ b/aws/terraform.tfvars.example
@@ -134,6 +134,22 @@ cluster_ssh_key = "salt://sshkeys/cluster.id_rsa"
 # true or false (default)
 #hwcct = false
 
+##########################
+# Bastion (jumpbox) machine variables
+##########################
+
+# Enable bastion usage. If this option is enabled, it will create a unique public ip address that is attached to the bastion machine.
+# The rest of the machines won't have a public ip address and the SSH connection must be done through the bastion
+#bastion_enabled = false
+
+# Bastion SSH keys. If they are not set the public_key and private_key are used
+#bastion_public_key  = "/home/myuser/.ssh/id_rsa_bastion.pub"
+#bastion_private_key = "/home/myuser/.ssh/id_rsa_bastion"
+
+# bastion server image. By default, PAYG image is used. The usage is the same as the HANA images
+#bastion_os_image = "suse-sles-sap-15-sp1-byos"
+#bastion_os_owner = "amazon"
+
 #########################
 # HANA machines variables
 #########################

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -295,7 +295,7 @@ variable "hana_os_owner" {
 variable "hana_instancetype" {
   description = "The instance type of the hana nodes"
   type        = string
-  default     = "r6i.xlarge"
+  default     = "r5b.xlarge"
 }
 
 variable "hana_majority_maker_instancetype" {
@@ -773,7 +773,7 @@ variable "monitoring_os_owner" {
 variable "monitor_instancetype" {
   description = "The instance type of the monitoring node."
   type        = string
-  default     = "t3.micro"
+  default     = "t3.small"
 }
 
 variable "monitoring_srv_ip" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -87,6 +87,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "ec2-user"
+}
+
 # Deployment variables
 
 variable "deployment_name" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -59,6 +59,12 @@ variable "virtual_address_range" {
   }
 }
 
+variable "public_subnet_address_range" {
+  description = "Address range to create the subnet for the public services (bastion) machines. If not given the addresses will be generated based on vpc_address_range"
+  type        = string
+  default     = ""
+}
+
 variable "infra_subnet_address_range" {
   description = "Address range to create the subnet for the infrastructure (iscsi, monitoring, etc) machines. If not given the addresses will be generated based on vpc_address_range"
   type        = string
@@ -212,6 +218,68 @@ variable "hana_count" {
   default     = 2
 }
 
+## Bastion variables
+variable "bastion_enabled" {
+  description = "Create a VM to work as a bastion to avoid the usage of public ip addresses and manage the ssh connection to the other machines"
+  type        = bool
+  default     = true
+}
+
+variable "bastion_name" {
+  description = "hostname, without the domain part"
+  type        = string
+  default     = "vmbastion"
+}
+
+variable "bastion_network_domain" {
+  description = "hostname's network domain"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_os_image" {
+  description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp1-byos)"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_os_owner" {
+  description = "OS image owner. For BYOS images the owner usually is 'amazon'"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_instancetype" {
+  description = "The instance type of the bastion server node."
+  type        = string
+  default     = "t3.small"
+}
+
+variable "bastion_ip" {
+  description = "bastion server address. It should be in same iprange as host_ips"
+  type        = string
+  default     = ""
+  validation {
+    condition = (
+      var.bastion_ip == "" || can(regex("^(?:[0-9]{1,3}\\.){3}[0-9]{1,3}$", var.bastion_ip))
+    )
+    error_message = "Invalid IP address format."
+  }
+}
+
+variable "bastion_public_key" {
+  description = "Content of a SSH public key or path to an already existing SSH public key to the bastion. If it's not set the key provided in public_key will be used"
+  type        = string
+  default     = ""
+}
+
+variable "bastion_private_key" {
+  description = "Content of a SSH private key or path to an already existing SSH private key to the bastion. If it's not set the key provided in private_key will be used"
+  type        = string
+  default     = ""
+}
+
+## Hana variables
 variable "hana_os_image" {
   description = "sles4sap AMI image identifier or a pattern used to find the image name (e.g. suse-sles-sap-15-sp3-byos)"
   type        = string

--- a/azure/README.md
+++ b/azure/README.md
@@ -178,6 +178,7 @@ Example based on `10.74.0.0/16` vnet address range and `10.74.0.0/24` subnet add
 
 | Service                          | Variable                     | Addresses                                                  | Comments                                                                                               |
 | ----                             | --------                     | ---------                                                  | --------                                                                                               |
+| Bastion                          | -                            | `10.74.2.5`                                         |                                                                                                        |
 | iSCSI server                     | `iscsi_srv_ip`               | `10.74.0.4`                                                |                                                                                                        |
 | Monitoring                       | `monitoring_srv_ip`          | `10.74.0.5`                                                |                                                                                                        |
 | HANA ips                         | `hana_ips`                   | `10.74.0.10`, `10.74.0.11`                                 |                                                                                                        |

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -173,7 +173,7 @@ module "drbd_node" {
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
   host_ips            = local.drbd_ips
-  iscsi_srv_ip        = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip        = join("", module.iscsi_server.iscsi_ip)
   nfs_mounting_point  = var.drbd_nfs_mounting_point
   nfs_export_name     = var.netweaver_sid
   # only used by azure fence agent (native fencing)
@@ -214,7 +214,7 @@ module "netweaver_node" {
   storage_account_path        = var.netweaver_storage_account
   host_ips                    = local.netweaver_ips
   virtual_host_ips            = local.netweaver_virtual_ips
-  iscsi_srv_ip                = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                = join("", module.iscsi_server.iscsi_ip)
   # ANF specific
   anf_account_name           = local.anf_account_name
   anf_pool_name              = local.anf_pool_name
@@ -250,7 +250,7 @@ module "hana_node" {
   cluster_ssh_key               = var.cluster_ssh_key
   hana_data_disks_configuration = var.hana_data_disks_configuration
   os_image                      = local.hana_os_image
-  iscsi_srv_ip                  = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                  = join("", module.iscsi_server.iscsi_ip)
   # ANF specific
   anf_account_name                = local.anf_account_name
   anf_pool_name                   = local.anf_pool_name

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "hana" {
   depends_on = [azurerm_virtual_machine.hana]
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = [data.azurerm_network_interface.hana.*.private_ip_address]
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = [data.azurerm_public_ip.hana.*.ip_address]
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = [azurerm_virtual_machine.hana.*.name]
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = [data.azurerm_public_ip.hana.*.fqdn]
 }

--- a/azure/modules/iscsi_server/outputs.tf
+++ b/azure/modules/iscsi_server/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "iscsisrv" {
   depends_on = [azurerm_virtual_machine.iscsisrv]
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = data.azurerm_network_interface.iscsisrv.*.private_ip_address
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = data.azurerm_public_ip.iscsisrv.*.ip_address
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = azurerm_virtual_machine.iscsisrv.*.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = data.azurerm_public_ip.iscsisrv.*.fqdn
 }

--- a/azure/modules/majority_maker_node/outputs.tf
+++ b/azure/modules/majority_maker_node/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "majority_maker" {
   depends_on = [azurerm_virtual_machine.majority_maker]
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = [data.azurerm_network_interface.majority_maker.*.private_ip_address]
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = [data.azurerm_public_ip.majority_maker.*.ip_address]
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = [azurerm_virtual_machine.majority_maker.*.name]
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = [data.azurerm_public_ip.majority_maker.*.fqdn]
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -58,6 +58,10 @@ output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # drbd
 
 output "drbd_ip" {
@@ -74,6 +78,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 # netweaver
@@ -94,8 +102,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -6,20 +6,20 @@
 
 # iSCSI server
 
-output "iscsi_srv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
-  value = module.iscsi_server.iscsisrv_public_name
+output "iscsi_public_name" {
+  value = module.iscsi_server.iscsi_public_name
 }
 
 # Monitoring
@@ -42,20 +42,20 @@ output "monitoring_public_name" {
 
 # Hana nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
-  value = module.hana_node.cluster_nodes_public_name
+output "hana_public_name" {
+  value = module.hana_node.hana_public_name
 }
 
 # drbd

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -66,11 +66,6 @@ variable "subnet_netapp_address_range" {
   }
 }
 
-variable "admin_user" {
-  description = "Administration user used to create the machines"
-  type        = string
-}
-
 variable "storage_account_name" {
   description = "Azure storage account name where HANA installation software is available"
   type        = string
@@ -95,6 +90,12 @@ variable "authorized_keys" {
   description = "List of additional authorized SSH public keys content or path to already existing SSH public keys to access the created machines with the used admin user (admin_user variable in this case)"
   type        = list(string)
   default     = []
+}
+
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "sles"
 }
 
 variable "bastion_name" {

--- a/gcp/README.md
+++ b/gcp/README.md
@@ -167,9 +167,9 @@ Example based on `10.0.0.0/24` VPC address range. The virtual addresses must be 
 
 | Service                          | Variable                     | Addresses                                          | Comments                                                                                               |
 | ----                             | --------                     | ---------                                          | --------                                                                                               |
+| Bastion                          | -                            | `10.0.2.5`                                         |                                                                                                        |
 | iSCSI server                     | `iscsi_srv_ip`               | `10.0.0.4`                                         |                                                                                                        |
 | Monitoring                       | `monitoring_srv_ip`          | `10.0.0.5`                                         |                                                                                                        |
-| Bastion                          | -                            | `10.0.2.5`                                         |                                                                                                        |
 | HANA IPs                         | `hana_ips`                   | `10.0.0.10`, `10.0.0.11`                           |                                                                                                        |
 | HANA cluster vIP                 | `hana_cluster_vip`           | `10.0.1.12`                                        | Only used if HA is enabled in HANA                                                                     |
 | HANA cluster vIP secondary       | `hana_cluster_vip_secondary` | `10.0.1.13`                                        | Only used if the Active/Active setup is used                                                           |

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -91,7 +91,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "root"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -190,7 +190,7 @@ module "drbd_node" {
   drbd_data_disk_type  = var.drbd_data_disk_type
   gcp_credentials_file = var.gcp_credentials_file
   host_ips             = local.drbd_ips
-  iscsi_srv_ip         = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip         = module.iscsi_server.iscsi_ip
   cluster_ssh_pub      = var.cluster_ssh_pub
   cluster_ssh_key      = var.cluster_ssh_key
   nfs_mounting_point   = var.drbd_nfs_mounting_point
@@ -216,7 +216,7 @@ module "netweaver_node" {
   os_image                  = local.netweaver_os_image
   gcp_credentials_file      = var.gcp_credentials_file
   host_ips                  = local.netweaver_ips
-  iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip              = module.iscsi_server.iscsi_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -244,7 +244,7 @@ module "hana_node" {
   os_image                              = local.hana_os_image
   gcp_credentials_file                  = var.gcp_credentials_file
   host_ips                              = local.hana_ips
-  iscsi_srv_ip                          = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip                          = module.iscsi_server.iscsi_ip
   hana_data_disks_configuration         = var.hana_data_disks_configuration
   filestore_tier                        = var.filestore_tier
   hana_scale_out_filestore_quota_data   = var.hana_scale_out_filestore_quota_data

--- a/gcp/modules/hana_node/outputs.tf
+++ b/gcp/modules/hana_node/outputs.tf
@@ -1,15 +1,15 @@
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = google_compute_instance.clusternodes.*.network_interface.0.network_ip
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = local.bastion_enabled ? [] : google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = google_compute_instance.clusternodes.*.name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }

--- a/gcp/modules/iscsi_server/outputs.tf
+++ b/gcp/modules/iscsi_server/outputs.tf
@@ -1,15 +1,15 @@
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = join("", google_compute_instance.iscsisrv.*.network_interface.0.network_ip)
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = local.bastion_enabled ? "" : join("", google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip)
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = join("", google_compute_instance.iscsisrv.*.name)
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -6,37 +6,37 @@
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
 # Cluster nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }
 

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -40,6 +40,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # Monitoring
 
 output "monitoring_ip" {
@@ -76,6 +80,10 @@ output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
 }
 
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
+}
+
 # netweaver
 
 output "netweaver_ip" {
@@ -94,8 +102,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -61,6 +61,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "root"
+}
+
 variable "bastion_name" {
   description = "hostname, without the domain part"
   type        = string

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -83,7 +83,7 @@ module "common_variables" {
   ha_sap_deployment_repo              = var.ha_sap_deployment_repo
   additional_packages                 = var.additional_packages
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "root"
+  authorized_user                     = var.admin_user
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
   provisioning_output_colored         = var.provisioning_output_colored

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -16,6 +16,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 output "drbd_ip" {
   value = module.drbd_node.output_data.private_addresses
 }
@@ -30,6 +34,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = []
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 output "iscsi_ip" {
@@ -79,3 +87,31 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = []
 }
+
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+# no ssh key used to connect
+#output "ssh_private_key" {
+#  value = var.private_key
+#}
+#
+#output "ssh_public_key" {
+#  value = var.public_key
+#}
+
+# no bastion implemented
+#output "ssh_bastion_private_key" {
+#  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+#}
+#
+#output "ssh_bastion_public_key" {
+#  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
+#}

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -1,18 +1,18 @@
 # Outputs: IP address and port where the service will be listening on
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = module.hana_node.output_data.private_addresses
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = module.hana_node.output_data.addresses
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = module.hana_node.output_data.name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }
 
@@ -32,19 +32,19 @@ output "drbd_public_name" {
   value = []
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = module.iscsi_server.output_data.private_addresses
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = module.iscsi_server.output_data.addresses
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = module.iscsi_server.output_data.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
@@ -64,18 +64,18 @@ output "monitoring_public_name" {
   value = ""
 }
 
-output "netweaver_nodes_ip" {
+output "netweaver_ip" {
   value = module.netweaver_node.output_data.private_addresses
 }
 
-output "netweaver_nodes_public_ip" {
+output "netweaver_public_ip" {
   value = module.netweaver_node.output_data.addresses
 }
 
-output "netweaver_nodes_name" {
+output "netweaver_name" {
   value = module.netweaver_node.output_data.name
 }
 
-output "netweaver_nodes_public_name" {
+output "netweaver_public_name" {
   value = []
 }

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -59,6 +59,12 @@ variable "authorized_keys" {
   default     = ["~/.ssh/id_rsa.pub"]
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "root"
+}
+
 # Deployment variables
 #
 variable "deployment_name" {

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -81,7 +81,7 @@ For detailed information and deployment options have a look at `terraform.tfvars
 
 	```
 	terraform apply -target="module.nfs_server"
-	rsync -avPc --delete -e "ssh -l sles -i id_rsa -J sles@$(terraform output -raw bastion_public_ip)" --rsync-path="sudo rsync" ~/Downloads/SAP/sapinst/ $(terraform output -raw nfssrv_ip):/mnt_permanent/sapdata/sapinst/
+	rsync -avPc --delete -e "ssh -l sles -i id_rsa -J sles@$(terraform output -raw bastion_public_ip)" --rsync-path="sudo rsync" ~/Downloads/SAP/sapinst/ $(terraform output -raw nfs_ip):/mnt_permanent/sapdata/sapinst/
 
 	```
 

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -174,10 +174,11 @@ Example based on `10.0.0.0/24` address range.
 
 | Service                          | Variable                     | Addresses                                          | Comments                                                                                               |
 | ----                             | --------------------         | ---------                                          | --------                                                                                               |
+| Bastion                          | -                            | `10.0.0.3`                                         |                                                                                                        |
 | iSCSI server                     | `iscsi_srv_ip`               | `10.0.0.4`                                         |                                                                                                        |
 | Monitoring                       | `monitoring_srv_ip`          | `10.0.0.5`                                         |                                                                                                        |
 | HANA IPs                         | `hana_ips`                   | `10.0.0.10`, `10.0.0.11`                           |                                                                                                        |
-| HANA cluster vIP                 | `hana_cluster_vip`           | `10.0.2.12`                                        | Only used if HA is enabled in HANA                                                                     |
+| HANA cluster vIP                 | `hana_cluster_vip`           | `10.0.0.12`                                        | Only used if HA is enabled in HANA                                                                     |
 | HANA cluster vIP secondary       | `hana_cluster_vip_secondary` | `10.0.0.13`                                        | Only used if the Active/Active setup is used                                                           |
 | DRBD IPs                         | `drbd_ips`                   | `10.0.0.20`, `10.0.0.21`                           |                                                                                                        |
 | DRBD cluster vIP                 | `drbd_cluster_vip`           | `10.0.0.22`                                        |                                                                                                        |

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -201,7 +201,7 @@ module "drbd_node" {
   firewall_internal   = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image            = local.drbd_os_image
   host_ips            = local.drbd_ips
-  iscsi_srv_ip        = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip        = module.iscsi_server.iscsi_ip
   drbd_data_disk_type = var.drbd_data_disk_type
   drbd_data_disk_size = var.drbd_data_disk_size
   cluster_ssh_pub     = var.cluster_ssh_pub
@@ -231,7 +231,7 @@ module "netweaver_node" {
   network_subnet_id         = local.subnet_id
   firewall_internal         = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                  = local.netweaver_os_image
-  iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip              = module.iscsi_server.iscsi_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -263,7 +263,7 @@ module "hana_node" {
   firewall_internal             = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                      = local.hana_os_image
   host_ips                      = local.hana_ips
-  iscsi_srv_ip                  = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip                  = module.iscsi_server.iscsi_ip
   hana_data_disk_type           = var.hana_data_disk_type
   hana_data_disks_configuration = var.hana_data_disks_configuration
   cluster_ssh_pub               = var.cluster_ssh_pub

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -94,7 +94,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "sles"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/openstack/modules/iscsi_server/outputs.tf
+++ b/openstack/modules/iscsi_server/outputs.tf
@@ -10,22 +10,22 @@ data "openstack_compute_instance_v2" "iscsisrv" {
   depends_on = [openstack_compute_instance_v2.iscsisrv]
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
   # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
   # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   # value = join(",",openstack_compute_instance_v2.iscsisrv.*.name)
   value = openstack_compute_instance_v2.iscsisrv.*.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   # value = []
   value = openstack_compute_instance_v2.iscsisrv.*.name
 }

--- a/openstack/modules/nfs_server/outputs.tf
+++ b/openstack/modules/nfs_server/outputs.tf
@@ -10,18 +10,18 @@ data "openstack_compute_instance_v2" "nfssrv" {
   depends_on = [openstack_compute_instance_v2.nfssrv]
 }
 
-output "nfssrv_ip" {
+output "nfs_ip" {
   value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
 }
 
-output "nfssrv_public_ip" {
+output "nfs_public_ip" {
   value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
 }
 
-output "nfssrv_name" {
+output "nfs_name" {
   value = openstack_compute_instance_v2.nfssrv.*.name
 }
 
-output "nfssrv_public_name" {
+output "nfs_public_name" {
   value = openstack_compute_instance_v2.nfssrv.*.name
 }

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -40,6 +40,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # Monitoring
 
 output "monitoring_ip" {
@@ -74,6 +78,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 # NFS
@@ -112,8 +120,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -6,19 +6,19 @@
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
@@ -78,20 +78,20 @@ output "drbd_public_name" {
 
 # NFS
 
-output "nfssrv_ip" {
-  value = module.nfs_server.nfssrv_ip
+output "nfs_ip" {
+  value = module.nfs_server.nfs_ip
 }
 
-output "nfssrv_public_ip" {
-  value = module.nfs_server.nfssrv_public_ip
+output "nfs_public_ip" {
+  value = module.nfs_server.nfs_public_ip
 }
 
-output "nfssrv_name" {
-  value = module.nfs_server.nfssrv_name
+output "nfs_name" {
+  value = module.nfs_server.nfs_name
 }
 
-output "nfssrv_public_name" {
-  value = module.nfs_server.nfssrv_public_name
+output "nfs_public_name" {
+  value = module.nfs_server.nfs_public_name
 }
 
 # netweaver

--- a/openstack/variables.tf
+++ b/openstack/variables.tf
@@ -91,6 +91,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "sles"
+}
+
 variable "bastion_name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
This adds the option to deploy on AWS with a bastion host setup (enabled by default).
Only the bastion host will get a public IP. All other machines will be deployed in private subnets and will not be internet facing. They will have internet access through a NAT gateway though.