### PR TITLE
refactor and unify output variables for all output variables

### DIFF
--- a/aws/main.tf
+++ b/aws/main.tf
@@ -79,7 +79,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "ec2-user"
+  authorized_user                     = var.admin_user
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
   provisioning_output_colored         = var.provisioning_output_colored

--- a/aws/main.tf
+++ b/aws/main.tf
@@ -183,7 +183,7 @@ module "drbd_node" {
   drbd_data_disk_type   = var.drbd_data_disk_type
   cluster_ssh_pub       = var.cluster_ssh_pub
   cluster_ssh_key       = var.cluster_ssh_key
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip          = join("", module.iscsi_server.iscsi_ip)
   nfs_mounting_point    = var.drbd_nfs_mounting_point
   nfs_export_name       = var.netweaver_sid
   on_destroy_dependencies = [
@@ -242,7 +242,7 @@ module "netweaver_node" {
   s3_bucket             = var.netweaver_s3_bucket
   host_ips              = local.netweaver_ips
   virtual_host_ips      = local.netweaver_virtual_ips
-  iscsi_srv_ip          = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip          = join("", module.iscsi_server.iscsi_ip)
   cluster_ssh_pub       = var.cluster_ssh_pub
   cluster_ssh_key       = var.cluster_ssh_key
   on_destroy_dependencies = [
@@ -275,7 +275,7 @@ module "hana_node" {
   host_ips                      = local.hana_ips
   block_devices                 = var.block_devices
   hana_data_disks_configuration = var.hana_data_disks_configuration
-  iscsi_srv_ip                  = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                  = join("", module.iscsi_server.iscsi_ip)
   cluster_ssh_pub               = var.cluster_ssh_pub
   cluster_ssh_key               = var.cluster_ssh_key
   # passed to majority_maker module

--- a/aws/modules/drbd_node/outputs.tf
+++ b/aws/modules/drbd_node/outputs.tf
@@ -12,6 +12,10 @@ output "drbd_public_ip" {
 }
 
 output "drbd_name" {
+  value = data.aws_instance.drbd.*.tags.Name
+}
+
+output "drbd_id" {
   value = data.aws_instance.drbd.*.id
 }
 

--- a/aws/modules/hana_node/outputs.tf
+++ b/aws/modules/hana_node/outputs.tf
@@ -3,19 +3,19 @@ data "aws_instance" "hana" {
   instance_id = element(aws_instance.hana.*.id, count.index)
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = data.aws_instance.hana.*.private_ip
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = data.aws_instance.hana.*.public_ip
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = data.aws_instance.hana.*.id
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = data.aws_instance.hana.*.public_dns
 }
 
@@ -23,14 +23,14 @@ output "majority_maker_ip" {
   value = module.hana_majority_maker.majority_maker_ip
 }
 
-output "majority_maker_public_ip" {
-  value = module.hana_majority_maker.majority_maker_public_ip
+output "hana_majority_maker_public_ip" {
+  value = module.hana_majority_maker.hana_majority_maker_public_ip
 }
 
-output "majority_maker_name" {
-  value = module.hana_majority_maker.majority_maker_name
+output "hana_majority_maker_name" {
+  value = module.hana_majority_maker.hana_majority_maker_name
 }
 
-output "majority_maker_public_name" {
-  value = module.hana_majority_maker.majority_maker_public_name
+output "hana_majority_maker_public_name" {
+  value = module.hana_majority_maker.hana_majority_maker_public_name
 }

--- a/aws/modules/hana_node/outputs.tf
+++ b/aws/modules/hana_node/outputs.tf
@@ -12,6 +12,10 @@ output "hana_public_ip" {
 }
 
 output "hana_name" {
+  value = data.aws_instance.hana.*.tags.Name
+}
+
+output "hana_id" {
   value = data.aws_instance.hana.*.id
 }
 
@@ -29,6 +33,10 @@ output "hana_majority_maker_public_ip" {
 
 output "hana_majority_maker_name" {
   value = module.hana_majority_maker.hana_majority_maker_name
+}
+
+output "hana_majority_maker_id" {
+  value = module.hana_majority_maker.hana_majority_maker_id
 }
 
 output "hana_majority_maker_public_name" {

--- a/aws/modules/iscsi_server/outputs.tf
+++ b/aws/modules/iscsi_server/outputs.tf
@@ -3,18 +3,18 @@ data "aws_instance" "iscsisrv" {
   instance_id = element(aws_instance.iscsisrv.*.id, count.index)
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = data.aws_instance.iscsisrv.*.private_ip
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = data.aws_instance.iscsisrv.*.public_ip
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = data.aws_instance.iscsisrv.*.id
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = data.aws_instance.iscsisrv.*.public_dns
 }

--- a/aws/modules/iscsi_server/outputs.tf
+++ b/aws/modules/iscsi_server/outputs.tf
@@ -12,6 +12,10 @@ output "iscsi_public_ip" {
 }
 
 output "iscsi_name" {
+  value = data.aws_instance.iscsisrv.*.tags.Name
+}
+
+output "iscsi_id" {
   value = data.aws_instance.iscsisrv.*.id
 }
 

--- a/aws/modules/majority_maker_node/outputs.tf
+++ b/aws/modules/majority_maker_node/outputs.tf
@@ -7,14 +7,14 @@ output "majority_maker_ip" {
   value = data.aws_instance.majority_maker.*.private_ip
 }
 
-output "majority_maker_public_ip" {
+output "hana_majority_maker_public_ip" {
   value = data.aws_instance.majority_maker.*.public_ip
 }
 
-output "majority_maker_name" {
+output "hana_majority_maker_name" {
   value = data.aws_instance.majority_maker.*.id
 }
 
-output "majority_maker_public_name" {
+output "hana_majority_maker_public_name" {
   value = data.aws_instance.majority_maker.*.public_dns
 }

--- a/aws/modules/majority_maker_node/outputs.tf
+++ b/aws/modules/majority_maker_node/outputs.tf
@@ -12,6 +12,10 @@ output "hana_majority_maker_public_ip" {
 }
 
 output "hana_majority_maker_name" {
+  value = data.aws_instance.majority_maker.*.tags.Name
+}
+
+output "hana_majority_maker_id" {
   value = data.aws_instance.majority_maker.*.id
 }
 

--- a/aws/modules/monitoring/outputs.tf
+++ b/aws/modules/monitoring/outputs.tf
@@ -12,6 +12,10 @@ output "monitoring_public_ip" {
 }
 
 output "monitoring_name" {
+  value = join("", data.aws_instance.monitoring.*.tags.Name)
+}
+
+output "monitoring_id" {
   value = join("", data.aws_instance.monitoring.*.id)
 }
 

--- a/aws/modules/netweaver_node/outputs.tf
+++ b/aws/modules/netweaver_node/outputs.tf
@@ -12,6 +12,10 @@ output "netweaver_public_ip" {
 }
 
 output "netweaver_name" {
+  value = data.aws_instance.netweaver.*.tags.Name
+}
+
+output "netweaver_id" {
   value = data.aws_instance.netweaver.*.id
 }
 

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -6,36 +6,36 @@
 
 # Cluster nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
-  value = module.hana_node.cluster_nodes_public_name
+output "hana_public_name" {
+  value = module.hana_node.hana_public_name
 }
 
-output "majority_maker_ip" {
+output "hana_majority_maker_ip" {
   value = module.hana_node.majority_maker_ip
 }
 
-output "majority_maker_public_ip" {
-  value = module.hana_node.majority_maker_public_ip
+output "hana_majority_maker_public_ip" {
+  value = module.hana_node.hana_majority_maker_public_ip
 }
 
-output "majority_maker_name" {
-  value = module.hana_node.majority_maker_name
+output "hana_majority_maker_name" {
+  value = module.hana_node.hana_majority_maker_name
 }
 
-output "majority_maker_public_name" {
-  value = module.hana_node.majority_maker_public_name
+output "hana_majority_maker_public_name" {
+  value = module.hana_node.hana_majority_maker_public_name
 }
 
 # Monitoring
@@ -76,20 +76,20 @@ output "netweaver_public_name" {
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = join("", module.iscsi_server.iscsisrv_ip)
+output "iscsi_ip" {
+  value = join("", module.iscsi_server.iscsi_ip)
 }
 
-output "iscsisrv_public_ip" {
-  value = join("", module.iscsi_server.iscsisrv_public_ip)
+output "iscsi_public_ip" {
+  value = join("", module.iscsi_server.iscsi_public_ip)
 }
 
-output "iscsisrv_name" {
-  value = join("", module.iscsi_server.iscsisrv_name)
+output "iscsi_name" {
+  value = join("", module.iscsi_server.iscsi_name)
 }
 
-output "iscsisrv_public_name" {
-  value = join("", module.iscsi_server.iscsisrv_public_name)
+output "iscsi_public_name" {
+  value = join("", module.iscsi_server.iscsi_public_name)
 }
 
 # DRBD

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -18,6 +18,10 @@ output "hana_name" {
   value = module.hana_node.hana_name
 }
 
+output "hana_id" {
+  value = module.hana_node.hana_id
+}
+
 output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
@@ -38,6 +42,10 @@ output "hana_majority_maker_name" {
   value = module.hana_node.hana_majority_maker_name
 }
 
+output "hana_majority_maker_id" {
+  value = module.hana_node.hana_majority_maker_id
+}
+
 output "hana_majority_maker_public_name" {
   value = module.hana_node.hana_majority_maker_public_name
 }
@@ -56,6 +64,10 @@ output "monitoring_name" {
   value = module.monitoring.monitoring_name
 }
 
+output "monitoring_id" {
+  value = module.monitoring.monitoring_id
+}
+
 output "monitoring_public_name" {
   value = module.monitoring.monitoring_public_name
 }
@@ -72,6 +84,10 @@ output "netweaver_public_ip" {
 
 output "netweaver_name" {
   value = module.netweaver_node.netweaver_name
+}
+
+output "netweaver_id" {
+  value = module.netweaver_node.netweaver_id
 }
 
 output "netweaver_public_name" {
@@ -96,6 +112,10 @@ output "iscsi_name" {
   value = join("", module.iscsi_server.iscsi_name)
 }
 
+output "iscsi_id" {
+  value = join("", module.iscsi_server.iscsi_id)
+}
+
 output "iscsi_public_name" {
   value = join("", module.iscsi_server.iscsi_public_name)
 }
@@ -112,6 +132,10 @@ output "drbd_public_ip" {
 
 output "drbd_name" {
   value = module.drbd_node.drbd_name
+}
+
+output "drbd_id" {
+  value = module.drbd_node.drbd_id
 }
 
 output "drbd_public_name" {
@@ -134,6 +158,10 @@ output "bastion_public_ip" {
 
 output "bastion_name" {
   value = module.bastion.bastion_name
+}
+
+output "bastion_id" {
+  value = module.bastion.bastion_id
 }
 
 output "bastion_public_name" {

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -146,27 +146,27 @@ output "drbd_vip" {
   value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
-# bastion
+# no bastion on AWS yet
 
-output "bastion_ip" {
-  value = module.bastion.bastion_ip
-}
-
-output "bastion_public_ip" {
-  value = module.bastion.bastion_public_ip
-}
-
-output "bastion_name" {
-  value = module.bastion.bastion_name
-}
-
-output "bastion_id" {
-  value = module.bastion.bastion_id
-}
-
-output "bastion_public_name" {
-  value = module.bastion.bastion_public_name
-}
+#output "bastion_ip" {
+#  value = module.bastion.bastion_ip
+#}
+#
+#output "bastion_public_ip" {
+#  value = module.bastion.bastion_public_ip
+#}
+#
+#output "bastion_name" {
+#  value = module.bastion.bastion_name
+#}
+#
+#output "bastion_id" {
+#  value = module.bastion.bastion_id
+#}
+#
+#output "bastion_public_name" {
+#  value = module.bastion.bastion_public_name
+#}
 
 # ssh variables
 
@@ -182,10 +182,11 @@ output "ssh_public_key" {
   value = var.public_key
 }
 
-output "ssh_bastion_private_key" {
-  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
-}
-
-output "ssh_bastion_public_key" {
-  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
-}
+# no bastion on AWS yet
+#output "ssh_bastion_private_key" {
+#  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+#}
+#
+#output "ssh_bastion_public_key" {
+#  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
+#}

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -22,6 +22,10 @@ output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 output "hana_majority_maker_ip" {
   value = module.hana_node.majority_maker_ip
 }
@@ -74,6 +78,10 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # iSCSI server
 
 output "iscsi_ip" {
@@ -108,4 +116,48 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
+}
+
+# bastion
+
+output "bastion_ip" {
+  value = module.bastion.bastion_ip
+}
+
+output "bastion_public_ip" {
+  value = module.bastion.bastion_public_ip
+}
+
+output "bastion_name" {
+  value = module.bastion.bastion_name
+}
+
+output "bastion_public_name" {
+  value = module.bastion.bastion_public_name
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/aws/outputs.tf
+++ b/aws/outputs.tf
@@ -7,23 +7,23 @@
 # Cluster nodes
 
 output "hana_ip" {
-  value = module.hana_node.hana_ip
+  value = compact(module.hana_node.hana_ip)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.hana_public_ip
+  value = compact(module.hana_node.hana_public_ip)
 }
 
 output "hana_name" {
-  value = module.hana_node.hana_name
+  value = compact(module.hana_node.hana_name)
 }
 
 output "hana_id" {
-  value = module.hana_node.hana_id
+  value = compact(module.hana_node.hana_id)
 }
 
 output "hana_public_name" {
-  value = module.hana_node.hana_public_name
+  value = compact(module.hana_node.hana_public_name)
 }
 
 output "hana_vip" {
@@ -75,23 +75,23 @@ output "monitoring_public_name" {
 # Netweaver
 
 output "netweaver_ip" {
-  value = module.netweaver_node.netweaver_ip
+  value = compact(module.netweaver_node.netweaver_ip)
 }
 
 output "netweaver_public_ip" {
-  value = module.netweaver_node.netweaver_public_ip
+  value = compact(module.netweaver_node.netweaver_public_ip)
 }
 
 output "netweaver_name" {
-  value = module.netweaver_node.netweaver_name
+  value = compact(module.netweaver_node.netweaver_name)
 }
 
 output "netweaver_id" {
-  value = module.netweaver_node.netweaver_id
+  value = compact(module.netweaver_node.netweaver_id)
 }
 
 output "netweaver_public_name" {
-  value = module.netweaver_node.netweaver_public_name
+  value = compact(module.netweaver_node.netweaver_public_name)
 }
 
 output "netweaver_vip" {
@@ -123,23 +123,23 @@ output "iscsi_public_name" {
 # DRBD
 
 output "drbd_ip" {
-  value = module.drbd_node.drbd_ip
+  value = compact(module.drbd_node.drbd_ip)
 }
 
 output "drbd_public_ip" {
-  value = module.drbd_node.drbd_public_ip
+  value = compact(module.drbd_node.drbd_public_ip)
 }
 
 output "drbd_name" {
-  value = module.drbd_node.drbd_name
+  value = compact(module.drbd_node.drbd_name)
 }
 
 output "drbd_id" {
-  value = module.drbd_node.drbd_id
+  value = compact(module.drbd_node.drbd_id)
 }
 
 output "drbd_public_name" {
-  value = module.drbd_node.drbd_public_name
+  value = compact(module.drbd_node.drbd_public_name)
 }
 
 output "drbd_vip" {

--- a/aws/variables.tf
+++ b/aws/variables.tf
@@ -81,6 +81,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "ec2-user"
+}
+
 # Deployment variables
 
 variable "deployment_name" {

--- a/azure/main.tf
+++ b/azure/main.tf
@@ -173,7 +173,7 @@ module "drbd_node" {
   cluster_ssh_pub     = var.cluster_ssh_pub
   cluster_ssh_key     = var.cluster_ssh_key
   host_ips            = local.drbd_ips
-  iscsi_srv_ip        = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip        = join("", module.iscsi_server.iscsi_ip)
   nfs_mounting_point  = var.drbd_nfs_mounting_point
   nfs_export_name     = var.netweaver_sid
   # only used by azure fence agent (native fencing)
@@ -214,7 +214,7 @@ module "netweaver_node" {
   storage_account_path        = var.netweaver_storage_account
   host_ips                    = local.netweaver_ips
   virtual_host_ips            = local.netweaver_virtual_ips
-  iscsi_srv_ip                = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                = join("", module.iscsi_server.iscsi_ip)
   # ANF specific
   anf_account_name           = local.anf_account_name
   anf_pool_name              = local.anf_pool_name
@@ -250,7 +250,7 @@ module "hana_node" {
   cluster_ssh_key               = var.cluster_ssh_key
   hana_data_disks_configuration = var.hana_data_disks_configuration
   os_image                      = local.hana_os_image
-  iscsi_srv_ip                  = join("", module.iscsi_server.iscsisrv_ip)
+  iscsi_srv_ip                  = join("", module.iscsi_server.iscsi_ip)
   # ANF specific
   anf_account_name                = local.anf_account_name
   anf_pool_name                   = local.anf_pool_name

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "hana" {
   depends_on = [azurerm_virtual_machine.hana]
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = [data.azurerm_network_interface.hana.*.private_ip_address]
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = [data.azurerm_public_ip.hana.*.ip_address]
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = [azurerm_virtual_machine.hana.*.name]
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = [data.azurerm_public_ip.hana.*.fqdn]
 }

--- a/azure/modules/hana_node/outputs.tf
+++ b/azure/modules/hana_node/outputs.tf
@@ -15,17 +15,17 @@ data "azurerm_network_interface" "hana" {
 }
 
 output "hana_ip" {
-  value = [data.azurerm_network_interface.hana.*.private_ip_address]
+  value = data.azurerm_network_interface.hana.*.private_ip_address
 }
 
 output "hana_public_ip" {
-  value = [data.azurerm_public_ip.hana.*.ip_address]
+  value = data.azurerm_public_ip.hana.*.ip_address
 }
 
 output "hana_name" {
-  value = [azurerm_virtual_machine.hana.*.name]
+  value = azurerm_virtual_machine.hana.*.name
 }
 
 output "hana_public_name" {
-  value = [data.azurerm_public_ip.hana.*.fqdn]
+  value = data.azurerm_public_ip.hana.*.fqdn
 }

--- a/azure/modules/iscsi_server/outputs.tf
+++ b/azure/modules/iscsi_server/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "iscsisrv" {
   depends_on = [azurerm_virtual_machine.iscsisrv]
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = data.azurerm_network_interface.iscsisrv.*.private_ip_address
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = data.azurerm_public_ip.iscsisrv.*.ip_address
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = azurerm_virtual_machine.iscsisrv.*.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = data.azurerm_public_ip.iscsisrv.*.fqdn
 }

--- a/azure/modules/majority_maker_node/outputs.tf
+++ b/azure/modules/majority_maker_node/outputs.tf
@@ -14,18 +14,18 @@ data "azurerm_network_interface" "majority_maker" {
   depends_on = [azurerm_virtual_machine.majority_maker]
 }
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = [data.azurerm_network_interface.majority_maker.*.private_ip_address]
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = [data.azurerm_public_ip.majority_maker.*.ip_address]
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = [azurerm_virtual_machine.majority_maker.*.name]
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = [data.azurerm_public_ip.majority_maker.*.fqdn]
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -58,6 +58,10 @@ output "hana_public_name" {
   value = module.hana_node.hana_public_name
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # drbd
 
 output "drbd_ip" {
@@ -74,6 +78,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 # netweaver
@@ -94,8 +102,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -6,20 +6,20 @@
 
 # iSCSI server
 
-output "iscsi_srv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
-  value = module.iscsi_server.iscsisrv_public_name
+output "iscsi_public_name" {
+  value = module.iscsi_server.iscsi_public_name
 }
 
 # Monitoring
@@ -42,20 +42,20 @@ output "monitoring_public_name" {
 
 # Hana nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
-  value = module.hana_node.cluster_nodes_public_name
+output "hana_public_name" {
+  value = module.hana_node.hana_public_name
 }
 
 # drbd

--- a/azure/outputs.tf
+++ b/azure/outputs.tf
@@ -43,19 +43,19 @@ output "monitoring_public_name" {
 # Hana nodes
 
 output "hana_ip" {
-  value = module.hana_node.hana_ip
+  value = compact(module.hana_node.hana_ip)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.hana_public_ip
+  value = compact(module.hana_node.hana_public_ip)
 }
 
 output "hana_name" {
-  value = module.hana_node.hana_name
+  value = compact(module.hana_node.hana_name)
 }
 
 output "hana_public_name" {
-  value = module.hana_node.hana_public_name
+  value = compact(module.hana_node.hana_public_name)
 }
 
 output "hana_vip" {
@@ -65,19 +65,19 @@ output "hana_vip" {
 # drbd
 
 output "drbd_ip" {
-  value = module.drbd_node.drbd_ip
+  value = compact(module.drbd_node.drbd_ip)
 }
 
 output "drbd_public_ip" {
-  value = module.drbd_node.drbd_public_ip
+  value = compact(module.drbd_node.drbd_public_ip)
 }
 
 output "drbd_name" {
-  value = module.drbd_node.drbd_name
+  value = compact(module.drbd_node.drbd_name)
 }
 
 output "drbd_public_name" {
-  value = module.drbd_node.drbd_public_name
+  value = compact(module.drbd_node.drbd_public_name)
 }
 
 output "drbd_vip" {
@@ -87,19 +87,19 @@ output "drbd_vip" {
 # netweaver
 
 output "netweaver_ip" {
-  value = module.netweaver_node.netweaver_ip
+  value = compact(module.netweaver_node.netweaver_ip)
 }
 
 output "netweaver_public_ip" {
-  value = module.netweaver_node.netweaver_public_ip
+  value = compact(module.netweaver_node.netweaver_public_ip)
 }
 
 output "netweaver_name" {
-  value = module.netweaver_node.netweaver_name
+  value = compact(module.netweaver_node.netweaver_name)
 }
 
 output "netweaver_public_name" {
-  value = module.netweaver_node.netweaver_public_name
+  value = compact(module.netweaver_node.netweaver_public_name)
 }
 
 output "netweaver_vip" {

--- a/azure/variables.tf
+++ b/azure/variables.tf
@@ -66,11 +66,6 @@ variable "subnet_netapp_address_range" {
   }
 }
 
-variable "admin_user" {
-  description = "Administration user used to create the machines"
-  type        = string
-}
-
 variable "storage_account_name" {
   description = "Azure storage account name where HANA installation software is available"
   type        = string
@@ -95,6 +90,12 @@ variable "authorized_keys" {
   description = "List of additional authorized SSH public keys content or path to already existing SSH public keys to access the created machines with the used admin user (admin_user variable in this case)"
   type        = list(string)
   default     = []
+}
+
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "sles"
 }
 
 variable "bastion_name" {

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -91,7 +91,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "root"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/gcp/main.tf
+++ b/gcp/main.tf
@@ -190,7 +190,7 @@ module "drbd_node" {
   drbd_data_disk_type  = var.drbd_data_disk_type
   gcp_credentials_file = var.gcp_credentials_file
   host_ips             = local.drbd_ips
-  iscsi_srv_ip         = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip         = module.iscsi_server.iscsi_ip
   cluster_ssh_pub      = var.cluster_ssh_pub
   cluster_ssh_key      = var.cluster_ssh_key
   nfs_mounting_point   = var.drbd_nfs_mounting_point
@@ -216,7 +216,7 @@ module "netweaver_node" {
   os_image                  = local.netweaver_os_image
   gcp_credentials_file      = var.gcp_credentials_file
   host_ips                  = local.netweaver_ips
-  iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip              = module.iscsi_server.iscsi_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -244,7 +244,7 @@ module "hana_node" {
   os_image                              = local.hana_os_image
   gcp_credentials_file                  = var.gcp_credentials_file
   host_ips                              = local.hana_ips
-  iscsi_srv_ip                          = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip                          = module.iscsi_server.iscsi_ip
   hana_data_disks_configuration         = var.hana_data_disks_configuration
   filestore_tier                        = var.filestore_tier
   hana_scale_out_filestore_quota_data   = var.hana_scale_out_filestore_quota_data

--- a/gcp/modules/hana_node/outputs.tf
+++ b/gcp/modules/hana_node/outputs.tf
@@ -1,15 +1,15 @@
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = google_compute_instance.clusternodes.*.network_interface.0.network_ip
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = local.bastion_enabled ? [] : google_compute_instance.clusternodes.*.network_interface.0.access_config.0.nat_ip
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = google_compute_instance.clusternodes.*.name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }

--- a/gcp/modules/iscsi_server/outputs.tf
+++ b/gcp/modules/iscsi_server/outputs.tf
@@ -1,15 +1,15 @@
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = join("", google_compute_instance.iscsisrv.*.network_interface.0.network_ip)
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = local.bastion_enabled ? "" : join("", google_compute_instance.iscsisrv.*.network_interface.0.access_config.0.nat_ip)
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = join("", google_compute_instance.iscsisrv.*.name)
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -6,37 +6,37 @@
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
 # Cluster nodes
 
-output "cluster_nodes_ip" {
-  value = module.hana_node.cluster_nodes_ip
+output "hana_ip" {
+  value = module.hana_node.hana_ip
 }
 
-output "cluster_nodes_public_ip" {
-  value = module.hana_node.cluster_nodes_public_ip
+output "hana_public_ip" {
+  value = module.hana_node.hana_public_ip
 }
 
-output "cluster_nodes_name" {
-  value = module.hana_node.cluster_nodes_name
+output "hana_name" {
+  value = module.hana_node.hana_name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }
 

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -40,6 +40,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # Monitoring
 
 output "monitoring_ip" {
@@ -76,6 +80,10 @@ output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
 }
 
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
+}
+
 # netweaver
 
 output "netweaver_ip" {
@@ -94,8 +102,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/gcp/outputs.tf
+++ b/gcp/outputs.tf
@@ -25,19 +25,19 @@ output "iscsi_public_name" {
 # Cluster nodes
 
 output "hana_ip" {
-  value = module.hana_node.hana_ip
+  value = compact(module.hana_node.hana_ip)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.hana_public_ip
+  value = compact(module.hana_node.hana_public_ip)
 }
 
 output "hana_name" {
-  value = module.hana_node.hana_name
+  value = compact(module.hana_node.hana_name)
 }
 
 output "hana_public_name" {
-  value = []
+  value = compact(module.hana_node.hana_public_name)
 }
 
 output "hana_vip" {
@@ -65,19 +65,19 @@ output "monitoring_public_name" {
 # drbd
 
 output "drbd_ip" {
-  value = module.drbd_node.drbd_ip
+  value = compact(module.drbd_node.drbd_ip)
 }
 
 output "drbd_public_ip" {
-  value = module.drbd_node.drbd_public_ip
+  value = compact(module.drbd_node.drbd_public_ip)
 }
 
 output "drbd_name" {
-  value = module.drbd_node.drbd_name
+  value = compact(module.drbd_node.drbd_name)
 }
 
 output "drbd_public_name" {
-  value = module.drbd_node.drbd_public_name
+  value = compact(module.drbd_node.drbd_public_name)
 }
 
 output "drbd_vip" {
@@ -87,19 +87,19 @@ output "drbd_vip" {
 # netweaver
 
 output "netweaver_ip" {
-  value = module.netweaver_node.netweaver_ip
+  value = compact(module.netweaver_node.netweaver_ip)
 }
 
 output "netweaver_public_ip" {
-  value = module.netweaver_node.netweaver_public_ip
+  value = compact(module.netweaver_node.netweaver_public_ip)
 }
 
 output "netweaver_name" {
-  value = module.netweaver_node.netweaver_name
+  value = compact(module.netweaver_node.netweaver_name)
 }
 
 output "netweaver_public_name" {
-  value = module.netweaver_node.netweaver_public_name
+  value = compact(module.netweaver_node.netweaver_public_name)
 }
 
 output "netweaver_vip" {

--- a/gcp/variables.tf
+++ b/gcp/variables.tf
@@ -61,6 +61,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "root"
+}
+
 variable "bastion_name" {
   description = "hostname, without the domain part"
   type        = string

--- a/libvirt/main.tf
+++ b/libvirt/main.tf
@@ -83,7 +83,7 @@ module "common_variables" {
   ha_sap_deployment_repo              = var.ha_sap_deployment_repo
   additional_packages                 = var.additional_packages
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "root"
+  authorized_user                     = var.admin_user
   provisioner                         = var.provisioner
   provisioning_log_level              = var.provisioning_log_level
   provisioning_output_colored         = var.provisioning_output_colored

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -16,6 +16,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 output "drbd_ip" {
   value = module.drbd_node.output_data.private_addresses
 }
@@ -30,6 +34,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = []
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 output "iscsi_ip" {
@@ -79,3 +87,31 @@ output "netweaver_name" {
 output "netweaver_public_name" {
   value = []
 }
+
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+# no ssh key used to connect
+#output "ssh_private_key" {
+#  value = var.private_key
+#}
+#
+#output "ssh_public_key" {
+#  value = var.public_key
+#}
+
+# no bastion implemented
+#output "ssh_bastion_private_key" {
+#  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+#}
+#
+#output "ssh_bastion_public_key" {
+#  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
+#}

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -1,18 +1,18 @@
 # Outputs: IP address and port where the service will be listening on
 
-output "cluster_nodes_ip" {
+output "hana_ip" {
   value = module.hana_node.output_data.private_addresses
 }
 
-output "cluster_nodes_public_ip" {
+output "hana_public_ip" {
   value = module.hana_node.output_data.addresses
 }
 
-output "cluster_nodes_name" {
+output "hana_name" {
   value = module.hana_node.output_data.name
 }
 
-output "cluster_nodes_public_name" {
+output "hana_public_name" {
   value = []
 }
 
@@ -32,19 +32,19 @@ output "drbd_public_name" {
   value = []
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = module.iscsi_server.output_data.private_addresses
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = module.iscsi_server.output_data.addresses
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   value = module.iscsi_server.output_data.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
@@ -64,18 +64,18 @@ output "monitoring_public_name" {
   value = ""
 }
 
-output "netweaver_nodes_ip" {
+output "netweaver_ip" {
   value = module.netweaver_node.output_data.private_addresses
 }
 
-output "netweaver_nodes_public_ip" {
+output "netweaver_public_ip" {
   value = module.netweaver_node.output_data.addresses
 }
 
-output "netweaver_nodes_name" {
+output "netweaver_name" {
   value = module.netweaver_node.output_data.name
 }
 
-output "netweaver_nodes_public_name" {
+output "netweaver_public_name" {
   value = []
 }

--- a/libvirt/outputs.tf
+++ b/libvirt/outputs.tf
@@ -1,15 +1,15 @@
 # Outputs: IP address and port where the service will be listening on
 
 output "hana_ip" {
-  value = module.hana_node.output_data.private_addresses
+  value = compact(module.hana_node.output_data.private_addresses)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.output_data.addresses
+  value = compact(module.hana_node.output_data.addresses)
 }
 
 output "hana_name" {
-  value = module.hana_node.output_data.name
+  value = compact(module.hana_node.output_data.name)
 }
 
 output "hana_public_name" {
@@ -21,19 +21,15 @@ output "hana_vip" {
 }
 
 output "drbd_ip" {
-  value = module.drbd_node.output_data.private_addresses
+  value = compact(module.drbd_node.output_data.private_addresses)
 }
 
 output "drbd_public_ip" {
-  value = module.drbd_node.output_data.addresses
+  value = compact(module.drbd_node.output_data.addresses)
 }
 
 output "drbd_name" {
-  value = module.drbd_node.output_data.name
-}
-
-output "drbd_public_name" {
-  value = []
+  value = compact(module.drbd_node.output_data.name)
 }
 
 output "drbd_vip" {
@@ -73,15 +69,15 @@ output "monitoring_public_name" {
 }
 
 output "netweaver_ip" {
-  value = module.netweaver_node.output_data.private_addresses
+  value = compact(module.netweaver_node.output_data.private_addresses)
 }
 
 output "netweaver_public_ip" {
-  value = module.netweaver_node.output_data.addresses
+  value = compact(module.netweaver_node.output_data.addresses)
 }
 
 output "netweaver_name" {
-  value = module.netweaver_node.output_data.name
+  value = compact(module.netweaver_node.output_data.name)
 }
 
 output "netweaver_public_name" {

--- a/libvirt/variables.tf
+++ b/libvirt/variables.tf
@@ -59,6 +59,12 @@ variable "authorized_keys" {
   default     = ["~/.ssh/id_rsa.pub"]
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "root"
+}
+
 # Deployment variables
 #
 variable "deployment_name" {

--- a/openstack/README.md
+++ b/openstack/README.md
@@ -81,7 +81,7 @@ For detailed information and deployment options have a look at `terraform.tfvars
 
 	```
 	terraform apply -target="module.nfs_server"
-	rsync -avPc --delete -e "ssh -l sles -i id_rsa -J sles@$(terraform output -raw bastion_public_ip)" --rsync-path="sudo rsync" ~/Downloads/SAP/sapinst/ $(terraform output -raw nfssrv_ip):/mnt_permanent/sapdata/sapinst/
+	rsync -avPc --delete -e "ssh -l sles -i id_rsa -J sles@$(terraform output -raw bastion_public_ip)" --rsync-path="sudo rsync" ~/Downloads/SAP/sapinst/ $(terraform output -raw nfs_ip):/mnt_permanent/sapdata/sapinst/
 
 	```
 

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -201,7 +201,7 @@ module "drbd_node" {
   firewall_internal   = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image            = local.drbd_os_image
   host_ips            = local.drbd_ips
-  iscsi_srv_ip        = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip        = module.iscsi_server.iscsi_ip
   drbd_data_disk_type = var.drbd_data_disk_type
   drbd_data_disk_size = var.drbd_data_disk_size
   cluster_ssh_pub     = var.cluster_ssh_pub
@@ -231,7 +231,7 @@ module "netweaver_node" {
   network_subnet_id         = local.subnet_id
   firewall_internal         = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                  = local.netweaver_os_image
-  iscsi_srv_ip              = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip              = module.iscsi_server.iscsi_ip
   cluster_ssh_pub           = var.cluster_ssh_pub
   cluster_ssh_key           = var.cluster_ssh_key
   netweaver_software_bucket = var.netweaver_software_bucket
@@ -263,7 +263,7 @@ module "hana_node" {
   firewall_internal             = openstack_networking_secgroup_v2.ha_firewall_internal.id
   os_image                      = local.hana_os_image
   host_ips                      = local.hana_ips
-  iscsi_srv_ip                  = module.iscsi_server.iscsisrv_ip
+  iscsi_srv_ip                  = module.iscsi_server.iscsi_ip
   hana_data_disk_type           = var.hana_data_disk_type
   hana_data_disks_configuration = var.hana_data_disks_configuration
   cluster_ssh_pub               = var.cluster_ssh_pub

--- a/openstack/main.tf
+++ b/openstack/main.tf
@@ -94,7 +94,7 @@ module "common_variables" {
   public_key                          = var.public_key
   private_key                         = var.private_key
   authorized_keys                     = var.authorized_keys
-  authorized_user                     = "sles"
+  authorized_user                     = var.admin_user
   bastion_enabled                     = var.bastion_enabled
   bastion_public_key                  = var.bastion_public_key
   bastion_private_key                 = var.bastion_private_key

--- a/openstack/modules/bastion/outputs.tf
+++ b/openstack/modules/bastion/outputs.tf
@@ -4,10 +4,16 @@ data "openstack_networking_floatingip_v2" "bastion" {
   depends_on = [openstack_compute_instance_v2.bastion]
 }
 
+data "openstack_compute_instance_v2" "bastion" {
+  count      = local.bastion_count
+  id         = openstack_compute_instance_v2.bastion.0.id
+  depends_on = [openstack_compute_instance_v2.bastion]
+}
+
 output "public_ip" {
   value = join("", data.openstack_networking_floatingip_v2.bastion.*.address)
 }
 
 output "bastion_ip" {
-  value = join(",", openstack_networking_port_v2.bastion.0.all_fixed_ips)
+  value = data.openstack_compute_instance_v2.bastion.*.access_ip_v4
 }

--- a/openstack/modules/drbd_node/outputs.tf
+++ b/openstack/modules/drbd_node/outputs.tf
@@ -11,15 +11,15 @@ data "openstack_compute_instance_v2" "drbd" {
 }
 
 output "drbd_ip" {
-  value = join(",", openstack_compute_instance_v2.drbd.*.access_ip_v4)
+  value = data.openstack_compute_instance_v2.drbd.*.access_ip_v4
 }
 
 output "drbd_public_ip" {
-  value = join(",", openstack_compute_instance_v2.drbd.*.access_ip_v4)
+  value = []
 }
 
 output "drbd_name" {
-  value = openstack_compute_instance_v2.drbd.*.name
+  value = data.openstack_compute_instance_v2.drbd.*.name
 }
 
 output "drbd_public_name" {

--- a/openstack/modules/hana_node/outputs.tf
+++ b/openstack/modules/hana_node/outputs.tf
@@ -11,15 +11,15 @@ data "openstack_compute_instance_v2" "hana" {
 }
 
 output "hana_ip" {
-  value = join(",", openstack_compute_instance_v2.hana.*.access_ip_v4)
+  value = data.openstack_compute_instance_v2.hana.*.access_ip_v4
 }
 
 output "hana_public_ip" {
-  value = join(",", openstack_compute_instance_v2.hana.*.access_ip_v4)
+  value = []
 }
 
 output "hana_name" {
-  value = openstack_compute_instance_v2.hana.*.name
+  value = data.openstack_compute_instance_v2.hana.*.name
 }
 
 output "hana_public_name" {

--- a/openstack/modules/iscsi_server/outputs.tf
+++ b/openstack/modules/iscsi_server/outputs.tf
@@ -10,22 +10,22 @@ data "openstack_compute_instance_v2" "iscsisrv" {
   depends_on = [openstack_compute_instance_v2.iscsisrv]
 }
 
-output "iscsisrv_ip" {
+output "iscsi_ip" {
   value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
   # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
 }
 
-output "iscsisrv_public_ip" {
+output "iscsi_public_ip" {
   value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
   # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
 }
 
-output "iscsisrv_name" {
+output "iscsi_name" {
   # value = join(",",openstack_compute_instance_v2.iscsisrv.*.name)
   value = openstack_compute_instance_v2.iscsisrv.*.name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   # value = []
   value = openstack_compute_instance_v2.iscsisrv.*.name
 }

--- a/openstack/modules/iscsi_server/outputs.tf
+++ b/openstack/modules/iscsi_server/outputs.tf
@@ -11,21 +11,17 @@ data "openstack_compute_instance_v2" "iscsisrv" {
 }
 
 output "iscsi_ip" {
-  value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
-  # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
+  value = join("", data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
 }
 
 output "iscsi_public_ip" {
-  value = join(",", openstack_compute_instance_v2.iscsisrv.*.access_ip_v4)
-  # value = data.openstack_compute_instance_v2.iscsisrv.*.access_ip_v4
+  value = []
 }
 
 output "iscsi_name" {
-  # value = join(",",openstack_compute_instance_v2.iscsisrv.*.name)
-  value = openstack_compute_instance_v2.iscsisrv.*.name
+  value = data.openstack_compute_instance_v2.iscsisrv.*.name
 }
 
 output "iscsi_public_name" {
-  # value = []
-  value = openstack_compute_instance_v2.iscsisrv.*.name
+  value = []
 }

--- a/openstack/modules/monitoring/outputs.tf
+++ b/openstack/modules/monitoring/outputs.tf
@@ -11,15 +11,15 @@ data "openstack_compute_instance_v2" "monitoring" {
 }
 
 output "monitoring_ip" {
-  value = join(",", openstack_compute_instance_v2.monitoring.*.access_ip_v4)
+  value = data.openstack_compute_instance_v2.monitoring.*.access_ip_v4
 }
 
 output "monitoring_public_ip" {
-  value = join(",", openstack_compute_instance_v2.monitoring.*.access_ip_v4)
+  value = []
 }
 
 output "monitoring_name" {
-  value = openstack_compute_instance_v2.monitoring.*.name
+  value = data.openstack_compute_instance_v2.monitoring.*.name
 }
 
 output "monitoring_public_name" {

--- a/openstack/modules/netweaver_node/outputs.tf
+++ b/openstack/modules/netweaver_node/outputs.tf
@@ -11,15 +11,15 @@ data "openstack_compute_instance_v2" "netweaver" {
 }
 
 output "netweaver_ip" {
-  value = join(",", openstack_compute_instance_v2.netweaver.*.access_ip_v4)
+  value = data.openstack_compute_instance_v2.netweaver.*.access_ip_v4
 }
 
 output "netweaver_public_ip" {
-  value = join(",", openstack_compute_instance_v2.netweaver.*.access_ip_v4)
+  value = []
 }
 
 output "netweaver_name" {
-  value = openstack_compute_instance_v2.netweaver.*.name
+  value = data.openstack_compute_instance_v2.netweaver.*.name
 }
 
 output "netweaver_public_name" {

--- a/openstack/modules/nfs_server/outputs.tf
+++ b/openstack/modules/nfs_server/outputs.tf
@@ -10,18 +10,18 @@ data "openstack_compute_instance_v2" "nfssrv" {
   depends_on = [openstack_compute_instance_v2.nfssrv]
 }
 
-output "nfssrv_ip" {
+output "nfs_ip" {
   value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
 }
 
-output "nfssrv_public_ip" {
+output "nfs_public_ip" {
   value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
 }
 
-output "nfssrv_name" {
+output "nfs_name" {
   value = openstack_compute_instance_v2.nfssrv.*.name
 }
 
-output "nfssrv_public_name" {
+output "nfs_public_name" {
   value = openstack_compute_instance_v2.nfssrv.*.name
 }

--- a/openstack/modules/nfs_server/outputs.tf
+++ b/openstack/modules/nfs_server/outputs.tf
@@ -11,17 +11,17 @@ data "openstack_compute_instance_v2" "nfssrv" {
 }
 
 output "nfs_ip" {
-  value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
+  value = data.openstack_compute_instance_v2.nfssrv.*.access_ip_v4
 }
 
 output "nfs_public_ip" {
-  value = join(",", openstack_compute_instance_v2.nfssrv.*.access_ip_v4)
+  value = []
 }
 
 output "nfs_name" {
-  value = openstack_compute_instance_v2.nfssrv.*.name
+  value = data.openstack_compute_instance_v2.nfssrv.*.name
 }
 
 output "nfs_public_name" {
-  value = openstack_compute_instance_v2.nfssrv.*.name
+  value = []
 }

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -40,6 +40,10 @@ output "hana_public_name" {
   value = []
 }
 
+output "hana_vip" {
+  value = var.hana_active_active == true ? [module.common_variables.configuration["hana"]["cluster_vip"], module.common_variables.configuration["hana"]["cluster_vip_secondary"]] : [module.common_variables.configuration["hana"]["cluster_vip"]]
+}
+
 # Monitoring
 
 output "monitoring_ip" {
@@ -74,6 +78,10 @@ output "drbd_name" {
 
 output "drbd_public_name" {
   value = module.drbd_node.drbd_public_name
+}
+
+output "drbd_vip" {
+  value = var.drbd_enabled == true ? [module.common_variables.configuration["drbd"]["cluster_vip"]] : []
 }
 
 # NFS
@@ -112,8 +120,34 @@ output "netweaver_public_name" {
   value = module.netweaver_node.netweaver_public_name
 }
 
+output "netweaver_vip" {
+  value = var.netweaver_enabled == true ? local.netweaver_virtual_ips : []
+}
+
 # bastion
 
 output "bastion_public_ip" {
   value = module.bastion.public_ip
+}
+
+# ssh variables
+
+output "ssh_user" {
+  value = var.admin_user
+}
+
+output "ssh_private_key" {
+  value = var.private_key
+}
+
+output "ssh_public_key" {
+  value = var.public_key
+}
+
+output "ssh_bastion_private_key" {
+  value = var.bastion_private_key == "" ? var.private_key : var.bastion_private_key
+}
+
+output "ssh_bastion_public_key" {
+  value = var.bastion_public_key == "" ? var.public_key : var.bastion_public_key
 }

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -6,19 +6,19 @@
 
 # iSCSI server
 
-output "iscsisrv_ip" {
-  value = module.iscsi_server.iscsisrv_ip
+output "iscsi_ip" {
+  value = module.iscsi_server.iscsi_ip
 }
 
-output "iscsisrv_public_ip" {
-  value = module.iscsi_server.iscsisrv_public_ip
+output "iscsi_public_ip" {
+  value = module.iscsi_server.iscsi_public_ip
 }
 
-output "iscsisrv_name" {
-  value = module.iscsi_server.iscsisrv_name
+output "iscsi_name" {
+  value = module.iscsi_server.iscsi_name
 }
 
-output "iscsisrv_public_name" {
+output "iscsi_public_name" {
   value = []
 }
 
@@ -78,20 +78,20 @@ output "drbd_public_name" {
 
 # NFS
 
-output "nfssrv_ip" {
-  value = module.nfs_server.nfssrv_ip
+output "nfs_ip" {
+  value = module.nfs_server.nfs_ip
 }
 
-output "nfssrv_public_ip" {
-  value = module.nfs_server.nfssrv_public_ip
+output "nfs_public_ip" {
+  value = module.nfs_server.nfs_public_ip
 }
 
-output "nfssrv_name" {
-  value = module.nfs_server.nfssrv_name
+output "nfs_name" {
+  value = module.nfs_server.nfs_name
 }
 
-output "nfssrv_public_name" {
-  value = module.nfs_server.nfssrv_public_name
+output "nfs_public_name" {
+  value = module.nfs_server.nfs_public_name
 }
 
 # netweaver

--- a/openstack/outputs.tf
+++ b/openstack/outputs.tf
@@ -25,15 +25,15 @@ output "iscsi_public_name" {
 # Cluster nodes
 
 output "hana_ip" {
-  value = module.hana_node.hana_ip
+  value = compact(module.hana_node.hana_ip)
 }
 
 output "hana_public_ip" {
-  value = module.hana_node.hana_public_ip
+  value = compact(module.hana_node.hana_public_ip)
 }
 
 output "hana_name" {
-  value = module.hana_node.hana_name
+  value = compact(module.hana_node.hana_name)
 }
 
 output "hana_public_name" {
@@ -65,19 +65,19 @@ output "monitoring_public_name" {
 # drbd
 
 output "drbd_ip" {
-  value = module.drbd_node.drbd_ip
+  value = compact(module.drbd_node.drbd_ip)
 }
 
 output "drbd_public_ip" {
-  value = module.drbd_node.drbd_public_ip
+  value = compact(module.drbd_node.drbd_public_ip)
 }
 
 output "drbd_name" {
-  value = module.drbd_node.drbd_name
+  value = compact(module.drbd_node.drbd_name)
 }
 
 output "drbd_public_name" {
-  value = module.drbd_node.drbd_public_name
+  value = compact(module.drbd_node.drbd_public_name)
 }
 
 output "drbd_vip" {
@@ -105,19 +105,19 @@ output "nfs_public_name" {
 # netweaver
 
 output "netweaver_ip" {
-  value = module.netweaver_node.netweaver_ip
+  value = compact(module.netweaver_node.netweaver_ip)
 }
 
 output "netweaver_public_ip" {
-  value = module.netweaver_node.netweaver_public_ip
+  value = compact(module.netweaver_node.netweaver_public_ip)
 }
 
 output "netweaver_name" {
-  value = module.netweaver_node.netweaver_name
+  value = compact(module.netweaver_node.netweaver_name)
 }
 
 output "netweaver_public_name" {
-  value = module.netweaver_node.netweaver_public_name
+  value = compact(module.netweaver_node.netweaver_public_name)
 }
 
 output "netweaver_vip" {

--- a/openstack/variables.tf
+++ b/openstack/variables.tf
@@ -91,6 +91,12 @@ variable "authorized_keys" {
   default     = []
 }
 
+variable "admin_user" {
+  description = "User used to connect to machines and bastion"
+  type        = string
+  default     = "sles"
+}
+
 variable "bastion_name" {
   description = "hostname, without the domain part"
   type        = string


### PR DESCRIPTION
This refactors and unifies all output variables.
It will be some kind of breaking change if somebody utilizes the output variables.
e.g. `cluster_nodes_*` is refactored to `hana_*`.